### PR TITLE
Feat / add schedule demo mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "allure-commandline": "^2.17.2",
     "classnames": "^2.3.1",
+    "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",
     "history": "^4.10.1",
     "i18next": "^20.3.1",

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -105,6 +105,28 @@ describe('epgService', () => {
     });
   });
 
+  test('getSchedule enabled demo mode when scheduleDemo is set', async () => {
+    const mock = mockGet('/epg/channel1.json').willResolve(scheduleData);
+
+    // mock the date
+    vi.setSystemTime(new Date(2036, 5, 3, 14, 30, 10, 500));
+
+    const item = Object.assign({}, livePlaylist.playlist[0]);
+    item.scheduleDemo = '1';
+
+    const schedule = await epgService.getSchedule(item);
+
+    expect(mock).toHaveFetched();
+    expect(schedule.title).toEqual('Channel 1');
+    // first program
+    expect(schedule.programs[0].startTime).toEqual('2036-06-03T23:50:00.000Z');
+    expect(schedule.programs[0].endTime).toEqual('2036-06-04T00:55:00.000Z');
+
+    // last program
+    expect(schedule.programs[13].startTime).toEqual('2036-06-04T07:00:00.000Z');
+    expect(schedule.programs[13].endTime).toEqual('2036-06-04T07:40:00.000Z');
+  });
+
   test('getSchedules fetches and validates multiple schedules', async () => {
     const channel1Mock = mockGet('/epg/channel1.json').willResolve(scheduleData);
     const channel2Mock = mockGet('/epg/channel2.json').willResolve([]);
@@ -147,6 +169,7 @@ describe('epgService', () => {
     // missing title
     const schedule1 = await epgService.parseSchedule([
       {
+        id: '1234-1234-1234-1234-1234',
         startTime: '2022-07-19T09:00:00Z',
         endTime: '2022-07-19T12:00:00Z',
       },
@@ -154,6 +177,7 @@ describe('epgService', () => {
     // missing startTime
     const schedule2 = await epgService.parseSchedule([
       {
+        id: '1234-1234-1234-1234-1234',
         title: 'The title',
         endTime: '2022-07-19T12:00:00Z',
       },
@@ -161,20 +185,31 @@ describe('epgService', () => {
     // missing endTime
     const schedule3 = await epgService.parseSchedule([
       {
+        id: '1234-1234-1234-1234-1234',
         title: 'The title',
         startTime: '2022-07-19T09:00:00Z',
+      },
+    ]);
+    // missing id
+    const schedule4 = await epgService.parseSchedule([
+      {
+        title: 'The title',
+        startTime: '2022-07-19T09:00:00Z',
+        endTime: '2022-07-19T12:00:00Z',
       },
     ]);
 
     expect(schedule1.length).toEqual(0);
     expect(schedule2.length).toEqual(0);
     expect(schedule3.length).toEqual(0);
+    expect(schedule4.length).toEqual(0);
   });
 
   test('parseSchedule should remove programs where the startTime or endTime are not valid ISO8601', async () => {
     // invalid startTime
     const schedule1 = await epgService.parseSchedule([
       {
+        id: '1234-1234-1234-1234-1234',
         title: 'Test item',
         startTime: 'this is not ISO8601',
         endTime: '2022-07-19T12:00:00Z',
@@ -183,6 +218,7 @@ describe('epgService', () => {
     // invalid endTime
     const schedule2 = await epgService.parseSchedule([
       {
+        id: '1234-1234-1234-1234-1234',
         title: 'The title',
         startTime: '2022-07-19T09:00:00Z',
         endTime: 'this is not ISO8601',
@@ -193,7 +229,56 @@ describe('epgService', () => {
     expect(schedule2.length).toEqual(0);
   });
 
-  test('parseSchedule should transform valid program entries', async () => {
+  test('parseSchedule should update the start and end time when demo is enabled', async () => {
+    // some date in the far future
+    vi.setSystemTime(new Date(2036, 5, 3, 14, 30, 10, 500));
+
+    const schedule = await epgService.parseSchedule(
+      [
+        {
+          id: '1234-1234-1234-1234-1234',
+          title: 'Test item 1',
+          startTime: '2022-07-19T12:00:00Z',
+          endTime: '2022-07-19T17:00:00Z',
+        },
+        {
+          id: '1234-1234-1234-1234-1234',
+          title: 'Test item 2',
+          startTime: '2022-07-19T17:00:00Z',
+          endTime: '2022-07-19T23:00:00Z',
+        },
+        {
+          id: '1234-1234-1234-1234-1234',
+          title: 'Test item 3',
+          startTime: '2022-07-19T23:00:00Z',
+          endTime: '2022-07-20T05:30:00Z',
+        },
+        {
+          id: '1234-1234-1234-1234-1234',
+          title: 'Test item 4',
+          startTime: '2022-07-20T05:30:00Z',
+          endTime: '2022-07-20T12:00:00Z',
+        },
+      ],
+      true,
+    );
+
+    expect(schedule.length).toEqual(4);
+
+    expect(schedule[0].startTime).toEqual('2036-06-03T12:00:00.000Z');
+    expect(schedule[0].endTime).toEqual('2036-06-03T17:00:00.000Z');
+
+    expect(schedule[1].startTime).toEqual('2036-06-03T17:00:00.000Z');
+    expect(schedule[1].endTime).toEqual('2036-06-03T23:00:00.000Z');
+
+    expect(schedule[2].startTime).toEqual('2036-06-03T23:00:00.000Z');
+    expect(schedule[2].endTime).toEqual('2036-06-04T05:30:00.000Z');
+
+    expect(schedule[3].startTime).toEqual('2036-06-04T05:30:00.000Z');
+    expect(schedule[3].endTime).toEqual('2036-06-04T12:00:00.000Z');
+  });
+
+  test('transformProgram should transform valid program entries', async () => {
     const program1 = await epgService.transformProgram({
       id: '1234-1234-1234-1234',
       title: 'Test item',

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,12 +1,6 @@
 /**
- * Returns true when the given string is a valid date string
- */
-export function isValidDateString(input: string) {
-  return input ? new Date(input).toString() !== 'Invalid Date' : false;
-}
-
-/**
  * Seconds to ISO8601 duration or date string
+ * TODO: use date-fns to replace this util
  */
 export function secondsToISO8601(input: number, timeOnly: boolean = false): string {
   if (!input) {
@@ -29,41 +23,3 @@ export function secondsToISO8601(input: number, timeOnly: boolean = false): stri
 
   return isoString;
 }
-
-/**
- * Returns a Date instance with the time set to the beginning of the day
- */
-export const startOfDay = () => {
-  const date = new Date();
-  date.setHours(0, 0, 0, 0);
-
-  return date;
-};
-
-/**
- * Returns a Date instance with the time set to the end of the day
- */
-export const endOfDay = () => {
-  const date = new Date();
-  date.setHours(23, 59, 59, 999);
-
-  return date;
-};
-
-/**
- * Add X days to the given date
- */
-export const addDays = (date: Date, days: number) => {
-  date.setDate(date.getDate() + days);
-
-  return date;
-};
-
-/**
- * Subtract X days from the given date
- */
-export const subDays = (date: Date, days: number) => {
-  date.setDate(date.getDate() - days);
-
-  return date;
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,6 +3224,11 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+date-fns@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
When the live channel media item has the `scheduleDemo` custom property defined, all start and end times will be shifted to todays date.

This is useful when having a static EPG schedule for demo purposes.