### PR TITLE
Feat / add EPG service and data fixtures

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         'signing',
         'entitlement',
         'config',
+        'epg',
       ],
     ],
   },

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "stylelint-scss": "^3.20.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.3.4",
+    "vi-fetch": "^0.8.0",
     "vite": "^2.9.0",
     "vite-plugin-eslint": "^1.3.0",
     "vite-plugin-html": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-watch": "TZ=UTC vitest",
     "test-coverage": "TZ=UTC vitest run --coverage",
     "test-commit": "TZ=UTC vitest run --changed HEAD~1 --coverage",
-    "i18next": "i18next src/{components,containers,screens}/**/{**/,/}*.tsx && node ./scripts/i18next/generate.js",
+    "i18next": "i18next src/{components,containers,screens,services,stores}/**/{**/,/}*.{ts,tsx} && node ./scripts/i18next/generate.js",
     "format": "run-s -c format:*",
     "format:eslint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\" --fix",
     "format:prettier": "prettier --write \"{**/*,*}.{js,ts,jsx,tsx}\"",

--- a/public/epg/channel1.json
+++ b/public/epg/channel1.json
@@ -1,0 +1,530 @@
+[
+  {
+    "id": "00990617-c229-4d1e-b341-7fe100b36b3c",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T23:50:00",
+    "endTime": "2022-07-15T00:55:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "45a70c27-1681-4da3-ad3b-73fa7855ee6a",
+    "title": "Friends",
+    "startTime": "2022-07-15T00:55:00",
+    "endTime": "2022-07-15T02:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "d7846aa7-cd76-49eb-be7c-2e183a920d9e",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-15T02:35:00",
+    "endTime": "2022-07-15T03:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "03c2932e-8590-4ab1-bff5-8894558c34d1",
+    "title": "The Simpsons",
+    "startTime": "2022-07-15T03:30:00",
+    "endTime": "2022-07-15T04:15:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "317cfd01-85db-4a2b-a0c8-af1d5ca52686",
+    "title": "That '70s Show",
+    "startTime": "2022-07-15T04:15:00",
+    "endTime": "2022-07-15T04:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "449faed1-be35-4347-ba4a-39dc433bb1d3",
+    "title": "That '70s Show",
+    "startTime": "2022-07-15T04:30:00",
+    "endTime": "2022-07-15T05:10:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4430e87c-4491-4b93-ae16-5941474a3d1c",
+    "title": "How I Met Your Mother",
+    "startTime": "2022-07-15T05:10:00",
+    "endTime": "2022-07-15T05:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A father recounts to his children - through a series of flashbacks - the journey he and his four best friends took leading up to him meeting their mother."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/gvEisYtZ0iBMjnO3zqFU2oM26oM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "481cfbd1-9d0b-413c-9379-38608d8f7fd0",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-15T05:35:00",
+    "endTime": "2022-07-15T06:00:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f7cae874-cb64-46ac-b1d7-05db47d88b22",
+    "title": "Euphoria",
+    "startTime": "2022-07-15T06:00:00",
+    "endTime": "2022-07-15T07:00:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A look at life for a group of high school students as they grapple with issues of drugs, sex, and violence."
+      },
+      {
+        "key": "image",
+        "value": "https://images.fanart.tv/fanart/euphoria-2019-5ec8c62aa702d.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a2f80690-86e6-46e7-8a78-b243d5c8237e",
+    "title": "The Flash",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f99402a4-783d-4298-9ca2-d392db317927",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-15T07:40:00",
+    "endTime": "2022-07-15T08:05:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "6ffd595b-3cdb-431b-b444-934a0e4f63dc",
+    "title": "The Flash",
+    "startTime": "2022-07-15T08:05:00",
+    "endTime": "2022-07-15T08:20:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "78c4442f-2df0-4c75-8cf7-42d249f917b6",
+    "title": "Friends",
+    "startTime": "2022-07-15T08:20:00",
+    "endTime": "2022-07-15T08:45:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f54c4ead-8222-4ba3-99db-53d466df5fe3",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-15T08:45:00",
+    "endTime": "2022-07-15T09:15:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "ab958a02-a41c-4567-ae66-b87b7d6a1a77",
+    "title": "The Book of Boba Fett",
+    "startTime": "2022-07-15T09:15:00",
+    "endTime": "2022-07-15T10:20:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Bounty hunter Boba Fett & mercenary Fennec Shand navigate the underworld when they return to Tatooine to claim Jabba the Hutt's old turf."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/sjx6zjQI2dLGtEL0HGWsnq6UyLU.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5f69ebea-a10f-4acf-9529-a9247dcf8bdf",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-15T10:20:00",
+    "endTime": "2022-07-15T11:15:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "742e3a99-4463-46cf-bef2-a6e2765334ab",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-15T11:15:00",
+    "endTime": "2022-07-15T11:50:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "df272417-c45d-44e5-b928-4d3fb7ff3a76",
+    "title": "The Flash",
+    "startTime": "2022-07-15T11:50:00",
+    "endTime": "2022-07-15T13:45:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "24cb5ed1-f5eb-4dc1-a64b-4396aa7d5ec9",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-15T13:45:00",
+    "endTime": "2022-07-15T13:55:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "b324b65c-0678-42a8-b216-2f1b06ab7b1b",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-15T13:55:00",
+    "endTime": "2022-07-15T14:55:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "ab3f3968-c693-4c2c-a999-a5811680611c",
+    "title": "The Flash",
+    "startTime": "2022-07-15T14:55:00",
+    "endTime": "2022-07-15T15:55:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4ca8eb5e-e8bd-4157-915e-0c5a43f4b0bf",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-15T15:55:00",
+    "endTime": "2022-07-15T17:00:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "83d29f9f-7787-4644-9a9c-d4925522c68d",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-15T17:00:00",
+    "endTime": "2022-07-15T17:20:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "746cbddb-b5b4-42e6-bb10-3c2d2e8e25c9",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-15T17:20:00",
+    "endTime": "2022-07-15T17:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "89ad2461-7eb9-4896-a9d5-d4f92eb60130",
+    "title": "Late Night with Jimmy Fallon",
+    "startTime": "2022-07-15T17:30:00",
+    "endTime": "2022-07-15T18:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Comedian Jimmy Fallon hosts a late-night talk show."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uu5FuSKleCLh0Kq2pmGzlPH3aeS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a87ed404-05ac-48e2-b56c-a30f3acb792e",
+    "title": "House",
+    "startTime": "2022-07-15T18:30:00",
+    "endTime": "2022-07-15T19:25:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "An antisocial maverick doctor who specializes in diagnostic medicine does whatever it takes to solve puzzling cases that come his way using his crack team of doctors and his wits."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hiK4qc0tZijQ9KNUnBIS1k4tdMJ.jpg"
+      }
+    ]
+  },
+  {
+    "id": "19685580-f104-4cfe-9d63-f3144fb6a0d4",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-15T19:25:00",
+    "endTime": "2022-07-15T19:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "d061dd8e-6b9b-4efc-977c-58e7cae91168",
+    "title": "The Simpsons",
+    "startTime": "2022-07-15T19:30:00",
+    "endTime": "2022-07-15T20:05:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "bf8c53c2-63bd-455c-8f96-0fcc97068573",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-15T20:05:00",
+    "endTime": "2022-07-15T20:10:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "7aeb5b08-da25-46ed-a409-a047acf9e941",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-15T20:10:00",
+    "endTime": "2022-07-15T20:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "7c146e38-ee9b-4193-8c59-9a2b96ad95b6",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-15T20:35:00",
+    "endTime": "2022-07-15T21:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "70850251-2c81-4547-8b3e-88bb33b8ede9",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-15T21:35:00",
+    "endTime": "2022-07-15T23:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "981b69ad-1a8d-436e-bf26-fa2bfb4697e5",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-15T23:30:00",
+    "endTime": "2022-07-16T01:25:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  }
+]

