### PR TITLE
Fix / entitlement bug fixes

### DIFF
--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -12,10 +12,12 @@ import { addQueryParam } from '../../utils/history';
 import styles from './Payment.module.scss';
 
 import type { PaymentDetail, Subscription, Transaction } from '#types/subscription';
+import type { AccessModel } from '#types/Config';
 
 const VISIBLE_TRANSACTIONS = 4;
 
 type Props = {
+  accessModel: AccessModel;
   activeSubscription: Subscription | null;
   activePaymentDetail: PaymentDetail | null;
   transactions: Transaction[] | null;
@@ -28,6 +30,7 @@ type Props = {
 };
 
 const Payment = ({
+  accessModel,
   activePaymentDetail,
   activeSubscription,
   transactions,
@@ -72,37 +75,39 @@ const Payment = ({
 
   return (
     <>
-      <div className={panelClassName}>
-        <div className={panelHeaderClassName}>
-          <h3>{t('user:payment.subscription_details')}</h3>
+      {accessModel === 'SVOD' && (
+        <div className={panelClassName}>
+          <div className={panelHeaderClassName}>
+            <h3>{t('user:payment.subscription_details')}</h3>
+          </div>
+          {activeSubscription ? (
+            <React.Fragment>
+              <div className={styles.infoBox} key={activeSubscription.subscriptionId}>
+                <p>
+                  <strong>{getTitle(activeSubscription.period)}</strong> <br />
+                  {activeSubscription.status === 'active'
+                    ? t('user:payment.next_billing_date_on', { date: formatDate(activeSubscription.expiresAt) })
+                    : t('user:payment.subscription_expires_on', { date: formatDate(activeSubscription.expiresAt) })}
+                </p>
+                <p className={styles.price}>
+                  <strong>{formatPrice(activeSubscription.nextPaymentPrice, activeSubscription.nextPaymentCurrency, customer.country)}</strong>
+                  <small>/{t(`account:periods.${activeSubscription.period}`)}</small>
+                </p>
+              </div>
+              {activeSubscription.status === 'active' ? (
+                <Button label={t('user:payment.cancel_subscription')} onClick={onCancelSubscriptionClick} />
+              ) : (
+                <Button label={t('user:payment.renew_subscription')} onClick={onRenewSubscriptionClick} />
+              )}
+            </React.Fragment>
+          ) : isLoading ? null : (
+            <React.Fragment>
+              <p>{t('user:payment.no_subscription')}</p>
+              <Button variant="contained" color="primary" label={t('user:payment.complete_subscription')} onClick={onCompleteSubscriptionClick} />
+            </React.Fragment>
+          )}
         </div>
-        {activeSubscription ? (
-          <React.Fragment>
-            <div className={styles.infoBox} key={activeSubscription.subscriptionId}>
-              <p>
-                <strong>{getTitle(activeSubscription.period)}</strong> <br />
-                {activeSubscription.status === 'active'
-                  ? t('user:payment.next_billing_date_on', { date: formatDate(activeSubscription.expiresAt) })
-                  : t('user:payment.subscription_expires_on', { date: formatDate(activeSubscription.expiresAt) })}
-              </p>
-              <p className={styles.price}>
-                <strong>{formatPrice(activeSubscription.nextPaymentPrice, activeSubscription.nextPaymentCurrency, customer.country)}</strong>
-                <small>/{t(`account:periods.${activeSubscription.period}`)}</small>
-              </p>
-            </div>
-            {activeSubscription.status === 'active' ? (
-              <Button label={t('user:payment.cancel_subscription')} onClick={onCancelSubscriptionClick} />
-            ) : (
-              <Button label={t('user:payment.renew_subscription')} onClick={onRenewSubscriptionClick} />
-            )}
-          </React.Fragment>
-        ) : isLoading ? null : (
-          <React.Fragment>
-            <p>{t('user:payment.no_subscription')}</p>
-            <Button variant="contained" color="primary" label={t('user:payment.complete_subscription')} onClick={onCompleteSubscriptionClick} />
-          </React.Fragment>
-        )}
-      </div>
+      )}
       <div className={panelClassName}>
         <div className={panelHeaderClassName}>
           <h3>{t('user:payment.payment_method')}</h3>

--- a/src/containers/AccountModal/forms/Checkout.tsx
+++ b/src/containers/AccountModal/forms/Checkout.tsx
@@ -28,7 +28,15 @@ const Checkout = () => {
   const [couponCodeApplied, setCouponCodeApplied] = useState(false);
   const [paymentMethodId, setPaymentMethodId] = useState<number | undefined>(undefined);
 
-  const { order, offer, paymentMethods } = useCheckoutStore(({ order, offer, paymentMethods }) => ({ order, offer, paymentMethods }), shallow);
+  const { order, offer, paymentMethods, setOrder } = useCheckoutStore(
+    ({ order, offer, paymentMethods, setOrder }) => ({
+      order,
+      offer,
+      paymentMethods,
+      setOrder,
+    }),
+    shallow,
+  );
   const offerType = offer && !isSVODOffer(offer) ? 'tvod' : 'svod';
 
   const paymentSuccessUrl = useMemo(() => {
@@ -78,6 +86,11 @@ const Checkout = () => {
 
     create();
   }, [history, offer]);
+
+  // clear the order after closing the checkout modal
+  useEffect(() => {
+    return () => setOrder(null);
+  }, [setOrder]);
 
   const backButtonClickHandler = () => {
     history.push(addQueryParam(history, 'u', 'choose-offer'));

--- a/src/containers/AccountModal/forms/ChooseOffer.tsx
+++ b/src/containers/AccountModal/forms/ChooseOffer.tsx
@@ -47,9 +47,8 @@ const ChooseOffer = () => {
   }, [isLoading, offers, history]);
 
   useEffect(() => {
-    setValue('offerId', offers[offers.length - 1]?.offerId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [offerType, setValue]);
+    setValue('offerId', defaultOfferId);
+  }, [setValue, defaultOfferId]);
 
   // loading state
   if (!offers.length || isLoading) {

--- a/src/containers/AccountModal/forms/PersonalDetails.tsx
+++ b/src/containers/AccountModal/forms/PersonalDetails.tsx
@@ -12,6 +12,7 @@ import { useConfigStore } from '../../../stores/ConfigStore';
 
 import type { CaptureCustomAnswer, CleengCaptureQuestionField, PersonalDetailsFormData } from '#types/account';
 import { getCaptureStatus, updateCaptureAnswers } from '#src/stores/AccountController';
+import useOffers from '#src/hooks/useOffers';
 
 const yupConditional = (required: boolean, message: string) => {
   return required ? string().required(message) : mixed().notRequired();
@@ -22,6 +23,7 @@ const PersonalDetails = () => {
   const { t } = useTranslation('account');
   const accessModel = useConfigStore((s) => s.accessModel);
   const { data, isLoading } = useQuery('captureStatus', () => getCaptureStatus());
+  const { hasTVODOffers } = useOffers();
   const [questionValues, setQuestionValues] = useState<Record<string, string>>({});
   const [questionErrors, setQuestionErrors] = useState<Record<string, string>>({});
 
@@ -32,8 +34,10 @@ const PersonalDetails = () => {
   );
 
   const nextStep = useCallback(() => {
-    history.replace(addQueryParam(history, 'u', accessModel === 'SVOD' ? 'choose-offer' : 'welcome'));
-  }, [history, accessModel]);
+    const hasOffers = accessModel === 'SVOD' || (accessModel === 'AUTHVOD' && hasTVODOffers);
+
+    history.replace(addQueryParam(history, 'u', hasOffers ? 'choose-offer' : 'welcome'));
+  }, [history, accessModel, hasTVODOffers]);
 
   useEffect(() => {
     if (data && (!data.isCaptureEnabled || !data.shouldCaptureBeDisplayed)) nextStep();

--- a/src/containers/Layout/Layout.tsx
+++ b/src/containers/Layout/Layout.tsx
@@ -84,7 +84,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
     if (!cleengId) return null;
 
     return isLoggedIn ? (
-      <UserMenu showPaymentsItem={accessModel === 'SVOD'} />
+      <UserMenu showPaymentsItem={accessModel !== 'AVOD'} />
     ) : (
       <div className={styles.buttonContainer}>
         <Button fullWidth onClick={loginButtonClickHandler} label={t('sign_in')} />
@@ -124,7 +124,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
           userMenuOpen={userMenuOpen}
           toggleUserMenu={toggleUserMenu}
           canLogin={!!cleengId}
-          showPaymentsMenuItem={accessModel === 'SVOD'}
+          showPaymentsMenuItem={accessModel !== 'AVOD'}
         >
           <Button label={t('home')} to="/" variant="text" />
           {menu.map((item) => (

--- a/src/containers/StartWatchingButton/StartWatchingButton.tsx
+++ b/src/containers/StartWatchingButton/StartWatchingButton.tsx
@@ -13,7 +13,7 @@ import { useCheckoutStore } from '#src/stores/CheckoutStore';
 import type { PlaylistItem } from '#types/playlist';
 import { useWatchHistoryStore } from '#src/stores/WatchHistoryStore';
 import { useAccountStore } from '#src/stores/AccountStore';
-import { getSeriesId, isEpisode } from '#src/utils/media';
+import { getSeriesIdFromEpisode } from '#src/utils/media';
 import { episodeURLFromEpisode, videoUrl } from '#src/utils/formatting';
 
 type Props = {
@@ -49,9 +49,9 @@ const StartWatchingButton: React.VFC<Props> = ({ item }) => {
   }, [isEntitled, isLoggedIn, hasMediaOffers, videoProgress, t]);
 
   const handleStartWatchingClick = useCallback(() => {
-    const seriesId = getSeriesId(item);
+    const seriesId = getSeriesIdFromEpisode(item);
     const playlistId = searchParams.get('r');
-    const videoPlayUrl = isEpisode(item) && seriesId ? episodeURLFromEpisode(item, seriesId, playlistId, true) : videoUrl(item, playlistId, true);
+    const videoPlayUrl = seriesId ? episodeURLFromEpisode(item, seriesId, playlistId, true) : videoUrl(item, playlistId, true);
 
     if (isEntitled) return videoPlayUrl && history.push(videoPlayUrl);
     if (!isLoggedIn) return history.push(addQueryParam(history, 'u', 'create-account'));

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -20,7 +20,6 @@ const useOffers = () => {
   const { cleengSandbox, json } = config;
   const { requestedMediaOffers } = useCheckoutStore(({ requestedMediaOffers }) => ({ requestedMediaOffers }), shallow);
   const hasPremierOffer = (requestedMediaOffers || []).some((offer) => offer.premier);
-  const tvodOfferIds = (requestedMediaOffers || []).map(({ offerId }) => offerId);
   const [offerType, setOfferType] = useState<OfferType>(accessModel === 'SVOD' ? 'svod' : 'tvod');
 
   const monthlyOfferId = json?.cleengMonthlyOffer ? (json.cleengMonthlyOffer as string) : '';
@@ -50,7 +49,9 @@ const useOffers = () => {
     const allOffers = offerQueries.reduce<Offer[]>((prev, cur) => (cur.isSuccess && cur.data?.responseData ? [...prev, cur.data.responseData] : prev), []);
     const offers = allOffers.filter((offer) => (offerType === 'tvod' ? !isSVODOffer(offer) : isSVODOffer(offer)));
     const offersDict = Object.fromEntries(offers.map((offer) => [offer.offerId, offer]));
-    const defaultOfferId = hasPremierOffer ? tvodOfferIds[0] : yearlyOfferId || monthlyOfferId;
+    // we need to get the offerIds from the offer responses since it contains different offerIds based on the customers
+    // location. E.g. if an offer is configured as `S12345678` it becomes `S12345678_US` in the US.
+    const defaultOfferId = offers[offers.length - 1]?.offerId;
 
     return {
       hasTVODOffers: allOffers.some((offer) => !isSVODOffer(offer)),

--- a/src/screens/User/User.tsx
+++ b/src/screens/User/User.tsx
@@ -73,7 +73,7 @@ const User = (): JSX.Element => {
               <li>
                 <Button to="/u/favorites" label={t('nav.favorites')} variant="text" startIcon={<Favorite />} className={styles.button} />
               </li>
-              {accessModel === 'SVOD' && (
+              {accessModel !== 'AVOD' && (
                 <li>
                   <Button to="/u/payments" label={t('nav.payments')} variant="text" startIcon={<BalanceWallet />} className={styles.button} />
                 </li>
@@ -117,8 +117,9 @@ const User = (): JSX.Element => {
             />
           </Route>
           <Route path="/u/payments">
-            {accessModel === 'SVOD' ? (
+            {accessModel !== 'AVOD' ? (
               <Payment
+                accessModel={accessModel}
                 activeSubscription={subscription}
                 activePaymentDetail={activePayment}
                 transactions={transactions}

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -14,6 +14,7 @@ import { restoreWatchHistory, serializeWatchHistory } from '#src/stores/WatchHis
 import { restoreFavorites, serializeFavorites } from '#src/stores/FavoritesController';
 import { getPublicMediaTokens } from '#src/services/entitlement.service';
 import { getMediaByIds } from '#src/services/api.service';
+import { queryClient } from '#src/providers/QueryProvider';
 
 const PERSIST_KEY_ACCOUNT = 'auth';
 
@@ -180,6 +181,9 @@ export const login = async (email: string, password: string) => {
 
 export const logout = async () => {
   persist.removeItem(PERSIST_KEY_ACCOUNT);
+
+  // this invalidates all entitlements caches which makes the useEntitlement hook to verify the entitlements.
+  await queryClient.invalidateQueries('entitlements');
 
   useAccountStore.setState({
     auth: null,
@@ -379,15 +383,22 @@ export async function reloadActiveSubscription({ delay }: { delay: number } = { 
     // The subscription data takes a few seconds to load after it's purchased,
     // so here's a delay mechanism to give it time to process
     if (delay > 0) {
-      window.setTimeout(() => reloadActiveSubscription(), delay);
-    } else {
-      useAccountStore.setState({
-        subscription: activeSubscription,
-        loading: false,
-        transactions,
-        activePayment,
+      return new Promise((resolve: (value?: unknown) => void) => {
+        window.setTimeout(() => {
+          reloadActiveSubscription().finally(resolve);
+        }, delay);
       });
     }
+
+    // this invalidates all entitlements caches which makes the useEntitlement hook to verify the entitlements.
+    await queryClient.invalidateQueries('entitlements');
+
+    useAccountStore.setState({
+      subscription: activeSubscription,
+      loading: false,
+      transactions,
+      activePayment,
+    });
   });
 }
 


### PR DESCRIPTION
## Description

Here are a few bug fixes which had a high priority and seemed safe enough to fix. Most of the bugs reported by ourselves were due to the issues yesterday in the sandbox environment. 

**Fixes:**

- No offer modal after "buying" a TVOD item in the AUTHVOD access model
- Improve the entitlement mechanism by:
  - leveraging the `invalidateQueries` method from react-query
  - enable re-fetch on mount for the entitlement queries
  - clean entitlement caches after logout/reload subscriptions calls
  - wait for the reload subscriptions delay to be finished before continuing (loading state before confirming purchase)
- Fix the start watching button using the wrong URL for series
- Enable the Payments button in all menus and hide the subscription section in the AUTHVOD access model
- Clear any existing order after closing the checkout modal causing customers to see outdated order data

Next to this I've also fixed a metadata error in the Primitive Animals series causing it to navigate to the wrong media (different property).