### PR TITLE
Fix / prevent flash when navigating to movie page

### DIFF
--- a/src/hooks/useContentProtection.ts
+++ b/src/hooks/useContentProtection.ts
@@ -36,6 +36,7 @@ const useContentProtection = <T>(
     enabled: !!id && enabled && (!signingEnabled || !!token),
     placeholderData: placeholderData,
     retry: type === 'media',
+    keepPreviousData: type === 'media',
   });
 
   return {


### PR DESCRIPTION
## Description

When navigating to the video detail page, the media item is fetched even though it's cached. This causes the screen to render the loading state. Together this results in a "flashy" navigating. This PR fixes that by using the cached data even while loading the video (this was removed by accident in the DRM branch).
