### PR TITLE
Feat / fill schedule with static program when empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-watch": "TZ=UTC vitest",
     "test-coverage": "TZ=UTC vitest run --coverage",
     "test-commit": "TZ=UTC vitest run --changed HEAD~1 --coverage",
-    "i18next": "i18next src/{components,containers,screens}/**/{**/,/}*.tsx && node ./scripts/i18next/generate.js",
+    "i18next": "i18next src/{components,containers,screens,services,stores}/**/{**/,/}*.{ts,tsx} && node ./scripts/i18next/generate.js",
     "format": "run-s -c format:*",
     "format:eslint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\" --fix",
     "format:prettier": "prettier --write \"{**/*,*}.{js,ts,jsx,tsx}\"",

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -163,6 +163,58 @@
       ],
       "variations": {},
       "requiresSubscription": "false"
+    },
+    {
+      "title": "Channel 4",
+      "mediaid": "SDF23CJ",
+      "link": "https://content.jwplatform.com/previews/SDF23CJ",
+      "image": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=720",
+      "images": [
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=320",
+          "width": 320,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=480",
+          "width": 480,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=640",
+          "width": 640,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=720",
+          "width": 720,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=1280",
+          "width": 1280,
+          "type": "image/jpeg"
+        },
+        {
+          "src": "https://content.jwplatform.com/v2/media/SDF23CJ/poster.jpg?width=1920",
+          "width": 1920,
+          "type": "image/jpeg"
+        }
+      ],
+      "feedid": "JSKF03bk",
+      "duration": 0,
+      "pubdate": 1615480440,
+      "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
+      "tags": "live",
+      "scheduleUrl": "/epg/network-error.json",
+      "sources": [
+        {
+          "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",
+          "type": "application/vnd.apple.mpegurl"
+        }
+      ],
+      "variations": {},
+      "requiresSubscription": "false"
     }
   ],
   "feed_instance_id": "5f7f7d06-4f9e-4408-8baa-ff8cc469611a"

--- a/src/i18n/locales/en_US.ts
+++ b/src/i18n/locales/en_US.ts
@@ -3,6 +3,7 @@
 
 export { default as account } from './en_US/account.json';
 export { default as common } from './en_US/common.json';
+export { default as epg } from './en_US/epg.json';
 export { default as error } from './en_US/error.json';
 export { default as menu } from './en_US/menu.json';
 export { default as search } from './en_US/search.json';

--- a/src/i18n/locales/en_US/common.json
+++ b/src/i18n/locales/en_US/common.json
@@ -1,4 +1,8 @@
 {
+  "alert": {
+    "close": "Close",
+    "title": "An error occurred"
+  },
   "back": "Back",
   "card_lock": "Item locked",
   "close_modal": "Close",
@@ -6,10 +10,7 @@
     "close": "Cancel",
     "confirm": "Yes"
   },
-  "alert": {
-    "title": "An error occurred",
-    "close": "Close"
-  },
+  "default_site_name": "My OTT Application",
   "filter_videos_by_genre": "Filter videos by genre",
   "home": "Home",
   "live": "LIVE",
@@ -18,6 +19,5 @@
   "sign_in": "Sign in",
   "sign_up": "Sign up",
   "slide_left": "Slide left",
-  "slide_right": "Slide right",
-  "default_site_name": "My OTT Application"
+  "slide_right": "Slide right"
 }

--- a/src/i18n/locales/en_US/epg.json
+++ b/src/i18n/locales/en_US/epg.json
@@ -1,0 +1,10 @@
+{
+  "empty_schedule_program": {
+    "description": "No program information available",
+    "title": "No program information"
+  },
+  "failed_schedule_program": {
+    "description": "The program information failed to load",
+    "title": "Failed to load schedule"
+  }
+}

--- a/src/i18n/locales/en_US/video.json
+++ b/src/i18n/locales/en_US/video.json
@@ -9,17 +9,17 @@
   "episode_not_found": "Episode not found",
   "episodes": "Episodes",
   "favorite": "Favorite",