--- a/public/epg/channel2.json
+++ b/public/epg/channel2.json
@@ -1,0 +1,1474 @@
+[
+  {
+    "id": "40852655-2e9c-4d98-99f8-0778709f5768",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-12T00:00:00.000Z",
+    "endTime": "2022-07-12T00:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "581e933d-ac03-4e88-8886-928b8a7b1042",
+    "title": "The Flash",
+    "startTime": "2022-07-12T00:25:00.000Z",
+    "endTime": "2022-07-12T00:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5855be9f-ce8b-4755-a141-2e8cdf25943b",
+    "title": "Friends",
+    "startTime": "2022-07-12T00:40:00.000Z",
+    "endTime": "2022-07-12T01:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "8d573601-daaa-4a6c-ad5a-c311b380e5e0",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-12T01:05:00.000Z",
+    "endTime": "2022-07-12T01:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "dcd63e49-aa8c-4583-8696-8671e7e79869",
+    "title": "The Book of Boba Fett",
+    "startTime": "2022-07-12T01:35:00.000Z",
+    "endTime": "2022-07-12T02:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Bounty hunter Boba Fett & mercenary Fennec Shand navigate the underworld when they return to Tatooine to claim Jabba the Hutt's old turf."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/sjx6zjQI2dLGtEL0HGWsnq6UyLU.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c38fe168-3862-484f-a8aa-7b4238246c88",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-12T02:40:00.000Z",
+    "endTime": "2022-07-12T03:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a1813572-571e-435b-b4ab-7413f1c81863",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-12T03:35:00.000Z",
+    "endTime": "2022-07-12T04:10:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "25d5c7a7-f4d8-491e-8027-c41f7e44e9cf",
+    "title": "The Flash",
+    "startTime": "2022-07-12T04:10:00.000Z",
+    "endTime": "2022-07-12T06:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "d519a088-2ffe-48d8-b91f-21d8c0536fec",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-12T06:05:00.000Z",
+    "endTime": "2022-07-12T06:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "59bf2d59-2a19-459b-8346-2d923e2a082a",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-12T06:15:00.000Z",
+    "endTime": "2022-07-12T07:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "b628784b-1061-4a61-98f3-fa48ce3ce81f",
+    "title": "The Flash",
+    "startTime": "2022-07-12T07:15:00.000Z",
+    "endTime": "2022-07-12T08:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4b52a273-3f1b-4488-950a-7e134d694fed",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-12T08:15:00.000Z",
+    "endTime": "2022-07-12T09:20:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "8546cc8a-c1b2-4497-9631-2766945773d5",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-12T09:20:00.000Z",
+    "endTime": "2022-07-12T09:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "768bcca2-b5ef-4fc6-b97b-20fbc90bc13e",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-12T09:40:00.000Z",
+    "endTime": "2022-07-12T09:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "9011659d-f629-410b-8ff7-71dddc969dff",
+    "title": "Late Night with Jimmy Fallon",
+    "startTime": "2022-07-12T09:50:00.000Z",
+    "endTime": "2022-07-12T10:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Comedian Jimmy Fallon hosts a late-night talk show."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uu5FuSKleCLh0Kq2pmGzlPH3aeS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "7b54b55e-4100-4819-9f02-1b564c623d3b",
+    "title": "House",
+    "startTime": "2022-07-12T10:50:00.000Z",
+    "endTime": "2022-07-12T11:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "An antisocial maverick doctor who specializes in diagnostic medicine does whatever it takes to solve puzzling cases that come his way using his crack team of doctors and his wits."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hiK4qc0tZijQ9KNUnBIS1k4tdMJ.jpg"
+      }
+    ]
+  },
+  {
+    "id": "ae7f6911-ca05-4b58-a996-63583f83ac70",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-12T11:45:00.000Z",
+    "endTime": "2022-07-12T11:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a20fe28d-6e61-4c5c-9455-5839a86f5cd7",
+    "title": "The Simpsons",
+    "startTime": "2022-07-12T11:50:00.000Z",
+    "endTime": "2022-07-12T12:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5ccf8bad-99d9-416f-a412-63fb0fe62ad6",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-12T12:25:00.000Z",
+    "endTime": "2022-07-12T12:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "6f967acf-41f7-4d2d-8e67-9bb7496902bf",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-12T12:30:00.000Z",
+    "endTime": "2022-07-12T12:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "3195c701-1626-4232-899d-808ebbb812ba",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-12T12:55:00.000Z",
+    "endTime": "2022-07-12T13:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "ee84a0be-24c8-4d91-8012-62e8484e4350",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-12T13:55:00.000Z",
+    "endTime": "2022-07-12T15:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "8bcdf475-7b61-4783-b6c9-65451692afcb",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-12T15:50:00.000Z",
+    "endTime": "2022-07-12T17:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "bc1b5d4e-070f-4251-968a-9488a5c8022a",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-12T17:45:00.000Z",
+    "endTime": "2022-07-12T18:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f21573a7-e877-4a05-bdaf-0668fc652294",
+    "title": "Friends",
+    "startTime": "2022-07-12T18:50:00.000Z",
+    "endTime": "2022-07-12T20:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "6bcdd06f-894b-450b-a709-f343ed215797",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-12T20:30:00.000Z",
+    "endTime": "2022-07-12T21:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "e1c7ec6f-c4aa-459c-91f3-16ff514dd5ab",
+    "title": "The Simpsons",
+    "startTime": "2022-07-12T21:25:00.000Z",
+    "endTime": "2022-07-12T22:10:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c8fcf6f4-6469-40fd-953d-2f65f1127334",
+    "title": "That '70s Show",
+    "startTime": "2022-07-12T22:10:00.000Z",
+    "endTime": "2022-07-12T22:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a2342266-8158-4f79-aa25-58582623c013",
+    "title": "That '70s Show",
+    "startTime": "2022-07-12T22:25:00.000Z",
+    "endTime": "2022-07-12T23:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "9a0d3b75-1577-47a6-ab3a-b900d6b98c6b",
+    "title": "How I Met Your Mother",
+    "startTime": "2022-07-12T23:05:00.000Z",
+    "endTime": "2022-07-12T23:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A father recounts to his children - through a series of flashbacks - the journey he and his four best friends took leading up to him meeting their mother."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/gvEisYtZ0iBMjnO3zqFU2oM26oM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "b0f378c3-63f8-4b91-8058-c700e0120292",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-12T23:30:00.000Z",
+    "endTime": "2022-07-12T23:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c6b25003-5b7c-42eb-b0b4-2ffcec14017a",
+    "title": "Euphoria",
+    "startTime": "2022-07-12T23:55:00.000Z",
+    "endTime": "2022-07-13T00:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A look at life for a group of high school students as they grapple with issues of drugs, sex, and violence."
+      },
+      {
+        "key": "image",
+        "value": "https://images.fanart.tv/fanart/euphoria-2019-5ec8c62aa702d.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4e1f772b-67d8-4c13-a382-62cd0020ffb1",
+    "title": "The Flash",
+    "startTime": "2022-07-13T00:55:00.000Z",
+    "endTime": "2022-07-13T01:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "38e37f0d-cb3e-45d5-9f83-7f2d6f58f38a",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-13T01:35:00.000Z",
+    "endTime": "2022-07-13T02:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "66ed91bd-6cb8-4b1c-b05f-60c7a5b93a22",
+    "title": "The Flash",
+    "startTime": "2022-07-13T02:00:00.000Z",
+    "endTime": "2022-07-13T02:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5e734eb9-9bfa-4a57-9446-56244e5d61b5",
+    "title": "Friends",
+    "startTime": "2022-07-13T02:15:00.000Z",
+    "endTime": "2022-07-13T02:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "07a17379-338f-4d4a-a5cd-57177cf51187",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-13T02:40:00.000Z",
+    "endTime": "2022-07-13T03:10:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "2a9d5f5c-c50e-468a-8f22-60f17170940b",
+    "title": "The Book of Boba Fett",
+    "startTime": "2022-07-13T03:10:00.000Z",
+    "endTime": "2022-07-13T04:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Bounty hunter Boba Fett & mercenary Fennec Shand navigate the underworld when they return to Tatooine to claim Jabba the Hutt's old turf."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/sjx6zjQI2dLGtEL0HGWsnq6UyLU.jpg"
+      }
+    ]
+  },
+  {
+    "id": "0b6a04cd-53e5-4da4-943f-558cd09fc80e",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-13T04:15:00.000Z",
+    "endTime": "2022-07-13T05:10:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "adb73f33-85bf-4b01-a37b-60d1701f50bf",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-13T05:10:00.000Z",
+    "endTime": "2022-07-13T05:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "96c3f9a0-f6b4-4dc7-b151-5fc9c22c662c",
+    "title": "The Flash",
+    "startTime": "2022-07-13T05:45:00.000Z",
+    "endTime": "2022-07-13T07:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "32dcb9ce-e295-4b2f-a3b4-a49178269930",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-13T07:40:00.000Z",
+    "endTime": "2022-07-13T07:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4cd3dc6b-8725-40e5-a5db-2d27e8434df8",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-13T07:50:00.000Z",
+    "endTime": "2022-07-13T08:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "cc733c87-430e-414a-bdfc-ee1fb7f8076a",
+    "title": "The Flash",
+    "startTime": "2022-07-13T08:50:00.000Z",
+    "endTime": "2022-07-13T09:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "dd6391bb-db10-4080-8e42-7b5c4a00a620",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-13T09:50:00.000Z",
+    "endTime": "2022-07-13T10:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "e076460e-3778-4302-8bff-5f8ed3b086dc",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-13T10:55:00.000Z",
+    "endTime": "2022-07-13T11:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "abcd04fc-e0c9-42f5-8cef-ac47865ed85c",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-13T11:15:00.000Z",
+    "endTime": "2022-07-13T11:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "0e9aaa9c-e31c-4404-9da0-7606eed51c8c",
+    "title": "Late Night with Jimmy Fallon",
+    "startTime": "2022-07-13T11:25:00.000Z",
+    "endTime": "2022-07-13T12:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Comedian Jimmy Fallon hosts a late-night talk show."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uu5FuSKleCLh0Kq2pmGzlPH3aeS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "babd573e-ec1e-495f-8fd0-d36baf12871e",
+    "title": "House",
+    "startTime": "2022-07-13T12:25:00.000Z",
+    "endTime": "2022-07-13T13:20:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "An antisocial maverick doctor who specializes in diagnostic medicine does whatever it takes to solve puzzling cases that come his way using his crack team of doctors and his wits."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hiK4qc0tZijQ9KNUnBIS1k4tdMJ.jpg"
+      }
+    ]
+  },
+  {
+    "id": "6edc2bc2-2970-4594-9074-77d4a8fec873",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-13T13:20:00.000Z",
+    "endTime": "2022-07-13T13:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "fb7c2d1a-ee62-40ed-8fc8-b6d93d965332",
+    "title": "The Simpsons",
+    "startTime": "2022-07-13T13:25:00.000Z",
+    "endTime": "2022-07-13T14:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5dc2f3cc-d2a5-42b5-a0a3-7e5addb2ea0f",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-13T14:00:00.000Z",
+    "endTime": "2022-07-13T14:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "43ca8960-acb6-467c-a197-8d86bbcb0c2b",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-13T14:05:00.000Z",
+    "endTime": "2022-07-13T14:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "551a66a8-3db1-40d7-8423-fb16a1fff774",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-13T14:30:00.000Z",
+    "endTime": "2022-07-13T15:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "3bc1da51-67a7-42f1-b8d9-3f9987bcc6bc",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-13T15:30:00.000Z",
+    "endTime": "2022-07-13T17:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f44a2f47-be29-47cb-a287-bd65f328a1c7",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-13T17:25:00.000Z",
+    "endTime": "2022-07-13T19:20:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "8b6bf000-1575-449a-89b9-ca6f66421871",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-13T19:20:00.000Z",
+    "endTime": "2022-07-13T20:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "0d82da10-b55c-4b91-b6bc-1ceb6a45c2bc",
+    "title": "Friends",
+    "startTime": "2022-07-13T20:25:00.000Z",
+    "endTime": "2022-07-13T22:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "42187ff0-e968-4a4a-aea4-6fd01ffdf394",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-13T22:05:00.000Z",
+    "endTime": "2022-07-13T23:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "021c237c-92b3-459b-a905-61dfcee23d68",
+    "title": "The Simpsons",
+    "startTime": "2022-07-13T23:00:00.000Z",
+    "endTime": "2022-07-13T23:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c95ff569-5873-46bc-80df-dfb6423b8fcf",
+    "title": "That '70s Show",
+    "startTime": "2022-07-13T23:45:00.000Z",
+    "endTime": "2022-07-14T00:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4f59342d-46a6-421d-85ca-527dec7b6d5d",
+    "title": "That '70s Show",
+    "startTime": "2022-07-14T00:00:00.000Z",
+    "endTime": "2022-07-14T00:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "21a4ce7a-5f7b-4985-aab6-42e7bd806e9d",
+    "title": "How I Met Your Mother",
+    "startTime": "2022-07-14T00:40:00.000Z",
+    "endTime": "2022-07-14T01:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A father recounts to his children - through a series of flashbacks - the journey he and his four best friends took leading up to him meeting their mother."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/gvEisYtZ0iBMjnO3zqFU2oM26oM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "e66b5ffa-b0b4-4148-a30f-dcd2ed7fbf93",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-14T01:05:00.000Z",
+    "endTime": "2022-07-14T01:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "240c451b-115e-4777-8245-2c675f16c3d7",
+    "title": "Euphoria",
+    "startTime": "2022-07-14T01:30:00.000Z",
+    "endTime": "2022-07-14T02:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A look at life for a group of high school students as they grapple with issues of drugs, sex, and violence."
+      },
+      {
+        "key": "image",
+        "value": "https://images.fanart.tv/fanart/euphoria-2019-5ec8c62aa702d.jpg"
+      }
+    ]
+  },
+  {
+    "id": "e746ab4c-00b5-46f8-b817-747b8281420d",
+    "title": "The Flash",
+    "startTime": "2022-07-14T02:30:00.000Z",
+    "endTime": "2022-07-14T03:10:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5eddcadc-83b6-4bd4-b73f-bcfed4a7c07e",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-14T03:10:00.000Z",
+    "endTime": "2022-07-14T03:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4e0d07a1-8b84-4d94-96c8-86cf3ad9682c",
+    "title": "The Flash",
+    "startTime": "2022-07-14T03:35:00.000Z",
+    "endTime": "2022-07-14T03:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "92fc8f75-25a8-43ec-8603-83a4ee347209",
+    "title": "Friends",
+    "startTime": "2022-07-14T03:50:00.000Z",
+    "endTime": "2022-07-14T04:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "8a807ba7-668d-4778-b927-214c808dc253",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-14T04:15:00.000Z",
+    "endTime": "2022-07-14T04:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "7bd90470-30e7-4aac-81c6-191e81fcb324",
+    "title": "The Book of Boba Fett",
+    "startTime": "2022-07-14T04:45:00.000Z",
+    "endTime": "2022-07-14T05:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Bounty hunter Boba Fett & mercenary Fennec Shand navigate the underworld when they return to Tatooine to claim Jabba the Hutt's old turf."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/sjx6zjQI2dLGtEL0HGWsnq6UyLU.jpg"
+      }
+    ]
+  },
+  {
+    "id": "3f488f6a-3309-4afd-9433-e49971b5d731",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T05:50:00.000Z",
+    "endTime": "2022-07-14T06:45:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "a561899e-0c03-4631-b25c-a6b0352396a2",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-14T06:45:00.000Z",
+    "endTime": "2022-07-14T07:20:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "730bd114-42ed-497f-9566-52109fa05d4c",
+    "title": "The Flash",
+    "startTime": "2022-07-14T07:20:00.000Z",
+    "endTime": "2022-07-14T09:15:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "adc0c35e-4ce2-48ba-9ad0-4cc0b9929052",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-14T09:15:00.000Z",
+    "endTime": "2022-07-14T09:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "57540443-aa59-4ed2-8a97-fe0c53ea5f59",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-14T09:25:00.000Z",
+    "endTime": "2022-07-14T10:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "29ddc5c8-bfce-41c4-a832-6bd017529f75",
+    "title": "The Flash",
+    "startTime": "2022-07-14T10:25:00.000Z",
+    "endTime": "2022-07-14T11:25:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c7643d4f-2190-4178-8543-8a311fd8372e",
+    "title": "And Just Like That...",
+    "startTime": "2022-07-14T11:25:00.000Z",
+    "endTime": "2022-07-14T12:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The series will follow Carrie, Miranda and Charlotte as they navigate the journey from the complicated reality of life and friendship in their 30s to the even more complicated reality of life and friendship in their 50s."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/1CqkiWeuwlaMswG02q3mBmraiDM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "1ff5f764-7fd1-4a2e-8553-0a25918bcf93",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-14T12:30:00.000Z",
+    "endTime": "2022-07-14T12:50:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "62c5cf9c-ac5c-4c2a-a5da-d2c5f1ed7d08",
+    "title": "The Daily Show with Trevor Noah: Ears Edition",
+    "startTime": "2022-07-14T12:50:00.000Z",
+    "endTime": "2022-07-14T13:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Listen to highlights and extended interviews in the \"Ears Edition\" of The Daily Show with Trevor Noah. From Comedy Central's Podcast Network."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uyilhJ7MBLjiaQXboaEwe44Z0jA.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5b88ef5a-394c-4a9d-8bc9-7b7fc7f5830f",
+    "title": "Late Night with Jimmy Fallon",
+    "startTime": "2022-07-14T13:00:00.000Z",
+    "endTime": "2022-07-14T14:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Comedian Jimmy Fallon hosts a late-night talk show."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/uu5FuSKleCLh0Kq2pmGzlPH3aeS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "c6b117cc-0658-4788-a0b7-acb8beb5fde3",
+    "title": "House",
+    "startTime": "2022-07-14T14:00:00.000Z",
+    "endTime": "2022-07-14T14:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "An antisocial maverick doctor who specializes in diagnostic medicine does whatever it takes to solve puzzling cases that come his way using his crack team of doctors and his wits."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hiK4qc0tZijQ9KNUnBIS1k4tdMJ.jpg"
+      }
+    ]
+  },
+  {
+    "id": "73067c1a-ea9d-40c4-8510-2b6bab73baed",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T14:55:00.000Z",
+    "endTime": "2022-07-14T15:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "712e0aa9-c81f-41fb-8fb0-bfb2c4868575",
+    "title": "The Simpsons",
+    "startTime": "2022-07-14T15:00:00.000Z",
+    "endTime": "2022-07-14T15:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "bb948aa8-dd48-496b-8881-72739c5cbdf9",
+    "title": "The Silent Sea",
+    "startTime": "2022-07-14T15:35:00.000Z",
+    "endTime": "2022-07-14T15:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "During a perilous 24-hour mission on the moon, space explorers try to retrieve samples from an abandoned research facility steeped in classified secrets."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/9hNJ3fvIVd4WE3rU1Us2awoTpgM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "5486daff-4130-4cd6-a742-69d3b123b301",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-14T15:40:00.000Z",
+    "endTime": "2022-07-14T16:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "dc209bc0-5de8-4d99-b1e4-91f49401e8f2",
+    "title": "SpongeBob SquarePants",
+    "startTime": "2022-07-14T16:05:00.000Z",
+    "endTime": "2022-07-14T17:05:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The misadventures of a talking sea sponge who works at a fast food restaurant, attends a boating school, and lives in an underwater pineapple."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/maFEWU41jdUOzDfRVkojq7fluIm.jpg"
+      }
+    ]
+  },
+  {
+    "id": "d03e7b47-2014-440e-b28a-087fa72841d6",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T17:05:00.000Z",
+    "endTime": "2022-07-14T19:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "cdfdf1a6-5ace-4a09-9272-5b43751a3afc",
+    "title": "The Fairly OddParents",
+    "startTime": "2022-07-14T19:00:00.000Z",
+    "endTime": "2022-07-14T20:55:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follow Timmy Turner's cousin, Vivian \"Viv\" Turner, and her new stepbrother, Roy Ragland, as they navigate life in Dimmsdale with the help of their fairy godparents, Wanda and Cosmo."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/jlruzecsif3tkCSoHlUaPR01O7U.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f144f44f-7c30-4bd2-9144-2b0648566b85",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T20:55:00.000Z",
+    "endTime": "2022-07-14T22:00:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f6b997d7-497f-4176-afa7-58f1d4bf761c",
+    "title": "Friends",
+    "startTime": "2022-07-14T22:00:00.000Z",
+    "endTime": "2022-07-14T23:40:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "e10e6236-b476-42c3-8dbb-666f67938f6c",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-14T23:40:00.000Z",
+    "endTime": "2022-07-15T00:35:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  }
+]

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -154,7 +154,7 @@
       "pubdate": 1615480440,
       "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
       "tags": "live",
