### PR TITLE
docs: add personal access token instructions to dev guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for considering contributing to our repo! We appreciate all contributions to the app, large or small. Please take the time to read through this document before making a contribution to ensure a fun and effective process for everyone involved.
 
+You can read the [Developer Guidelines](./docs/developer-guidelines.md) for advice on how to get your development environment setup.
+
 ## General guidelines
 
 Are you having trouble getting started with the OTT Web App, configuration, or customization? If so, please check the [developer docs](https://github.com/jwplayer/ott-web-app/tree/develop/docs) before submitting an issue here.

--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -7,14 +7,7 @@
 - Format the code through `yarn format`
 - Lint through `yarn lint`
 - Lint and fix through `yarn lint --fix`
-
-## How to use the create-base script
-
-The `yarn create-base` can be used to quickly scaffold a component, container or screen.
-
-- use `yarn create-base components/YourComponentName` to create a base component
-- use `yarn create-base containers/YourContainerName` to create a base container
-- use `yarn create-base screens/YourScreenName` to create a base screen
+- The JW organization requires personal access tokens for all of their repositories. In order to create a branch or pull request you'll need to [Generate a Personal Access Token](https://github.com/settings/tokens) and then [store it in your git config](https://stackoverflow.com/questions/46645843/where-to-store-my-git-personal-access-token/67360592). (For token permissions, `repo` should be sufficient.) 
 
 ## Git Commit Guidelines (conventional changelog)
 


### PR DESCRIPTION
## Description

Small doc update

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] User stories met
- [ ] Storybook stories
- [ ] Unit tests added
- [ ] Linting passing
- [ ] Unit tests passing
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
