### PR TITLE
Fix / account fixes

### DIFF
--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -57,11 +57,11 @@ export const getMediaById = (id: string): Promise<PlaylistItem | undefined> => {
  */
 export const getMediaByIds = async (ids: string[]): Promise<PlaylistItem[]> => {
   // @todo this should be updated when it will become possible to request multiple media items in a single request
-  const responses = await Promise.all(ids.map((id) => getMediaById(id)));
+  const responses = await Promise.allSettled(ids.map((id) => getMediaById(id)));
 
   function notEmpty<Value>(value: Value | null | undefined): value is Value {
     return value !== null && value !== undefined;
   }
 
-  return responses.filter(notEmpty);
+  return responses.map((result) => (result.status === 'fulfilled' ? result.value : null)).filter(notEmpty);
 };

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -182,6 +182,9 @@ export const logout = async () => {
   useAccountStore.setState({
     auth: null,
     user: null,
+    subscription: null,
+    transactions: null,
+    activePayment: null,
     customerConsents: null,
     publisherConsents: null,
   });

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -156,12 +156,7 @@ export const afterLogin = async (sandbox: boolean, auth: AuthData) => {
     user: response.responseData,
   });
 
-  if (accessModel === 'SVOD') {
-    await reloadActiveSubscription();
-  }
-
-  await getCustomerConsents();
-  await getPublisherConsents();
+  await Promise.allSettled([accessModel === 'SVOD' ? reloadActiveSubscription() : Promise.resolve(), getCustomerConsents(), getPublisherConsents()]);
 
   useAccountStore.setState({ loading: false });
 };
@@ -301,6 +296,7 @@ export const updateCaptureAnswers = async (capture: Capture) => {
 
     if (response.errors.length > 0) throw new Error(response.errors[0]);
 
+    // @todo why is this needed?
     await afterLogin(cleengSandbox, auth);
 
     return response.responseData;
@@ -369,9 +365,11 @@ export async function reloadActiveSubscription({ delay }: { delay: number } = { 
   useAccountStore.setState({ loading: true });
 
   return await useLoginContext(async ({ cleengSandbox, customerId, auth: { jwt } }) => {
-    const activeSubscription = await getActiveSubscription({ cleengSandbox, customerId, jwt });
-    const transactions = await getAllTransactions({ cleengSandbox, customerId, jwt });
-    const activePayment = await getActivePayment({ cleengSandbox, customerId, jwt });
+    const [activeSubscription, transactions, activePayment] = await Promise.all([
+      getActiveSubscription({ cleengSandbox, customerId, jwt }),
+      getAllTransactions({ cleengSandbox, customerId, jwt }),
+      getActivePayment({ cleengSandbox, customerId, jwt }),
+    ]);
 
     // The subscription data takes a few seconds to load after it's purchased,
     // so here's a delay mechanism to give it time to process


### PR DESCRIPTION
## Description

This PR contains 2 fixes and 1 improvement regarding the login flow:

- Fix a login error when a watch history item failed to load (due to removal)
- Fix the "Start watching" button showing whilst being logged out
- Improve reload subscriptions speed by performing all requests parallel