-      "scheduleUrl": "/epg/channel2.json",
+      "scheduleUrl": "/epg/does-not-exist.json",
       "sources": [
         {
           "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -1,0 +1,169 @@
+{
+  "title": "Live Channels",
+  "description": "",
+  "kind": "MANUAL",
+  "feedid": "JSKF03bk",
+  "links": {
+    "first": "https://content.jwplatform.com/v2/playlists/JSKF03bk?page_limit=25&format=json&internal=false&page_offset=1",
+    "last": "https://content.jwplatform.com/v2/playlists/JSKF03bk?page_limit=25&format=json&internal=false&page_offset=1"
+  },
+  "playlist": [
+    {
+      "title": "Channel 1",
+      "mediaid": "LEBW145Q",
+      "link": "https://content.jwplatform.com/previews/LEBW145Q",
+      "image": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=720",
+      "images": [
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=320",
+          "width": 320,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=480",
+          "width": 480,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=640",
+          "width": 640,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=720",
+          "width": 720,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=1280",
+          "width": 1280,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/LEBW145Q/poster.jpg?width=1920",
+          "width": 1920,
+          "type": "image/jpeg"
+        }
+      ],
+      "feedid": "JSKF03bk",
+      "duration": 0,
+      "pubdate": 1615480440,
+      "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
+      "tags": "live",
+      "scheduleUrl": "/epg/channel1.json",
+      "sources": [
+        {
+          "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",
+          "type": "application/vnd.apple.mpegurl"
+        }
+      ],
+      "variations": {},
+      "requiresSubscription": "false"
+    },
+    {
+      "title": "Channel 2",
+      "mediaid": "NS2Q213",
+      "link": "https://content.jwplatform.com/previews/NS2Q213",
+      "image": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=720",
+      "images": [
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=320",
+          "width": 320,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=480",
+          "width": 480,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=640",
+          "width": 640,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=720",
+          "width": 720,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=1280",
+          "width": 1280,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/NS2Q213/poster.jpg?width=1920",
+          "width": 1920,
+          "type": "image/jpeg"
+        }
+      ],
+      "feedid": "JSKF03bk",
+      "duration": 0,
+      "pubdate": 1615480440,
+      "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
+      "tags": "live",
+      "scheduleUrl": "/epg/channel2.json",
+      "sources": [
+        {
+          "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",
+          "type": "application/vnd.apple.mpegurl"
+        }
+      ],
+      "variations": {},
+      "requiresSubscription": "false"
+    },
+    {
+      "title": "Channel 3",
+      "mediaid": "JDODS53",
+      "link": "https://content.jwplatform.com/previews/JDODS53",
+      "image": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=720",
+      "images": [
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=320",
+          "width": 320,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=480",
+          "width": 480,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=640",
+          "width": 640,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=720",
+          "width": 720,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=1280",
+          "width": 1280,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/JDODS53/poster.jpg?width=1920",
+          "width": 1920,
+          "type": "image/jpeg"
+        }
+      ],
+      "feedid": "JSKF03bk",
+      "duration": 0,
+      "pubdate": 1615480440,
+      "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
+      "tags": "live",
+      "scheduleUrl": "/epg/channel2.json",
+      "sources": [
+        {
+          "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",
+          "type": "application/vnd.apple.mpegurl"
+        }
+      ],
+      "variations": {},
+      "requiresSubscription": "false"
+    }
+  ],
+  "feed_instance_id": "5f7f7d06-4f9e-4408-8baa-ff8cc469611a"
+}

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -163,6 +163,58 @@
       ],
       "variations": {},
       "requiresSubscription": "false"