+  "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{maxCount}} favorite videos. Please delete one and repeat the operation.",
   "remove_from_favorites": "Remove from favorites",
   "season_prefix": "Season ",
   "series_error": "An error occurred while requesting series",
   "share": "Share",
   "sign_up_to_start_watching": "Sign up to start watching!",
   "start_watching": "Start watching",
-  "total_episodes": "{{ count }} episode",
-  "total_episodes_plural": "{{ count }} episodes",
+  "total_episodes": "{{count}} episode",
+  "total_episodes_plural": "{{count}} episodes",
   "trailer": "Trailer",
   "video_not_found": "Video not found",
   "watch_trailer": "Watch the trailer",
-  "share_video": "Share this video",
-  "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{ count }} favorite videos. Please delete one and repeat the operation."
+  "share_video": "Share this video"
 }

--- a/src/i18n/locales/nl_NL.ts
+++ b/src/i18n/locales/nl_NL.ts
@@ -3,6 +3,7 @@
 
 export { default as account } from './nl_NL/account.json';
 export { default as common } from './nl_NL/common.json';
+export { default as epg } from './nl_NL/epg.json';
 export { default as error } from './nl_NL/error.json';
 export { default as menu } from './nl_NL/menu.json';
 export { default as search } from './nl_NL/search.json';

--- a/src/i18n/locales/nl_NL/common.json
+++ b/src/i18n/locales/nl_NL/common.json
@@ -1,4 +1,8 @@
 {
+  "alert": {
+    "close": "",
+    "title": ""
+  },
   "back": "",
   "card_lock": "",
   "close_modal": "",
@@ -6,10 +10,7 @@
     "close": "",
     "confirm": ""
   },
-  "alert": {
-    "title": "",
-    "close": ""
-  },
+  "default_site_name": "",
   "filter_videos_by_genre": "",
   "home": "",
   "live": "",
@@ -18,6 +19,5 @@
   "sign_in": "",
   "sign_up": "",
   "slide_left": "",
-  "slide_right": "",
-  "default_site_name": ""
+  "slide_right": ""
 }

--- a/src/i18n/locales/nl_NL/epg.json
+++ b/src/i18n/locales/nl_NL/epg.json
@@ -1,0 +1,10 @@
+{
+  "empty_schedule_program": {
+    "description": "",
+    "title": ""
+  },
+  "failed_schedule_program": {
+    "description": "",
+    "title": ""
+  }
+}

--- a/src/i18n/locales/nl_NL/video.json
+++ b/src/i18n/locales/nl_NL/video.json
@@ -9,6 +9,7 @@
   "episode_not_found": "",
   "episodes": "",
   "favorite": "",
+  "favorites_warning": "",
   "remove_from_favorites": "",
   "season_prefix": "",
   "series_error": "",
@@ -20,6 +21,6 @@
   "trailer": "",
   "video_not_found": "",
   "watch_trailer": "",
-  "share_video": "",
-  "favorites_warning": ""
+  "favorites_warning_plural": "",
+  "share_video": ""
 }

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -1,6 +1,6 @@
-import { string, boolean, array, object, SchemaOf, StringSchema, mixed } from 'yup';
+import { array, boolean, mixed, object, SchemaOf, string, StringSchema } from 'yup';
 
-import type { Config, Content, Menu, Styling, Features, Cleeng } from '#types/Config';
+import type { Cleeng, Config, Content, Features, Menu, Styling } from '#types/Config';
 import { PersonalShelf } from '#src/enum/PersonalShelf';
 import i18n from '#src/i18n/config';
 import { logDev } from '#src/utils/common';
