### PR TITLE
Feat / update program information

### DIFF
--- a/public/epg/channel4.json
+++ b/public/epg/channel4.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "f6b997d7-497f-4176-afa7-58f1d4bf761c",
+    "title": "Friends",
+    "startTime": "2022-07-14T20:00:00.000Z",
+    "endTime": "2022-07-14T20:30:00.000Z",
+    "chapterPointCustomProperties": [
+      {
+        "key": "description",
+        "value": "Follows the personal and professional lives of six twenty to thirty-something-year-old friends living in Manhattan."
+      },
+      {
+        "key": "image",
+        "value": "https://www.themoviedb.org/t/p/w1066_and_h600_bestv2/l0qVZIpXtIo7km9u5Yqh0nKPOr5.jpg"
+      }
+    ]
+  }
+]

--- a/src/components/Epg/ChannelItem.tsx
+++ b/src/components/Epg/ChannelItem.tsx
@@ -3,13 +3,14 @@ import { Channel, ChannelBox, ChannelLogo } from 'planby';
 
 type Props = {
   channel: Channel;
+  onClick?: (channel: Channel) => void;
 };
 
-const ChannelItem: React.VFC<Props> = ({ channel }) => {
+const ChannelItem: React.VFC<Props> = ({ channel, onClick }) => {
   const { position, logo } = channel;
 
   return (
-    <ChannelBox {...position}>
+    <ChannelBox {...position} onClick={() => onClick && onClick(channel)} style={{ cursor: 'pointer' }}>
       <ChannelLogo src={logo} alt="Logo" />
     </ChannelBox>
   );

--- a/src/components/Tag/Tag.module.scss
+++ b/src/components/Tag/Tag.module.scss
@@ -1,0 +1,37 @@
+@use '../../styles/mixins/responsive';
+@use '../../styles/theme';
+@use '../../styles/variables';
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  color: var(--card-color);
+  font-family: var(--body-font-family);
+  font-weight: 600;
+  white-space: nowrap;
+  background-color: rgba(variables.$black, 0.6);
+  border-radius: 4px;
+
+  &.normal {
+    padding: 4px 8px;
+    font-size: 16px;
+
+    @include responsive.mobile-only {
+      font-size: 14px;
+    }
+  }
+
+  &.large {
+    padding: 9px 16px;
+    font-size: 18px;
+
+    @include responsive.mobile-only {
+      padding: 4px 8px;
+      font-size: 16px;
+    }
+  }
+}
+
+.live {
+  background-color: variables.$red;
+}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './Tag.module.scss';
+
+type Props = {
+  className?: string;
+  isLive?: boolean;
+  size?: 'normal' | 'large';
+};
+
+const Tag: React.FC<Props> = ({ children, className, isLive = false, size = 'normal' }) => {
+  return (
+    <div
+      className={classNames(className, styles.tag, styles[size], {
+        [styles.live]: isLive,
+      })}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Tag;

--- a/src/components/VideoDetails/VideoDetails.module.scss
+++ b/src/components/VideoDetails/VideoDetails.module.scss
@@ -43,6 +43,7 @@
 .info {
   width: 70%;
   max-width: 650px;
+  min-height: 300px;
 
   @include responsive.tablet-only() {
     width: 350px;
@@ -58,6 +59,7 @@
 
 .title {
   @include typography.video-title-base;
+  margin-bottom: calc(variables.$base-spacing / 2);
 }
 
 .metaContainer {

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,3 +11,6 @@ export const MAX_WATCHLIST_ITEMS_COUNT = 48;
 export const ADYEN_TEST_CLIENT_KEY = 'test_I4OFGUUCEVB5TI222AS3N2Y2LY6PJM3K';
 
 export const ADYEN_LIVE_CLIENT_KEY = 'live_BQDOFBYTGZB3XKF62GBYSLPUJ4YW2TPL';
+
+// how often the live channel schedule is refetched in ms
+export const LIVE_CHANNELS_REFETCH_INTERVAL = 15_000 * 60;

--- a/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.module.scss
+++ b/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.module.scss
@@ -1,3 +1,4 @@
+@use '../../styles/variables';
 @use '../../styles/mixins/responsive';
 
 .catchupButton {
@@ -5,4 +6,8 @@
     flex: 2 !important;
     white-space: nowrap;
   }
+}
+
+.tag {
+  margin-right: calc(variables.$base-spacing / 2);
 }

--- a/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -153,7 +153,7 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
                 {...rest}
               />
             )}
-            renderChannel={({ channel }) => <ChannelItem key={channel.uuid} channel={channel} />}
+            renderChannel={({ channel }) => <ChannelItem key={channel.uuid} channel={channel} onClick={(channel) => setActiveChannel(channel.uuid)} />}
           />
         </Epg>
       </VideoDetails>

--- a/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -4,6 +4,7 @@ import shallow from 'zustand/shallow';
 import { Epg, Layout } from 'planby';
 import { useHistory, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
+import { differenceInSeconds, format } from 'date-fns';
 
 import styles from './PlaylistLiveChannels.module.scss';
 
@@ -21,10 +22,11 @@ import StartWatchingButton from '#src/containers/StartWatchingButton/StartWatchi
 import usePlanByEpg from '#src/hooks/usePlanByEpg';
 import Cinema from '#src/containers/Cinema/Cinema';
 import useEntitlement from '#src/hooks/useEntitlement';
-import { addQueryParams } from '#src/utils/formatting';
+import { addQueryParams, formatDurationTag } from '#src/utils/formatting';
 import Button from '#src/components/Button/Button';
 import Play from '#src/icons/Play';
 import useLiveProgram from '#src/hooks/useLiveProgram';
+import Tag from '#src/components/Tag/Tag';
 
 function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playlist: Playlist }) {
   const { t } = useTranslation('epg');
@@ -57,6 +59,52 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
   const channelMediaItem = useMemo(() => playlist.find(({ mediaid }) => channel?.id === mediaid), [channel?.id, playlist]);
   const { isEntitled } = useEntitlement(channelMediaItem);
 
+  const videoDetails = useMemo(() => {
+    if (program) {
+      return {
+        title: program.title,
+        description: program.description || '',
+        poster: program.image,
+        canWatch: isLive || (isVod && isWatchableFromBeginning),
+        canWatchFromBeginning: isEntitled && isLive && isWatchableFromBeginning,
+      };
+    }
+
+    return {
+      title: channel?.title || '',
+      description: channel?.description || '',
+      poster: channel?.image,
+      canWatch: true,
+      canWatchFromBeginning: false,
+    };
+  }, [channel, isEntitled, isLive, isVod, isWatchableFromBeginning, program]);
+
+  const primaryMetadata = useMemo(() => {
+    if (!channel) {
+      return '';
+    }
+
+    if (!program) {
+      return <Tag isLive>{t('common:live')}</Tag>;
+    }
+
+    const startTime = new Date(program.startTime);
+    const endTime = new Date(program.endTime);
+    const durationInSeconds = differenceInSeconds(endTime, startTime);
+    const duration = formatDurationTag(durationInSeconds);
+
+    return (
+      <>
+        <Tag className={styles.tag} isLive={isLive}>
+          {isLive ? t('common:live') : `${format(startTime, 'p')} - ${format(endTime, 'p')}`}
+        </Tag>
+        {t('on_channel', { name: channel.title })}
+        {' • '}
+        {duration}
+      </>
+    );
+  }, [channel, isLive, program, t]);
+
   // Effects
   useEffect(() => {
     const toImage = program?.image || channelMediaItem?.image;
@@ -69,12 +117,6 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
   }
 
   const pageTitle = `${title} - ${siteName}`;
-  const programTitle = program?.title || t('empty_schedule_program.title') || '';
-  const programDescription = program?.description || t('empty_schedule_program.description') || '';
-  const primaryMetadata = t('on_channel', { name: channel.title });
-
-  const canWatch = isLive || (isVod && isWatchableFromBeginning);
-  const canWatchFromBeginning = isEntitled && isLive && isWatchableFromBeginning;
 
   return (
     <>
@@ -88,7 +130,7 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
           open={play && isEntitled}
           onClose={goBack}
           item={channelMediaItem}
-          title={programTitle}
+          title={videoDetails.title}
           primaryMetadata={primaryMetadata}
           feedId={feedid}
           liveStartDateTime={liveStartDateTime}
@@ -97,10 +139,11 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
         />
       )}
       <VideoDetails
-        title={programTitle}
-        description={programDescription}
+        title={videoDetails.title}
+        description={videoDetails.description}
         primaryMetadata={primaryMetadata}
         posterMode={posterFading ? 'fading' : 'normal'}
+        poster={videoDetails.poster}
         startWatchingButton={
           channelMediaItem ? (
             <>
@@ -111,9 +154,9 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
                   start: isVod ? program?.startTime : undefined,
                   end: isVod ? program?.endTime : undefined,
                 })}
-                disabled={!canWatch}
+                disabled={!videoDetails.canWatch}
               />
-              {canWatchFromBeginning && (
+              {videoDetails.canWatchFromBeginning && (
                 <Button
                   className={styles.catchupButton}
                   onClick={() =>

--- a/src/hooks/useLiveChannels.ts
+++ b/src/hooks/useLiveChannels.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import type { PlaylistItem } from '#types/playlist';
 import epgService, { EpgChannel, EpgProgram } from '#src/services/epg.service';
-import { programIsLive } from '#src/utils/epg';
+import { getLiveProgram, programIsLive } from '#src/utils/epg';
 
 /**
  * This hook fetches the schedules for the given list of playlist items and manages the current channel and program.
@@ -18,24 +18,14 @@ const useLiveChannels = (playlist: PlaylistItem[], enableAutoUpdate = true) => {
   const { data: channels = [] } = useQuery(['schedules', ...playlist.map(({ mediaid }) => mediaid)], () => epgService.getSchedules(playlist));
 
   const [autoUpdate, setAutoUpdate] = useState(enableAutoUpdate);
-  const [channel, setChannel] = useState<EpgChannel | undefined>(channels[0]);
+  const [channel, setChannel] = useState<EpgChannel | undefined>();
   const [program, setProgram] = useState<EpgProgram | undefined>();
-
-  // helper function to select the live program of the current channel
-  const setLiveProgram = (currentChannel: EpgChannel | undefined) => {
-    if (!currentChannel) return;
-    const liveProgram = currentChannel.programs.find(programIsLive);
-
-    if (!program || program.id !== liveProgram?.id) {
-      setProgram(liveProgram);
-    }
-  };
 
   // this effect updates the program when watching the live stream and the next program starts
   useEffect(() => {
     if (!autoUpdate || !enableAutoUpdate) return;
 
-    const intervalId = window.setInterval(() => setLiveProgram(channel), 5_000);
+    const intervalId = window.setInterval(() => setProgram(getLiveProgram(channel)), 5_000);
 
     return () => clearInterval(intervalId);
   }, [channel, autoUpdate, enableAutoUpdate]);
@@ -49,7 +39,7 @@ const useLiveChannels = (playlist: PlaylistItem[], enableAutoUpdate = true) => {
       setChannel(firstChannel);
 
       // auto select live program
-      setLiveProgram(firstChannel);
+      setProgram(getLiveProgram(firstChannel));
     }
   }, [channels]);
 
@@ -58,16 +48,20 @@ const useLiveChannels = (playlist: PlaylistItem[], enableAutoUpdate = true) => {
     (id: string, programId?: string) => {
       const channel = channels?.find((channel) => channel.id === id);
 
-      if (channel) {
-        const program = channel.programs.find((program) => program.id === programId);
-
-        setChannel(channel);
-        setProgram(program);
-
-        // enable auto update when there is no program information or when the program is live
-        // when the user clicks on a VOD item, we don't want to update the information automatically
-        setAutoUpdate(!program || programIsLive(program));
+      // early return when no channel was found
+      if (!channel) {
+        return;
       }
+
+      // select the found program or live program when no programId is given
+      const program = programId ? channel.programs.find((program) => program.id === programId) : getLiveProgram(channel);
+
+      setChannel(channel);
+      setProgram(program);
+
+      // enable auto update when there is no program information or when the program is live
+      // when the user clicks on a VOD item, we don't want to update the information automatically
+      setAutoUpdate(!program || programIsLive(program));
     },
     [channels],
   );

--- a/src/hooks/useLiveChannels.ts
+++ b/src/hooks/useLiveChannels.ts
@@ -25,7 +25,7 @@ const useLiveChannels = (playlist: PlaylistItem[], enableAutoUpdate = true) => {
   useEffect(() => {
     if (!autoUpdate || !enableAutoUpdate) return;
 
-    const intervalId = window.setInterval(() => setProgram(getLiveProgram(channel)), 5_000);
+    const intervalId = window.setInterval(() => channel && setProgram(getLiveProgram(channel)), 5_000);
 
     return () => clearInterval(intervalId);
   }, [channel, autoUpdate, enableAutoUpdate]);

--- a/src/i18n/locales/en_US/epg.json
+++ b/src/i18n/locales/en_US/epg.json
@@ -1,12 +1,4 @@
 {
-  "empty_schedule_program": {
-    "description": "No program information available",
-    "title": "No program information"
-  },
-  "failed_schedule_program": {
-    "description": "The program information failed to load",
-    "title": "Failed to load schedule"
-  },
   "on_channel": "On {{name}}",
   "start_from_beginning": "Start from beginning"
 }

--- a/src/i18n/locales/nl_NL/epg.json
+++ b/src/i18n/locales/nl_NL/epg.json
@@ -1,12 +1,4 @@
 {
-  "empty_schedule_program": {
-    "description": "",
-    "title": ""
-  },
-  "failed_schedule_program": {
-    "description": "",
-    "title": ""
-  },
   "on_channel": "",
   "start_from_beginning": ""
 }

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -56,55 +56,6 @@ describe('epgService', () => {
     expect(schedule.programs.length).toEqual(14);
   });
 
-  test('getSchedule adds a static program when the schedule is empty or fails', async () => {
-    const mock1 = mockGet('/epg/channel2.json').willResolve([]);
-    const mock2 = mockGet('/epg/does-not-exist.json').willFail('', 404, 'Not found');
-    const mock3 = mockGet('/epg/network-error.json').willThrow(new Error('Network error'));
-
-    // mock the date
-    vi.setSystemTime(new Date(2022, 1, 1, 14, 30, 10, 500));
-
-    const emptySchedule = await epgService.getSchedule(livePlaylist.playlist[1]);
-    const failedSchedule = await epgService.getSchedule(livePlaylist.playlist[2]);
-    const networkErrorSchedule = await epgService.getSchedule(livePlaylist.playlist[3]);
-
-    expect(mock1).toHaveFetched();
-    expect(emptySchedule.title).toEqual('Channel 2');
-    expect(emptySchedule.programs.length).toEqual(1);
-    expect(emptySchedule.programs[0]).toMatchObject({
-      id: 'no-program-NS2Q213',
-      title: 'epg:empty_schedule_program.title',
-      description: 'epg:empty_schedule_program.description',
-      startTime: '2022-01-31T00:00:00.000Z',
-      endTime: '2022-02-02T23:59:59.999Z',
-      image: undefined,
-    });
-
-    expect(mock2).toHaveFetched();
-    expect(failedSchedule.title).toEqual('Channel 3');
-    expect(failedSchedule.programs.length).toEqual(1);
-    expect(failedSchedule.programs[0]).toMatchObject({
-      id: 'no-program-JDODS53',
-      title: 'epg:failed_schedule_program.title',
-      description: 'epg:failed_schedule_program.description',
-      startTime: '2022-01-31T00:00:00.000Z',
-      endTime: '2022-02-02T23:59:59.999Z',
-      image: undefined,
-    });
-
-    expect(mock3).toHaveFetched();
-    expect(networkErrorSchedule.title).toEqual('Channel 4');
-    expect(networkErrorSchedule.programs.length).toEqual(1);
-    expect(networkErrorSchedule.programs[0]).toMatchObject({
-      id: 'no-program-SDF23CJ',
-      title: 'epg:failed_schedule_program.title',
-      description: 'epg:failed_schedule_program.description',
-      startTime: '2022-01-31T00:00:00.000Z',
-      endTime: '2022-02-02T23:59:59.999Z',
-      image: undefined,
-    });
-  });
-
   test('getSchedule enabled demo mode when scheduleDemo is set', async () => {
     const mock = mockGet('/epg/channel1.json').willResolve(scheduleData);
 
@@ -149,20 +100,17 @@ describe('epgService', () => {
     expect(schedules[0].title).toEqual('Channel 1');
     expect(schedules[0].programs.length).toEqual(14);
 
-    // empty schedule (with static program)
+    // empty schedule
     expect(schedules[1].title).toEqual('Channel 2');
-    expect(schedules[1].programs.length).toEqual(1);
-    expect(schedules[1].programs[0].title).toEqual('epg:empty_schedule_program.title');
+    expect(schedules[1].programs.length).toEqual(0);
 
-    // failed fetching the schedule request (with static program)
+    // empty schedule (failed fetching)
     expect(schedules[2].title).toEqual('Channel 3');
-    expect(schedules[2].programs.length).toEqual(1);
-    expect(schedules[2].programs[0].title).toEqual('epg:failed_schedule_program.title');
+    expect(schedules[2].programs.length).toEqual(0);
 
-    // network error (with static program)
+    // empty schedule (network error)
     expect(schedules[3].title).toEqual('Channel 4');
-    expect(schedules[3].programs.length).toEqual(1);
-    expect(schedules[3].programs[0].title).toEqual('epg:failed_schedule_program.title');
+    expect(schedules[3].programs.length).toEqual(0);
   });
 
   test('parseSchedule should remove programs where required fields are missing', async () => {

--- a/src/services/epg.service.ts
+++ b/src/services/epg.service.ts
@@ -4,7 +4,6 @@ import { addDays, differenceInDays, endOfDay, isValid, set, startOfDay, subDays 
 import type { PlaylistItem } from '#types/playlist';
 import { getDataOrThrow } from '#src/utils/api';
 import { logDev } from '#src/utils/common';
-import i18n from '#src/i18n/config';
 
 const AUTHENTICATION_HEADER = 'API-KEY';
 
@@ -20,6 +19,7 @@ export const isFulfilled = <T>(input: PromiseSettledResult<T>): input is Promise
 export type EpgChannel = {
   id: string;
   title: string;
+  description: string;
   image: string;
   programs: EpgProgram[];
 };
@@ -149,22 +149,13 @@ class EpgService {
    */
   async getSchedule(item: PlaylistItem) {
     const schedule = await this.fetchSchedule(item);
-    let programs = await this.parseSchedule(schedule, !!item.scheduleDemo);
-
-    if (!programs.length) {
-      programs = [
-        this.generateStaticProgram({
-          id: `no-program-${item.mediaid}`,
-          title: schedule ? i18n.t('epg:empty_schedule_program.title') : i18n.t('epg:failed_schedule_program.title'),
-          description: schedule ? i18n.t('epg:empty_schedule_program.description') : i18n.t('epg:failed_schedule_program.description'),
-        }),
-      ];
-    }
+    const programs = await this.parseSchedule(schedule, !!item.scheduleDemo);
 
     return {
       id: item.mediaid,
       title: item.title,
       image: item.image,
+      description: item.description,
       programs,
     } as EpgChannel;
   }

--- a/src/styles/mixins/_typography.scss
+++ b/src/styles/mixins/_typography.scss
@@ -6,7 +6,7 @@
   font-family: var(--body-font-family);
   font-weight: var(--body-font-weight-bold);
   font-size: $font-size;
-  line-height: 40px;
+  line-height: 1em;
   letter-spacing: 0.25px;
 
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);

--- a/src/utils/epg.ts
+++ b/src/utils/epg.ts
@@ -1,6 +1,6 @@
 import { isAfter, isFuture, isPast, subHours } from 'date-fns';
 
-import type { EpgProgram } from '#src/services/epg.service';
+import type { EpgChannel, EpgProgram } from '#src/services/epg.service';
 
 /**
  * Returns true when the program is currently live e.g. the startTime is before now and the endTime is after now
@@ -30,4 +30,11 @@ export const programIsFullyWatchable = (program: EpgProgram, liveStreamCatchupHo
   const maxStartTime = subHours(new Date(), liveStreamCatchupHours);
 
   return isAfter(startTime, maxStartTime);
+};
+
+/**
+ * Get the live program of the given channel
+ */
+export const getLiveProgram = (channel: EpgChannel) => {
+  return channel.programs.find(programIsLive);
 };


### PR DESCRIPTION
This PR updates the current program information with the current program information and falls back to the channel information when no program is selected or available.

I've removed the static program for empty or failed schedules since this can't be handled properly. The plan is to add a status property to the EpgChannel type and let the EPG view render a custom text instead. This can be added when the EPG UI work is completed by @RCVZ.

Automatically re-fetch the live channel schedules every 15 minutes. Also, make sure to update the current channel and program information with the updated information. 

**Live program:**

![image](https://user-images.githubusercontent.com/3996119/181267655-1ced6e48-a04e-4bb6-a5bf-092fec592544.png)

**VOD program:**

![image](https://user-images.githubusercontent.com/3996119/181267849-ce8170f1-3d89-476a-b201-6a5a750c01a1.png)

**No program:**

![image](https://user-images.githubusercontent.com/3996119/181267923-6835b9f9-4e20-4394-962c-4c4a742f5cf7.png)