+    },
+    {
+      "title": "Channel 4",
+      "mediaid": "SDF23CJ",
+      "link": "https://content.jwplatform.com/previews/SDF23CJ",
+      "image": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=720",
+      "images": [
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=320",
+          "width": 320,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=480",
+          "width": 480,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=640",
+          "width": 640,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=720",
+          "width": 720,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=1280",
+          "width": 1280,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=1920",
+          "width": 1920,
+          "type": "image/jpeg"
+        }
+      ],
+      "feedid": "JSKF03bk",
+      "duration": 0,
+      "pubdate": 1615480440,
+      "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
+      "tags": "live",
+      "scheduleUrl": "/epg/network-error.json",
+      "sources": [
+        {
+          "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",
+          "type": "application/vnd.apple.mpegurl"
+        }
+      ],
+      "variations": {},
+      "requiresSubscription": "false"
     }
   ],
   "feed_instance_id": "5f7f7d06-4f9e-4408-8baa-ff8cc469611a"

--- a/src/fixtures/schedule.json
+++ b/src/fixtures/schedule.json
@@ -146,6 +146,57 @@
       {
         "key": "image",
         "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      },
+      {
+        "key": "other-property",
+        "value": "This property should be ignored"
+      }
+    ]
+  },
+  {
+    "id": "cbec3682-eae8-44d4-9cc1-a97b3e95413c",
+    "title": "Empty properties",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": []
+  },
+  {
+    "id": "c909c1ba-ba8f-485f-880e-12974b82819d",
+    "title": "No image",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Item description"
+      }
+    ]
+  },
+  {
+    "id": "6ab2c86e-d435-4311-a3bf-12a96c5f6603",
+    "title": "No description",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "image",
+        "value": "https://cdn.jwplayer.com/image.jpg"
+      }
+    ]
+  },
+  {
+    "id": "9507d674-506f-415f-85b6-cf32baaa2c2f",
+    "title": "Empty image and description",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": ""
+      },
+      {
+        "key": "image",
+        "value": ""
       }
     ]
   },

