### PR TITLE
Fix / TVOD fixes

### DIFF
--- a/src/components/CheckoutForm/CheckoutForm.tsx
+++ b/src/components/CheckoutForm/CheckoutForm.tsx
@@ -134,7 +134,7 @@ const CheckoutForm: React.FC<Props> = ({
                 <td className={styles.couponCell}>
                   {t('checkout.coupon_discount')}
                   <br />
-                  {!!offer.period && (
+                  {!!offer.period && offerType === 'svod' && (
                     <small>
                       {t('checkout.discount_period', {
                         count: order.discount.periods,

--- a/src/containers/AccountModal/forms/ChooseOffer.tsx
+++ b/src/containers/AccountModal/forms/ChooseOffer.tsx
@@ -8,6 +8,7 @@ import useOffers from '../../../hooks/useOffers';
 
 import { addQueryParam, removeQueryParam } from '#src/utils/history';
 import { useCheckoutStore } from '#src/stores/CheckoutStore';
+import { useConfigStore } from '#src/stores/ConfigStore';
 import LoadingOverlay from '#src/components/LoadingOverlay/LoadingOverlay';
 import ChooseOfferForm from '#src/components/ChooseOfferForm/ChooseOfferForm';
 import useForm, { UseFormOnSubmitHandler } from '#src/hooks/useForm';
@@ -17,6 +18,7 @@ const ChooseOffer = () => {
   const history = useHistory();
   const { t } = useTranslation('account');
   const { setOffer } = useCheckoutStore(({ setOffer }) => ({ setOffer }), shallow);
+  const { accessModel } = useConfigStore(({ accessModel }) => ({ accessModel }), shallow);
   const { isLoading, offerType, setOfferType, offers, offersDict, defaultOfferId, hasTVODOffers, hasPremierOffer } = useOffers();
 
   const validationSchema: SchemaOf<ChooseOfferFormData> = object().shape({
@@ -67,7 +69,7 @@ const ChooseOffer = () => {
       submitting={submitting}
       offers={offers}
       offerType={offerType}
-      setOfferType={hasTVODOffers && !hasPremierOffer ? setOfferType : undefined}
+      setOfferType={accessModel === 'SVOD' && hasTVODOffers && !hasPremierOffer ? setOfferType : undefined}
     />
   );
 };

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -10,11 +10,18 @@ import type { OfferType } from '#types/account';
 import { isSVODOffer } from '#src/utils/subscription';
 
 const useOffers = () => {
-  const { cleengSandbox, json } = useConfigStore(({ config }) => config, shallow);
+  const { config, accessModel } = useConfigStore(
+    ({ config, accessModel }) => ({
+      config,
+      accessModel,
+    }),
+    shallow,
+  );
+  const { cleengSandbox, json } = config;
   const { requestedMediaOffers } = useCheckoutStore(({ requestedMediaOffers }) => ({ requestedMediaOffers }), shallow);
   const hasPremierOffer = (requestedMediaOffers || []).some((offer) => offer.premier);
   const tvodOfferIds = (requestedMediaOffers || []).map(({ offerId }) => offerId);
-  const [offerType, setOfferType] = useState<OfferType>('svod');
+  const [offerType, setOfferType] = useState<OfferType>(accessModel === 'SVOD' ? 'svod' : 'tvod');
 
   const monthlyOfferId = json?.cleengMonthlyOffer ? (json.cleengMonthlyOffer as string) : '';
   const yearlyOfferId = json?.cleengYearlyOffer ? (json.cleengYearlyOffer as string) : '';


### PR DESCRIPTION
## Description

- Fix `offerType` being set to `svod` in checkout modal when the TVOD offer has a `period` value
  - While creating this feature the `period` value was `null`, but it seems that this is changed in the back-end
- Fix SVOD redirect URL for Adyen and No payment needed scenarios
- Hide the discount period label for TVOD offers
- Hide period label beside the offer price in checkout modal
- Fix choose offer modal being closed immediately for TVOD offers in an AUTHVOD access model