### PR TITLE
Feat / allow deep linking to live channel

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -26,6 +26,11 @@
       "enableText": true,
       "type": "playlist",
       "contentId": "xQaFzykq"
+    },
+    {
+      "enableText": true,
+      "type": "playlist",
+      "contentId": "WppSIFKF"
     }
   ],
   "menu": [

--- a/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/src/containers/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import shallow from 'zustand/shallow';
 import { Epg, Layout } from 'planby';
@@ -22,7 +22,7 @@ import StartWatchingButton from '#src/containers/StartWatchingButton/StartWatchi
 import usePlanByEpg from '#src/hooks/usePlanByEpg';
 import Cinema from '#src/containers/Cinema/Cinema';
 import useEntitlement from '#src/hooks/useEntitlement';
-import { addQueryParams, formatDurationTag } from '#src/utils/formatting';
+import { addQueryParams, formatDurationTag, liveChannelsURL } from '#src/utils/formatting';
 import Button from '#src/components/Button/Button';
 import Play from '#src/icons/Play';
 import useLiveProgram from '#src/hooks/useLiveProgram';
@@ -45,13 +45,15 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
   const history = useHistory();
   const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const play = searchParams.get('play') === '1';
+  const channelId = searchParams.get('channel') ?? undefined;
   const liveStartDateTime = searchParams.get('start');
   const liveEndDateTime = searchParams.get('end');
   const liveFromBeginning = searchParams.get('beginning') === '1';
-  const goBack = () => history.push(`/p/${feedid}`, false);
+  const goBack = () => feedid && history.push(liveChannelsURL(feedid, channelId));
 
   // EPG data
-  const { channels, channel, program, setActiveChannel } = useLiveChannels(playlist, !liveFromBeginning);
+  const [initialChannelId] = useState(channelId);
+  const { channels, channel, program, setActiveChannel } = useLiveChannels(playlist, initialChannelId, !liveFromBeginning);
   const { isLive, isVod, isWatchableFromBeginning } = useLiveProgram(program);
   const { getEpgProps, getLayoutProps } = usePlanByEpg(channels);
 
@@ -111,6 +113,11 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
     if (toImage) updateBlurImage(toImage);
   }, [channelMediaItem?.image, program, updateBlurImage]);
 
+  useEffect(() => {
+    // update the channel id in URL
+    if (channel && feedid) history.replace(liveChannelsURL(feedid, channel.id));
+  }, [history, feedid, channel]);
+
   // Loading
   if (!channel) {
     return <LoadingOverlay />;
@@ -149,8 +156,7 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
             <>
               <StartWatchingButton
                 item={channelMediaItem}
-                playUrl={addQueryParams(`/p/${feedid}`, {
-                  play: 1,
+                playUrl={addQueryParams(liveChannelsURL(feedid || '', channelId, true), {
                   start: isVod ? program?.startTime : undefined,
                   end: isVod ? program?.endTime : undefined,
                 })}
@@ -161,8 +167,7 @@ function PlaylistLiveChannels({ playlist: { feedid, title, playlist } }: { playl
                   className={styles.catchupButton}
                   onClick={() =>
                     history.push(
-                      addQueryParams(`/p/${feedid}`, {
-                        play: 1,
+                      addQueryParams(liveChannelsURL(feedid || '', channelId, true), {
                         start: program?.startTime,
                         beginning: 1,
                       }),

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,4 +1,4 @@
-import { getSeriesId, getSeriesIdFromEpisode, isEpisode, isSeriesPlaceholder } from '#src/utils/media';
+import { getSeriesId, getSeriesIdFromEpisode, isEpisode, isLiveChannel, isSeriesPlaceholder } from '#src/utils/media';
 import type { Playlist, PlaylistItem } from '#types/playlist';
 
 export const formatDurationTag = (seconds: number): string | null => {
@@ -64,14 +64,21 @@ export const slugify = (text: string, whitespaceChar: string = '-') =>
     .replace(/-+$/, '')
     .replace(/-/g, whitespaceChar);
 
-export const movieURL = (item: PlaylistItem, playlistId?: string | null, play: boolean = false) =>
+export const movieURL = (item: PlaylistItem, playlistId?: string | null, play = false) =>
   addQueryParams(`/m/${item.mediaid}/${slugify(item.title)}`, { r: playlistId, play: play ? '1' : null });
 
-export const seriesURL = (item: PlaylistItem, playlistId?: string | null, play: boolean = false) => {
+export const seriesURL = (item: PlaylistItem, playlistId?: string | null, play = false) => {
   const seriesId = getSeriesId(item);
 
   return addQueryParams(`/s/${seriesId}/${slugify(item.title)}`, {
     r: playlistId,
+    play: play ? '1' : null,
+  });
+};
+
+export const liveChannelsURL = (playlistId: string, channelId?: string, play = false) => {
+  return addQueryParams(`/p/${playlistId}`, {
+    channel: channelId,
     play: play ? '1' : null,
   });
 };
@@ -94,6 +101,10 @@ export const episodeURLFromEpisode = (item: PlaylistItem, seriesId: string, play
 };
 
 export const cardUrl = (item: PlaylistItem, playlistId?: string | null, play: boolean = false) => {
+  if (isLiveChannel(item)) {
+    return liveChannelsURL(item.liveChannelsId, item.mediaid, play);
+  }
+
   if (isEpisode(item)) {
     const seriesId = getSeriesIdFromEpisode(item);
 

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,4 +1,6 @@
-import type { PlaylistItem } from '../../types/playlist';
+import type { PlaylistItem } from '#types/playlist';
+
+type RequiredProperties<T, P extends keyof T> = T & Required<Pick<T, P>>;
 
 type DeprecatedPlaylistItem = {
   seriesPlayListId?: string;
@@ -20,6 +22,9 @@ export const isSeriesPlaceholder = (item: PlaylistItem) => {
 export const isEpisode = (item: PlaylistItem) => {
   return item && typeof item.episodeNumber !== 'undefined';
 };
+
+export const isLiveChannel = (item: PlaylistItem): item is RequiredProperties<PlaylistItem, 'contentType' | 'liveChannelsId'> =>
+  item.contentType === 'LiveChannel' && !!item.liveChannelsId;
 
 export const getSeriesIdFromEpisode = (item: PlaylistItem | undefined) => {
   if (!item || !isEpisode(item)) {

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -43,6 +43,8 @@ export type PlaylistItem = {
   free?: string;
   productIds?: string;
   mediaOffers?: MediaOffer[] | null;
+  contentType?: string;
+  liveChannelsId?: string;
   scheduleUrl?: string | null;
   scheduleToken?: string;
   scheduleDataFormat?: string;


### PR DESCRIPTION
This PR allows users to deep link to a live channel from any page or shared URLs.

For cards to work on the homepage, the following custom properties must be set:

```
{
  "contentType": "Live",
  "liveChannelsId": "123456" // playlist id with all live channels
}
```