--- a/src/fixtures/schedule.json
+++ b/src/fixtures/schedule.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "00990617-c229-4d1e-b341-7fe100b36b3c",
+    "title": "Peaky Blinders",
+    "startTime": "2022-07-14T23:50:00",
+    "endTime": "2022-07-15T00:55:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gangster family epic set in 1900s England, centering on a gang who sew razor blades in the peaks of their caps, and their fierce boss Tommy Shelby."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/wiE9doxiLwq3WCGamDIOb2PqBqc.jpg"
+      }
+    ]
+  },
+  {
+    "id": "45a70c27-1681-4da3-ad3b-73fa7855ee6a",
+    "title": "Friends",
+    "startTime": "2022-07-15T00:55:00",
+    "endTime": "2022-07-15T02:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  },
+  {
+    "id": "d7846aa7-cd76-49eb-be7c-2e183a920d9e",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-15T02:35:00",
+    "endTime": "2022-07-15T03:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "03c2932e-8590-4ab1-bff5-8894558c34d1",
+    "title": "The Simpsons",
+    "startTime": "2022-07-15T03:30:00",
+    "endTime": "2022-07-15T04:15:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "The satiric adventures of a working-class family in the misfit city of Springfield."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/hpU2cHC9tk90hswCFEpf5AtbqoL.jpg"
+      }
+    ]
+  },
+  {
+    "id": "317cfd01-85db-4a2b-a0c8-af1d5ca52686",
+    "title": "That '70s Show",
+    "startTime": "2022-07-15T04:15:00",
+    "endTime": "2022-07-15T04:30:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "449faed1-be35-4347-ba4a-39dc433bb1d3",
+    "title": "That '70s Show",
+    "startTime": "2022-07-15T04:30:00",
+    "endTime": "2022-07-15T05:10:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A comedy revolving around a group of teenage friends, their mishaps, and their coming of age, set in 1970s Wisconsin."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/3zRUiH8erHIgNUBTj05JT00HwsS.jpg"
+      }
+    ]
+  },
+  {
+    "id": "4430e87c-4491-4b93-ae16-5941474a3d1c",
+    "title": "How I Met Your Mother",
+    "startTime": "2022-07-15T05:10:00",
+    "endTime": "2022-07-15T05:35:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A father recounts to his children - through a series of flashbacks - the journey he and his four best friends took leading up to him meeting their mother."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/gvEisYtZ0iBMjnO3zqFU2oM26oM.jpg"
+      }
+    ]
+  },
+  {
+    "id": "481cfbd1-9d0b-413c-9379-38608d8f7fd0",
+    "title": "Malcolm in the Middle",
+    "startTime": "2022-07-15T05:35:00",
+    "endTime": "2022-07-15T06:00:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "A gifted young teen tries to survive life with his dimwitted, dysfunctional family."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/ysaA0BInz4071p3LKqAQnWKZCsK.jpg"
+      }
+    ]
+  },
+  {
+    "id": "f7cae874-cb64-46ac-b1d7-05db47d88b22",
+    "title": "Euphoria",
+    "startTime": "2022-07-15T06:00:00",
+    "endTime": "2022-07-15T07:00:00"
+  },
+  {
+    "id": "0c3405b6-6e5d-4800-8dc1-2ed75ec410d8",
+    "title": "The Flash",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "After being struck by lightning, Barry Allen wakes up from his coma to discover he's been given the power of super speed, becoming the Flash, fighting crime in Central City."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/akuD37ySZGUkXR7LNb1oOHCboy8.jpg"
+      }
+    ]
+  },
+  {
+    "title": "Missing id startsAt",
+    "startTime": "2022-07-15T07:00:00",
+    "endTime": "2022-07-15T07:40:00"
+  },
+  {
+    "id": "0c3405b6-6e5d-4800-8dc1-2ed75ec410d8",
+    "title": "Invalid startsAt",
+    "startTime": "this is not a date",
+    "endTime": "2022-07-15T07:40:00"
+  },
+  {
+    "id": "0c3405b6-6e5d-4800-8dc1-2ed75ec410d8",
+    "title": "Invalid endsAt",
+    "startTime": "2022-07-15T07:40:00",
+    "endTime": "this is not a date"
+  },
+  {
+    "id": "0c3405b6-6e5d-4800-8dc1-2ed75ec410d8",
+    "invalid_entry": "This entry should be removed from the validated schedule"
+  }
+]

--- a/src/i18n/locales/en_US.ts
+++ b/src/i18n/locales/en_US.ts
@@ -3,6 +3,7 @@
 
 export { default as account } from './en_US/account.json';
 export { default as common } from './en_US/common.json';
+export { default as epg } from './en_US/epg.json';
 export { default as error } from './en_US/error.json';
 export { default as menu } from './en_US/menu.json';
 export { default as search } from './en_US/search.json';

--- a/src/i18n/locales/en_US/common.json
+++ b/src/i18n/locales/en_US/common.json
@@ -1,4 +1,8 @@
 {
+  "alert": {
+    "close": "Close",
+    "title": "An error occurred"
+  },
   "back": "Back",
   "card_lock": "Item locked",
   "close_modal": "Close",
@@ -6,10 +10,7 @@
     "close": "Cancel",
     "confirm": "Yes"
   },
-  "alert": {
-    "title": "An error occurred",
-    "close": "Close"
-  },
+  "default_site_name": "My OTT Application",
   "filter_videos_by_genre": "Filter videos by genre",
   "home": "Home",
   "live": "LIVE",
@@ -18,6 +19,5 @@
   "sign_in": "Sign in",
   "sign_up": "Sign up",
   "slide_left": "Slide left",
-  "slide_right": "Slide right",
-  "default_site_name": "My OTT Application"
+  "slide_right": "Slide right"
 }

--- a/src/i18n/locales/en_US/epg.json
+++ b/src/i18n/locales/en_US/epg.json
@@ -1,0 +1,10 @@
+{
+  "empty_schedule_program": {
+    "description": "No program information available",
+    "title": "No program information"
+  },
+  "failed_schedule_program": {
+    "description": "The program information failed to load",
+    "title": "Failed to load schedule"
+  }
+}

--- a/src/i18n/locales/en_US/video.json
+++ b/src/i18n/locales/en_US/video.json
@@ -9,17 +9,17 @@
   "episode_not_found": "Episode not found",
   "episodes": "Episodes",
   "favorite": "Favorite",
+  "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{maxCount}} favorite videos. Please delete one and repeat the operation.",
   "remove_from_favorites": "Remove from favorites",
   "season_prefix": "Season ",
   "series_error": "An error occurred while requesting series",
   "share": "Share",
   "sign_up_to_start_watching": "Sign up to start watching!",
   "start_watching": "Start watching",
-  "total_episodes": "{{ count }} episode",
-  "total_episodes_plural": "{{ count }} episodes",
+  "total_episodes": "{{count}} episode",
+  "total_episodes_plural": "{{count}} episodes",
   "trailer": "Trailer",
   "video_not_found": "Video not found",
   "watch_trailer": "Watch the trailer",
-  "share_video": "Share this video",
-  "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{ count }} favorite videos. Please delete one and repeat the operation."
+  "share_video": "Share this video"
 }

--- a/src/i18n/locales/nl_NL.ts
+++ b/src/i18n/locales/nl_NL.ts
@@ -3,6 +3,7 @@
 
 export { default as account } from './nl_NL/account.json';
 export { default as common } from './nl_NL/common.json';
+export { default as epg } from './nl_NL/epg.json';
 export { default as error } from './nl_NL/error.json';
 export { default as menu } from './nl_NL/menu.json';
 export { default as search } from './nl_NL/search.json';

--- a/src/i18n/locales/nl_NL/common.json
+++ b/src/i18n/locales/nl_NL/common.json
@@ -1,4 +1,8 @@
 {
+  "alert": {
+    "close": "",
+    "title": ""
+  },
   "back": "",
   "card_lock": "",
   "close_modal": "",
@@ -6,10 +10,7 @@
     "close": "",
     "confirm": ""
   },
-  "alert": {
-    "title": "",
-    "close": ""
-  },
+  "default_site_name": "",
   "filter_videos_by_genre": "",
   "home": "",
   "live": "",
@@ -18,6 +19,5 @@
   "sign_in": "",
   "sign_up": "",
   "slide_left": "",
-  "slide_right": "",
-  "default_site_name": ""
+  "slide_right": ""
 }

--- a/src/i18n/locales/nl_NL/epg.json
+++ b/src/i18n/locales/nl_NL/epg.json
@@ -1,0 +1,10 @@
+{
+  "empty_schedule_program": {
+    "description": "",
+    "title": ""
+  },
+  "failed_schedule_program": {
+    "description": "",
+    "title": ""
+  }
+}

--- a/src/i18n/locales/nl_NL/video.json
+++ b/src/i18n/locales/nl_NL/video.json
@@ -9,6 +9,7 @@
   "episode_not_found": "",
   "episodes": "",
   "favorite": "",
+  "favorites_warning": "",
   "remove_from_favorites": "",
   "season_prefix": "",
   "series_error": "",
@@ -20,6 +21,6 @@
   "trailer": "",
   "video_not_found": "",
   "watch_trailer": "",
-  "share_video": "",
-  "favorites_warning": ""
+  "favorites_warning_plural": "",
+  "share_video": ""
 }

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -1,6 +1,6 @@
-import { string, boolean, array, object, SchemaOf, StringSchema, mixed } from 'yup';
+import { array, boolean, mixed, object, SchemaOf, string, StringSchema } from 'yup';
 