@@ -133,7 +133,7 @@ const enrichConfig = (config: Config): Config => {
   const { content, siteName } = config;
   const updatedContent = content.map((content) => Object.assign({ enableText: true, featured: false }, content));
 
-  return { ...config, siteName: siteName || i18n.t('common.default_site_name'), content: updatedContent };
+  return { ...config, siteName: siteName || i18n.t('common:default_site_name'), content: updatedContent };
 };
 
 export const validateConfig = (config?: Config): Promise<Config> => {

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -57,48 +57,48 @@ describe('epgService', () => {
   });
 
   test('getSchedule adds a static program when the schedule is empty or fails', async () => {
-    const channel2Mock = mockGet('/epg/channel2.json').willResolve([]);
-    const channel3Mock = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
-    const channel4Mock = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
+    const mock1 = mockGet('/epg/channel2.json').willResolve([]);
+    const mock2 = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
+    const mock3 = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
 
     // mock the date
     vi.setSystemTime(new Date(2022, 1, 1, 14, 30, 10, 500));
 
-    const schedule2 = await epgService.getSchedule(livePlaylist.playlist[1]);
-    const schedule3 = await epgService.getSchedule(livePlaylist.playlist[2]);
-    const schedule4 = await epgService.getSchedule(livePlaylist.playlist[3]);
+    const emptySchedule = await epgService.getSchedule(livePlaylist.playlist[1]);
+    const failedSchedule = await epgService.getSchedule(livePlaylist.playlist[2]);
+    const networkErrorSchedule = await epgService.getSchedule(livePlaylist.playlist[3]);
 
-    expect(channel2Mock).toHaveFetched();
-    expect(schedule2.title).toEqual('Channel 2');
-    expect(schedule2.programs.length).toEqual(1);
-    expect(schedule2.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock1).toHaveFetched();
+    expect(emptySchedule.title).toEqual('Channel 2');
+    expect(emptySchedule.programs.length).toEqual(1);
+    expect(emptySchedule.programs[0]).toMatchObject({
+      id: 'no-program-NS2Q213',
+      title: 'epg:empty_schedule_program.title',
+      description: 'epg:empty_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
-    expect(channel3Mock).toHaveFetched();
-    expect(schedule3.title).toEqual('Channel 3');
-    expect(schedule3.programs.length).toEqual(1);
-    expect(schedule3.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock2).toHaveFetched();
+    expect(failedSchedule.title).toEqual('Channel 3');
+    expect(failedSchedule.programs.length).toEqual(1);
+    expect(failedSchedule.programs[0]).toMatchObject({
+      id: 'no-program-JDODS53',
+      title: 'epg:failed_schedule_program.title',
+      description: 'epg:failed_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
-    expect(channel4Mock).toHaveFetched();
-    expect(schedule4.title).toEqual('Channel 4');
-    expect(schedule4.programs.length).toEqual(1);
-    expect(schedule4.programs[0]).toMatchObject({
-      id: 'no-program',
-      title: 'No program',
-      description: 'There is no information available for this program.',
+    expect(mock3).toHaveFetched();
+    expect(networkErrorSchedule.title).toEqual('Channel 4');
+    expect(networkErrorSchedule.programs.length).toEqual(1);
+    expect(networkErrorSchedule.programs[0]).toMatchObject({
+      id: 'no-program-SDF23CJ',
+      title: 'epg:failed_schedule_program.title',
+      description: 'epg:failed_schedule_program.description',
       startTime: '2022-01-31T00:00:00.000Z',
       endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
@@ -130,17 +130,17 @@ describe('epgService', () => {
     // empty schedule (with static program)
     expect(schedules[1].title).toEqual('Channel 2');
     expect(schedules[1].programs.length).toEqual(1);
-    expect(schedules[1].programs[0].title).toEqual('No program');
+    expect(schedules[1].programs[0].title).toEqual('epg:empty_schedule_program.title');
 
     // failed fetching the schedule request (with static program)
     expect(schedules[2].title).toEqual('Channel 3');
     expect(schedules[2].programs.length).toEqual(1);
-    expect(schedules[2].programs[0].title).toEqual('No program');
+    expect(schedules[2].programs[0].title).toEqual('epg:failed_schedule_program.title');
 
     // network error (with static program)
     expect(schedules[3].title).toEqual('Channel 4');
     expect(schedules[3].programs.length).toEqual(1);
-    expect(schedules[3].programs[0].title).toEqual('No program');
+    expect(schedules[3].programs[0].title).toEqual('epg:failed_schedule_program.title');
   });
 
   test('parseSchedule should remove programs where required fields are missing', async () => {

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -5,7 +5,6 @@ import epgService, { EpgProgram } from '#src/services/epg.service';
 import scheduleFixture from '#src/fixtures/schedule.json';
 import livePlaylistFixture from '#src/fixtures/livePlaylist.json';
 import type { Playlist } from '#types/playlist';
-import { addDays, endOfDay, startOfDay, subDays } from '#src/utils/datetime';
 
 const livePlaylist = livePlaylistFixture as Playlist;
 const scheduleData = scheduleFixture as EpgProgram[];
@@ -13,10 +12,12 @@ const scheduleData = scheduleFixture as EpgProgram[];
 describe('epgService', () => {
   beforeEach(() => {
     mockFetch.clearAll();
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   test('fetchSchedule performs a request', async () => {
@@ -60,6 +61,9 @@ describe('epgService', () => {
     const channel3Mock = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
     const channel4Mock = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
 
+    // mock the date
+    vi.setSystemTime(new Date(2022, 1, 1, 14, 30, 10, 500));
+
     const schedule2 = await epgService.getSchedule(livePlaylist.playlist[1]);
     const schedule3 = await epgService.getSchedule(livePlaylist.playlist[2]);
     const schedule4 = await epgService.getSchedule(livePlaylist.playlist[3]);
@@ -71,8 +75,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
@@ -83,8 +87,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
 
@@ -95,8 +99,8 @@ describe('epgService', () => {
       id: 'no-program',
       title: 'No program',
       description: 'There is no information available for this program.',
-      startTime: subDays(startOfDay(), 1).toJSON(),
-      endTime: addDays(endOfDay(), 1).toJSON(),
+      startTime: '2022-01-31T00:00:00.000Z',
+      endTime: '2022-02-02T23:59:59.999Z',
       image: undefined,
     });
   });

--- a/src/stores/FavoritesController.ts
+++ b/src/stores/FavoritesController.ts
@@ -82,7 +82,7 @@ export const toggleFavorite = (item: PlaylistItem | undefined) => {
 
   // If we exceed the max available number of favorites, we show a warning
   if (favorites?.length >= MAX_WATCHLIST_ITEMS_COUNT) {
-    setWarning(i18n.t('video:favorites_warning', { count: MAX_WATCHLIST_ITEMS_COUNT }));
+    setWarning(i18n.t('video:favorites_warning', { maxCount: MAX_WATCHLIST_ITEMS_COUNT }));
     return;
   }
 

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -35,7 +35,7 @@ export function secondsToISO8601(input: number, timeOnly: boolean = false): stri
  */
 export const startOfDay = () => {
   const date = new Date();
-  date.setHours(0, 0, 0);
+  date.setHours(0, 0, 0, 0);
 
   return date;
 };
@@ -45,7 +45,25 @@ export const startOfDay = () => {
  */
 export const endOfDay = () => {
   const date = new Date();
-  date.setHours(23, 59, 59);
+  date.setHours(23, 59, 59, 999);
+
+  return date;
+};
+
+/**
+ * Add X days to the given date
+ */
+export const addDays = (date: Date, days: number) => {
+  date.setDate(date.getDate() + days);
+
+  return date;
+};
+
+/**
+ * Subtract X days from the given date
+ */
+export const subDays = (date: Date, days: number) => {
+  date.setDate(date.getDate() - days);
 
   return date;
 };

--- a/test/vitest.setup.ts
+++ b/test/vitest.setup.ts
@@ -41,7 +41,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('#src/i18n/config', () => ({
-  default: () => ({
+  default: {
     t: (str: string) => str,
-  }),
+  },
 }));


### PR DESCRIPTION
## Description

This PR adds a static program in one of the following scenarios:

When the schedule is empty it creates a static program with the title: "No program information"
When the schedule request fails it creates a static program with the title: "Failed to load schedule"

I've also fixed an issue in the translation mocking and a few minor changes after I ran `$ yarn i18next` which scans for translation keys.