-import type { Config, Content, Menu, Styling, Features, Cleeng } from '#types/Config';
+import type { Cleeng, Config, Content, Features, Menu, Styling } from '#types/Config';
 import { PersonalShelf } from '#src/enum/PersonalShelf';
 import i18n from '#src/i18n/config';
 import { logDev } from '#src/utils/common';
@@ -133,7 +133,7 @@ const enrichConfig = (config: Config): Config => {
   const { content, siteName } = config;
   const updatedContent = content.map((content) => Object.assign({ enableText: true, featured: false }, content));
 
-  return { ...config, siteName: siteName || i18n.t('common.default_site_name'), content: updatedContent };
+  return { ...config, siteName: siteName || i18n.t('common:default_site_name'), content: updatedContent };
 };
 
 export const validateConfig = (config?: Config): Promise<Config> => {

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -22,8 +22,27 @@ describe('epgService', () => {
     const mock = mockGet('/epg/channel1.json').willResolve([]);
     const data = await epgService.fetchSchedule(livePlaylist.playlist[0]);
 
+    const request = mock.getRouteCalls()[0];
+    const requestHeaders = request?.[1]?.headers;
+
     expect(data).toEqual([]);
     expect(mock).toHaveFetched();
+    expect(requestHeaders).toEqual(new Headers()); // no headers expected
+  });
+
+  test('fetchSchedule adds authentication token', async () => {
+    const mock = mockGet('/epg/channel1.json').willResolve([]);
+    const item = Object.assign({}, livePlaylist.playlist[0]);
+
+    item.scheduleToken = 'AUTH-TOKEN';
+    const data = await epgService.fetchSchedule(item);
+
+    const request = mock.getRouteCalls()[0];
+    const requestHeaders = request?.[1]?.headers;
+
+    expect(data).toEqual([]);
+    expect(mock).toHaveFetched();
+    expect(requestHeaders).toEqual(new Headers({ 'API-KEY': 'AUTH-TOKEN' }));
   });
 
   test('getSchedule fetches and validates a valid schedule', async () => {

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -57,48 +57,48 @@ describe('epgService', () => {
   });
 
   test('getSchedule adds a static program when the schedule is empty or fails', async () => {
-    const channel2Mock = mockGet('/epg/channel2.json').willResolve([]);
-    const channel3Mock = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
-    const channel4Mock = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
+    const mock1 = mockGet('/epg/channel2.json').willResolve([]);
+    const mock2 = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
+    const mock3 = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
 
     // mock the date
     vi.setSystemTime(new Date(2022, 1, 1, 14, 30, 10, 500));
 
-    const schedule2 = await epgService.getSchedule(livePlaylist.playlist[1]);
-    const schedule3 = await epgService.getSchedule(livePlaylist.playlist[2]);
-    const schedule4 = await epgService.getSchedule(livePlaylist.playlist[3]);
+    const emptySchedule = await epgService.getSchedule(livePlaylist.playlist[1]);
+    const failedSchedule = await epgService.getSchedule(livePlaylist.playlist[2]);
+    const networkErrorSchedule = await epgService.getSchedule(livePlaylist.playlist[3]);
 
-    expect(channel2Mock).toHaveFetched();
-    expect(schedule2.title).toEqual('Channel 2');
-    expect(schedule2.programs.length).toEqual(1);
-    expect(schedule2.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock1).toHaveFetched();
+    expect(emptySchedule.title).toEqual('Channel 2');
+    expect(emptySchedule.programs.length).toEqual(1);
+    expect(emptySchedule.programs[0]).toMatchObject({
+      id: 'no-program-NS2Q213',
+      title: 'epg:empty_schedule_program.title',
+      description: 'epg:empty_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
-    expect(channel3Mock).toHaveFetched();
-    expect(schedule3.title).toEqual('Channel 3');
-    expect(schedule3.programs.length).toEqual(1);
-    expect(schedule3.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock2).toHaveFetched();
+    expect(failedSchedule.title).toEqual('Channel 3');
+    expect(failedSchedule.programs.length).toEqual(1);
+    expect(failedSchedule.programs[0]).toMatchObject({
+      id: 'no-program-JDODS53',
+      title: 'epg:failed_schedule_program.title',
+      description: 'epg:failed_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
-    expect(channel4Mock).toHaveFetched();
-    expect(schedule4.title).toEqual('Channel 4');
-    expect(schedule4.programs.length).toEqual(1);
-    expect(schedule4.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock3).toHaveFetched();
+    expect(networkErrorSchedule.title).toEqual('Channel 4');
+    expect(networkErrorSchedule.programs.length).toEqual(1);
+    expect(networkErrorSchedule.programs[0]).toMatchObject({
+      id: 'no-program-SDF23CJ',
+      title: 'epg:failed_schedule_program.title',
+      description: 'epg:failed_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
@@ -130,17 +130,17 @@ describe('epgService', () => {
     // empty schedule (with static program)
     expect(schedules[1].title).toEqual('Channel 2');
     expect(schedules[1].programs.length).toEqual(1);
-    expect(schedules[1].programs[0].title).toEqual('No program');
+    expect(schedules[1].programs[0].title).toEqual('epg:empty_schedule_program.title');
 
     // failed fetching the schedule request (with static program)
     expect(schedules[2].title).toEqual('Channel 3');
     expect(schedules[2].programs.length).toEqual(1);
-    expect(schedules[2].programs[0].title).toEqual('No program');
+    expect(schedules[2].programs[0].title).toEqual('epg:failed_schedule_program.title');
 
     // network error (with static program)
     expect(schedules[3].title).toEqual('Channel 4');
     expect(schedules[3].programs.length).toEqual(1);
-    expect(schedules[3].programs[0].title).toEqual('No program');
+    expect(schedules[3].programs[0].title).toEqual('epg:failed_schedule_program.title');
   });
 
   test('parseSchedule should remove programs where required fields are missing', async () => {

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -32,7 +32,7 @@ describe('epgService', () => {
 
     expect(mock).toHaveFetched();
     expect(schedule.title).toEqual('Channel 1');
-    expect(schedule.programs.length).toEqual(10);
+    expect(schedule.programs.length).toEqual(14);
   });
 
   test('getSchedules fetches and validates multiple schedules', async () => {
@@ -53,7 +53,7 @@ describe('epgService', () => {
 
     // valid schedule with 10 programs
     expect(schedules[0].title).toEqual('Channel 1');
-    expect(schedules[0].programs.length).toEqual(10);
+    expect(schedules[0].programs.length).toEqual(14);
 
     // empty schedule
     expect(schedules[1].title).toEqual('Channel 2');
@@ -112,5 +112,68 @@ describe('epgService', () => {
 
     expect(schedule1.length).toEqual(0);
     expect(schedule2.length).toEqual(0);
+  });
+
+  test('parseSchedule should transform valid program entries', async () => {
+    const program1 = await epgService.transformProgram({
+      id: '1234-1234-1234-1234',
+      title: 'Test item',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+    });
+    const program2 = await epgService.transformProgram({
+      id: '1234-1234-1234-1234',
+      title: 'Test item 2',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+      chapterPointCustomProperties: [],
+    });
+    const program3 = await epgService.transformProgram({
+      id: '1234-1234-1234-1234',
+      title: 'Test item 3',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+      chapterPointCustomProperties: [
+        {
+          key: 'description',
+          value: 'A description',
+        },
+        {
+          key: 'image',
+          value: 'https://cdn.jwplayer/logo.jpg',
+        },
+        {
+          key: 'other-key',
+          value: 'this property should be ignored',
+        },
+      ],
+    });
+
+    expect(program1).toEqual({
+      id: '1234-1234-1234-1234',
+      title: 'Test item',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+      description: undefined,
+      image: undefined,
+    });
+
+    expect(program2).toEqual({
+      id: '1234-1234-1234-1234',
+      title: 'Test item 2',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+      description: undefined,
+      image: undefined,
+    });
+
+    expect(program3).toEqual({
+      id: '1234-1234-1234-1234',
+      title: 'Test item 3',
+      startTime: '2022-07-19T12:00:00Z',
+      endTime: '2022-07-19T15:00:00Z',
+      description: 'A description',
+      image: 'https://cdn.jwplayer/logo.jpg',
+    });
   });
 });

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -1,0 +1,99 @@
+import epgService, { EpgProgram } from '#src/services/epg.service';
+import scheduleFixture from '#src/fixtures/schedule.json';
+import livePlaylistFixture from '#src/fixtures/livePlaylist.json';
+import type { Playlist, PlaylistItem } from '#types/playlist';
+
+const livePlaylist = livePlaylistFixture as Playlist;
+const scheduleData = scheduleFixture as EpgProgram[];
+
+describe('epgService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('getSchedule fetches and validates a valid schedule', async () => {
+    const spy = vitest.spyOn(epgService, 'fetchSchedule').mockImplementation(() => Promise.resolve(scheduleData));
+    const schedule = await epgService.getSchedule(livePlaylist.playlist[0]);
+
+    expect(spy).toBeCalled();
+    expect(schedule.title).toEqual('Channel 1');
+    expect(schedule.programs.length).toEqual(10);
+  });
+
+  test('parseSchedule should remove programs where required fields are missing', async () => {
+    // missing title
+    const schedule1 = await epgService.parseSchedule([
+      {
+        startsAt: '2022-07-19T09:00:00Z',
+        endsAt: '2022-07-19T12:00:00Z',
+      },
+    ]);
+    // missing startsAt
+    const schedule2 = await epgService.parseSchedule([
+      {
+        title: 'The title',
+        endsAt: '2022-07-19T12:00:00Z',
+      },
+    ]);
+    // missing endsAt
+    const schedule3 = await epgService.parseSchedule([
+      {
+        title: 'The title',
+        startsAt: '2022-07-19T09:00:00Z',
+      },
+    ]);
+
+    expect(schedule1.length).toEqual(0);
+    expect(schedule2.length).toEqual(0);
+    expect(schedule3.length).toEqual(0);
+  });
+
+  test('parseSchedule should remove programs where the startsAt or endsAt are not valid ISO8601', async () => {
+    // invalid startsAt
+    const schedule1 = await epgService.parseSchedule([
+      {
+        title: 'Test item',
+        startsAt: 'this is not ISO8601',
+        endsAt: '2022-07-19T12:00:00Z',
+      },
+    ]);
+    // invalid endsAt
+    const schedule2 = await epgService.parseSchedule([
+      {
+        title: 'The title',
+        startsAt: '2022-07-19T09:00:00Z',
+        endsAt: 'this is not ISO8601',
+      },
+    ]);
+
+    expect(schedule1.length).toEqual(0);
+    expect(schedule2.length).toEqual(0);
+  });
+
+  test('getSchedules fetches and validates multiple schedules', async () => {
+    const spy = vitest.spyOn(epgService, 'fetchSchedule').mockImplementation((item: PlaylistItem) => {
+      if (item.title === 'Channel 1') return Promise.resolve(scheduleData);
+      if (item.title === 'Channel 2') return Promise.resolve([]);
+      return Promise.reject(new Error('Something went wrong'));
+    });
+
+    // getSchedules for multiple playlist items
+    const schedules = await epgService.getSchedules(livePlaylist.playlist);
+
+    // make sure we are testing a playlist with three media items
+    expect(livePlaylistFixture.playlist.length).toBe(3);
+    expect(spy).toBeCalledTimes(3);
+
+    // valid schedule with 10 programs
+    expect(schedules[0].title).toEqual('Channel 1');
+    expect(schedules[0].programs.length).toEqual(10);
+
+    // empty schedule
+    expect(schedules[1].title).toEqual('Channel 2');
+    expect(schedules[1].programs.length).toEqual(0);
+
+    // failed fetching the schedule request
+    expect(schedules[2].title).toEqual('Channel 3');
+    expect(schedules[2].programs.length).toEqual(0);
+  });
+});

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -5,7 +5,6 @@ import epgService, { EpgProgram } from '#src/services/epg.service';
 import scheduleFixture from '#src/fixtures/schedule.json';
 import livePlaylistFixture from '#src/fixtures/livePlaylist.json';
 import type { Playlist } from '#types/playlist';
-import { addDays, endOfDay, startOfDay, subDays } from '#src/utils/datetime';
 
 const livePlaylist = livePlaylistFixture as Playlist;
 const scheduleData = scheduleFixture as EpgProgram[];
@@ -13,10 +12,12 @@ const scheduleData = scheduleFixture as EpgProgram[];
 describe('epgService', () => {
   beforeEach(() => {
     mockFetch.clearAll();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   test('fetchSchedule performs a request', async () => {
@@ -60,6 +61,9 @@ describe('epgService', () => {
     const channel3Mock = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
     const channel4Mock = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
 
+    // mock the date
+    vi.setSystemTime(new Date(2022, 1, 1, 14, 30, 10, 500));
+
     const schedule2 = await epgService.getSchedule(livePlaylist.playlist[1]);
     const schedule3 = await epgService.getSchedule(livePlaylist.playlist[2]);
     const schedule4 = await epgService.getSchedule(livePlaylist.playlist[3]);
@@ -71,8 +75,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
@@ -83,8 +87,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
@@ -95,8 +99,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
   });

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -24,22 +24,22 @@ describe('epgService', () => {
     // missing title
     const schedule1 = await epgService.parseSchedule([
       {
-        startsAt: '2022-07-19T09:00:00Z',
-        endsAt: '2022-07-19T12:00:00Z',
+        startTime: '2022-07-19T09:00:00Z',
+        endTime: '2022-07-19T12:00:00Z',
       },
     ]);
-    // missing startsAt
+    // missing startTime
     const schedule2 = await epgService.parseSchedule([
       {
         title: 'The title',
-        endsAt: '2022-07-19T12:00:00Z',
+        endTime: '2022-07-19T12:00:00Z',
       },
     ]);
-    // missing endsAt
+    // missing endTime
     const schedule3 = await epgService.parseSchedule([
       {
         title: 'The title',
-        startsAt: '2022-07-19T09:00:00Z',
+        startTime: '2022-07-19T09:00:00Z',
       },
     ]);
 
@@ -48,21 +48,21 @@ describe('epgService', () => {
     expect(schedule3.length).toEqual(0);
   });
 
-  test('parseSchedule should remove programs where the startsAt or endsAt are not valid ISO8601', async () => {
-    // invalid startsAt
+  test('parseSchedule should remove programs where the startTime or endTime are not valid ISO8601', async () => {
+    // invalid startTime
     const schedule1 = await epgService.parseSchedule([
       {
         title: 'Test item',
-        startsAt: 'this is not ISO8601',
-        endsAt: '2022-07-19T12:00:00Z',
+        startTime: 'this is not ISO8601',
+        endTime: '2022-07-19T12:00:00Z',
       },
     ]);
-    // invalid endsAt
+    // invalid endTime
     const schedule2 = await epgService.parseSchedule([
       {
         title: 'The title',
-        startsAt: '2022-07-19T09:00:00Z',
-        endsAt: 'this is not ISO8601',
+        startTime: '2022-07-19T09:00:00Z',
+        endTime: 'this is not ISO8601',
       },
     ]);
 

--- a/src/services/epg.service.ts
+++ b/src/services/epg.service.ts
@@ -5,7 +5,14 @@ import { getDataOrThrow } from '#src/utils/api';
 import { isValidDateString } from '#src/utils/datetime';
 import { logDev } from '#src/utils/common';
 
-export const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
+export const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => {
+  if (input.status === 'fulfilled') {
+    return true;
+  }
+
+  logDev(`An error occurred resolving a promise: `, input.reason);
+  return false;
+};
 
 export type EpgChannel = {
   title: string;

--- a/src/services/epg.service.ts
+++ b/src/services/epg.service.ts
@@ -1,0 +1,114 @@
+import { array, object, string } from 'yup';
+
+import type { PlaylistItem } from '#types/playlist';
+import { getDataOrThrow } from '#src/utils/api';
+import { isValidDateString } from '#src/utils/datetime';
+import { logDev } from '#src/utils/common';
+
+export const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
+
+export type EpgChannel = {
+  title: string;
+  image: string;
+  programs: EpgProgram[];
+};
+
+export type EpgProgram = {
+  id: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  description?: string;
+  image?: string;
+};
+
+const epgProgramSchema = object().shape({
+  id: string().required(),
+  title: string().required(),
+  startTime: string()
+    .required()
+    .test((value) => (value ? isValidDateString(value) : false)),
+  endTime: string()
+    .required()
+    .test((value) => (value ? isValidDateString(value) : false)),
+  chapterPointCustomProperties: array().of(
+    object().shape({
+      key: string().required(),
+      value: string().required(),
+    }),
+  ),
+});
+
+class EpgService {
+  async transformProgram(data: unknown) {
+    const incomingProgram = await epgProgramSchema.validate(data);
+    const transformed: EpgProgram = {
+      id: incomingProgram.id,
+      title: incomingProgram.title,
+      startTime: incomingProgram.startTime,
+      endTime: incomingProgram.endTime,
+    };
+
+    const customProperties = incomingProgram.chapterPointCustomProperties;
+
+    // map customProperties
+    if (customProperties) {
+      transformed.image = customProperties.find((item) => item.key === 'image')?.value || '';
+      transformed.description = customProperties.find((item) => item.key === 'description')?.value || '';
+    }
+
+    return transformed;
+  }
+
+  /**
+   * Ensure the given data validates to the EpgProgram schema
+   */
+  async parseSchedule(data: unknown) {
+    if (!Array.isArray(data)) return [];
+
+    const transformResults = await Promise.allSettled(data.map((program) => this.transformProgram(program)));
+
+    return transformResults.filter(isFulfilled).map((result) => result.value);
+  }
+
+  /**
+   * Fetch the schedule data for the given PlaylistItem
+   */
+  async fetchSchedule(item: PlaylistItem) {
+    if (!item.scheduleUrl) return [];
+
+    const response = await fetch(item.scheduleUrl);
+
+    return getDataOrThrow(response);
+  }
+
+  /**
+   * Fetch and parse the EPG schedule for the given PlaylistItem.
+   * When there is no program (empty schedule) or the request fails, it returns a static program.
+   */
+  async getSchedule(item: PlaylistItem) {
+    let programs: EpgProgram[] = [];
+
+    try {
+      const schedule = await this.fetchSchedule(item);
+      programs = await this.parseSchedule(schedule);
+    } catch (error: unknown) {
+      logDev(error);
+    }
+
+    return {
+      title: item.title,
+      programs,
+    } as EpgChannel;
+  }
+
+  /**
+   * Get all schedules for the given PlaylistItem's
+   */
+  async getSchedules(items: PlaylistItem[]) {
+    return Promise.all(items.map((item) => this.getSchedule(item)));
+  }
+}
+
+// TODO: currently exported as singleton, the initialisation should be moved to a Service registry when this is added
+export default new EpgService();

--- a/src/services/epg.service.ts
+++ b/src/services/epg.service.ts
@@ -5,6 +5,8 @@ import { getDataOrThrow } from '#src/utils/api';
 import { isValidDateString } from '#src/utils/datetime';
 import { logDev } from '#src/utils/common';
 
+const AUTHENTICATION_HEADER = 'API-KEY';
+
 export const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => {
   if (input.status === 'fulfilled') {
     return true;
@@ -77,8 +79,17 @@ class EpgService {
   async fetchSchedule(item: PlaylistItem) {
     if (!item.scheduleUrl) return undefined;
 
+    const headers = new Headers();
+
+    // add authentication token when `scheduleToken` is defined
+    if (item.scheduleToken) {
+      headers.set(AUTHENTICATION_HEADER, item.scheduleToken);
+    }
+
     try {
-      const response = await fetch(item.scheduleUrl);
+      const response = await fetch(item.scheduleUrl, {
+        headers,
+      });
 
       // await needed to ensure the error is caught here
       return await getDataOrThrow(response);

--- a/src/stores/FavoritesController.ts
+++ b/src/stores/FavoritesController.ts
@@ -82,7 +82,7 @@ export const toggleFavorite = (item: PlaylistItem | undefined) => {
 
   // If we exceed the max available number of favorites, we show a warning
   if (favorites?.length >= MAX_WATCHLIST_ITEMS_COUNT) {
-    setWarning(i18n.t('video:favorites_warning', { count: MAX_WATCHLIST_ITEMS_COUNT }));
+    setWarning(i18n.t('video:favorites_warning', { maxCount: MAX_WATCHLIST_ITEMS_COUNT }));
     return;
   }
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -51,9 +51,10 @@ export function calculateContrastColor(color: string) {
 }
 
 export const IS_DEV_BUILD = import.meta.env.DEV;
+export const IS_TEST_BUILD = import.meta.env.MODE === 'test';
 
 export function logDev(message: unknown, ...optionalParams: unknown[]) {
-  if (IS_DEV_BUILD) {
+  if (IS_DEV_BUILD && !IS_TEST_BUILD) {
     console.info(message, optionalParams);
   }
 }

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,4 +1,11 @@
 /**
+ * Returns true when the given string is a valid date string
+ */
+export function isValidDateString(input: string) {
+  return input ? new Date(input).toString() !== 'Invalid Date' : false;
+}
+
+/**
  * Seconds to ISO8601 duration or date string
  */
 export function secondsToISO8601(input: number, timeOnly: boolean = false): string {
@@ -22,3 +29,23 @@ export function secondsToISO8601(input: number, timeOnly: boolean = false): stri
 
   return isoString;
 }
+
+/**
+ * Returns a Date instance with the time set to the beginning of the day
+ */
+export const startOfDay = () => {
+  const date = new Date();
+  date.setHours(0, 0, 0);
+
+  return date;
+};
+
+/**
+ * Returns a Date instance with the time set to the end of the day
+ */
+export const endOfDay = () => {
+  const date = new Date();
+  date.setHours(23, 59, 59);
+
+  return date;
+};

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -35,7 +35,7 @@ export function secondsToISO8601(input: number, timeOnly: boolean = false): stri
  */
 export const startOfDay = () => {
   const date = new Date();
-  date.setHours(0, 0, 0);
+  date.setHours(0, 0, 0, 0);
 
   return date;
 };
@@ -45,7 +45,25 @@ export const startOfDay = () => {
  */
 export const endOfDay = () => {
   const date = new Date();
-  date.setHours(23, 59, 59);
+  date.setHours(23, 59, 59, 999);
+
+  return date;
+};
+
+/**
+ * Add X days to the given date
+ */
+export const addDays = (date: Date, days: number) => {
+  date.setDate(date.getDate() + days);
+
+  return date;
+};
+
+/**
+ * Subtract X days from the given date
+ */
+export const subDays = (date: Date, days: number) => {
+  date.setDate(date.getDate() - days);
 
   return date;
 };

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import 'react-app-polyfill/stable';
 import '@testing-library/jest-dom'; // Including this for the expect extensions
+import 'vi-fetch/setup';
 
 vi.stubGlobal(
   'matchMedia',

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -41,7 +41,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('#src/i18n/config', () => ({
-  default: () => ({
+  default: {
     t: (str: string) => str,
-  }),
+  },
 }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
     // Fallthrough must be documented
     "noFallthroughCasesInSwitch": true,
     "types": [
+      "vi-fetch/matchers",
       "vitest/globals",
       "@testing-library/jest-dom",
       "@types/jwplayer"

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -1,3 +1,5 @@
+import type { MediaOffer } from '#types/media';
+
 export type GetPlaylistParams = { page_limit?: string; related_media_id?: string; token?: string; search?: string };
 
 export type Image = {
@@ -24,10 +26,10 @@ export type PlaylistItem = {
   image: string;
   images: Image[];
   link: string;
-  genre: string;
+  genre?: string;
   mediaid: string;
   pubdate: number;
-  rating: string;
+  rating?: string;
   requiresSubscription?: string | null;
   sources: Source[];
   seriesId?: string;
@@ -36,11 +38,14 @@ export type PlaylistItem = {
   tags?: string;
   trailerId?: string;
   title: string;
-  tracks: Track[];
+  tracks?: Track[];
   variations?: Record<string, unknown>;
   free?: string;
   productIds?: string;
   mediaOffers?: MediaOffer[] | null;
+  scheduleUrl?: string | null;
+  scheduleDataFormat?: string;
+  scheduleDemo?: string;
 };
 
 export type Link = {

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -44,6 +44,7 @@ export type PlaylistItem = {
   productIds?: string;
   mediaOffers?: MediaOffer[] | null;
   scheduleUrl?: string | null;
+  scheduleToken?: string;
   scheduleDataFormat?: string;
   scheduleDemo?: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4212,6 +4212,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
+
 find-cache-dir@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
@@ -7297,6 +7302,16 @@ query-ast@^1.0.3:
   dependencies:
     invariant "2.2.4"
 
+query-string@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -8200,6 +8215,11 @@ speedline-core@^1.4.3:
     image-ssim "^0.2.0"
     jpeg-js "^0.4.1"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split2@^3.0.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
@@ -8233,6 +8253,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -8667,6 +8692,11 @@ tinyspy@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.2.tgz#2f95cb14c38089ca690385f339781cd35faae566"
   integrity sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==
 
+tinyspy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.0.tgz#0cb34587287b0432b33fe36a9bd945fe22b1eb89"
+  integrity sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9090,6 +9120,14 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vi-fetch@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/vi-fetch/-/vi-fetch-0.8.0.tgz#45170a3d9e2ecb2a775b128356f8faae671b5a66"
+  integrity sha512-uvEgEBTacSnlxRcoA56Drwkc2LbTvRNOdSx5MVayBfEsHAgQJAu+LwePlUOkidFsqQMcQxcb+LlC9qZ9v1yXiw==
+  dependencies:
+    query-string "^7.1.1"
+    tinyspy "^1.0.0"
 
 vinyl-fs@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
## Description

This is the first part of the EpgService with unit tests. It accepts media items as input and fetches all EPG schedules when defined.

The external data schema looks like (not needed to be defined in typings):

```ts
type ChapterPointCustomProperty = {
  key: string;
  value: string;
};

type IncomingEpgProgram = {
  id: string;
  title: string;
  startTime: string;
  endTime: string;
  chapterPointCustomProperties: ChapterPointCustomProperty[];
};
```

The above data is validated and transformed to the following schema:

```ts
type EpgProgram = {
  id: string;
  title: string;
  startTime: string;
  endTime: string;
  description?: string;
  image?: string;
};
```

There will be changes here when starting working on other features.