### PR TITLE
Feat / add unit tests for EPG hooks and service

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ts-node": "^10.7.0",
     "typescript": "^4.3.4",
     "vi-fetch": "^0.8.0",
-    "vite": "^2.9.0",
+    "vite": "^3.0.4",
     "vite-plugin-eslint": "^1.3.0",
     "vite-plugin-html": "^3.2.0",
     "vite-plugin-pwa": "^0.11.13",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@commitlint/config-conventional": "^12.1.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^11.2.6",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/dompurify": "^2.3.3",
     "@types/jwplayer": "^8.2.7",
     "@types/lodash.merge": "^4.6.6",
@@ -114,7 +115,7 @@
     "vite-plugin-pwa": "^0.11.13",
     "vite-plugin-static-copy": "^0.4.4",
     "vite-plugin-stylelint": "^2.1.0",
-    "vitest": "^0.10.0",
+    "vitest": "^0.19.1",
     "workbox-build": "^6.5.2",
     "workbox-window": "^6.5.2"
   },

--- a/src/components/Epg/Epg.tsx
+++ b/src/components/Epg/Epg.tsx
@@ -37,7 +37,14 @@ export default function Epg({ channels, setActiveChannel, channel, program, conf
   const itemHeight = isMobile ? 80 : 106;
 
   // Epg
-  const { getEpgProps, getLayoutProps, onScrollToNow, onScrollLeft, onScrollRight } = usePlanByEpg(channels, sidebarWidth, itemHeight, config);
+  const { highlightColor, backgroundColor } = config.styling;
+  const { getEpgProps, getLayoutProps, onScrollToNow, onScrollLeft, onScrollRight } = usePlanByEpg(
+    channels,
+    sidebarWidth,
+    itemHeight,
+    highlightColor,
+    backgroundColor,
+  );
   const catchupHoursDict = useMemo(() => Object.fromEntries(channels.map((channel) => [channel.id, channel.catchupHours])), [channels]);
 
   return (

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,4 +13,4 @@ export const ADYEN_TEST_CLIENT_KEY = 'test_I4OFGUUCEVB5TI222AS3N2Y2LY6PJM3K';
 export const ADYEN_LIVE_CLIENT_KEY = 'live_BQDOFBYTGZB3XKF62GBYSLPUJ4YW2TPL';
 
 // how often the live channel schedule is refetched in ms
-export const LIVE_CHANNELS_REFETCH_INTERVAL = 15_000 * 60;
+export const LIVE_CHANNELS_REFETCH_INTERVAL = 15 * 60_000;

--- a/src/fixtures/epgChannels.json
+++ b/src/fixtures/epgChannels.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "channel1",
+    "title": "Channel 1",
+    "description": "Description for Channel 1",
+    "image": "",
+    "programs": [
+      {
+        "id": "program1",
+        "title": "Program 1",
+        "startTime": "2022-07-15T10:00:00Z",
+        "endTime": "2022-07-15T10:30:00Z"
+      },
+      {
+        "id": "program2",
+        "title": "Program 2",
+        "startTime": "2022-07-15T10:30:00Z",
+        "endTime": "2022-07-15T11:00:00Z"
+      }
+    ],
+    "catchupHours": 2
+  },
+  {
+    "id": "channel2",
+    "title": "Channel 2",
+    "description": "Description for Channel 2",
+    "image": "",
+    "programs": [
+      {
+        "id": "program3",
+        "title": "Program 3",
+        "startTime": "2022-07-15T10:00:00Z",
+        "endTime": "2022-07-15T10:30:00Z"
+      },
+      {
+        "id": "program4",
+        "title": "Program 4",
+        "startTime": "2022-07-15T10:30:00Z",
+        "endTime": "2022-07-15T11:00:00Z"
+      }
+    ],
+    "catchupHours": 2
+  }
+]

--- a/src/fixtures/epgChannelsUpdate.json
+++ b/src/fixtures/epgChannelsUpdate.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "channel1",
+    "title": "Channel 1",
+    "description": "Description for Channel 1",
+    "image": "",
+    "programs": [
+      {
+        "id": "program1",
+        "title": "Program 1",
+        "startTime": "2022-07-15T10:00:00Z",
+        "endTime": "2022-07-15T10:45:00Z"
+      },
+      {
+        "id": "program2",
+        "title": "Program 2",
+        "startTime": "2022-07-15T10:45:00Z",
+        "endTime": "2022-07-15T11:00:00Z"
+      },
+      {
+        "id": "program5",
+        "title": "Program 5",
+        "startTime": "2022-07-15T11:00:00Z",
+        "endTime": "2022-07-15T11:30:00Z"
+      }
+    ],
+    "catchupHours": 2
+  },
+  {
+    "id": "channel2",
+    "title": "Channel 2",
+    "description": "Description for Channel 2",
+    "image": "",
+    "programs": [
+      {
+        "id": "program3",
+        "title": "Program 3",
+        "startTime": "2022-07-15T10:00:00Z",
+        "endTime": "2022-07-15T10:45:00Z"
+      },
+      {
+        "id": "program4",
+        "title": "Program 4",
+        "startTime": "2022-07-15T10:45:00Z",
+        "endTime": "2022-07-15T11:00:00Z"
+      },
+      {
+        "id": "program6",
+        "title": "Program 6",
+        "startTime": "2022-07-15T11:30:00Z",
+        "endTime": "2022-07-15T12:00:00Z"
+      }
+    ],
+    "catchupHours": 2
+  }
+]

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -51,7 +51,7 @@
       "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
       "tags": "live",
       "scheduleUrl": "/epg/channel1.json",
-      "catchupHours": 7,
+      "catchupHours": "7",
       "sources": [
         {
           "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",

--- a/src/fixtures/livePlaylist.json
+++ b/src/fixtures/livePlaylist.json
@@ -51,6 +51,7 @@
       "description": "A 24x7 airing of long films released by Blender Open Movie Project, including Elephants Dream, Big Buck Bunny, Sintel, Tears Of Steel, and Cosmos Laundromat.",
       "tags": "live",
       "scheduleUrl": "/epg/channel1.json",
+      "catchupHours": 7,
       "sources": [
         {
           "file": "https://demo-use1.cdn.vustreams.com/live/b49bec86-f786-4b08-941c-a4ee80f70e1f/live.isml/b49bec86-f786-4b08-941c-a4ee80f70e1f.m3u8",

--- a/src/hooks/useLiveChannels.test.ts
+++ b/src/hooks/useLiveChannels.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from 'vitest';
+import { renderHook } from '@testing-library/react-hooks';
+
+import epgService, { EpgChannel } from '#src/services/epg.service';
+import useLiveChannels from '#src/hooks/useLiveChannels';
+import { createWrapper } from '#test/testUtils';
+import type { Playlist } from '#types/playlist';
+import livePlaylistFixture from '#src/fixtures/livePlaylist.json';
+import epgChannelsFixture from '#src/fixtures/epgChannels.json';
+import epgChannelsUpdateFixture from '#src/fixtures/epgChannelsUpdate.json';
+
+const livePlaylist: Playlist = livePlaylistFixture;
+const schedule: EpgChannel[] = epgChannelsFixture;
+const scheduleUpdate: EpgChannel[] = epgChannelsUpdateFixture;
+
+describe('useLiveChannels', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('gets the date using the EPG service getSchedules method', async () => {
+    const mock = vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, ''), { wrapper: createWrapper() });
+
+    // initial empty channels
+    expect(result.current.channels).toEqual([]);
+    expect(result.current.channel).toBeUndefined();
+    expect(result.current.program).toBeUndefined();
+
+    await waitForNextUpdate();
+
+    expect(mock).toHaveBeenCalledOnce();
+    expect(mock).toHaveBeenCalledWith(livePlaylist.playlist);
+
+    // channels are set in state
+    expect(result.current.channels).toEqual(schedule);
+    // first channel selected
+    expect(result.current.channel).toEqual(schedule[0]);
+  });
+
+  test('selects the initial channel based of the initialChannelId', async () => {
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, 'channel2'), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // second channel selected (initial channel id)
+    expect(result.current.channel).toEqual(schedule[1]);
+  });
+
+  test('selects the live program of the current channel', async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:45:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // select live program on first channel
+    expect(result.current.program).toMatchObject({ id: 'program2' });
+  });
+
+  test('updates the program automatically when no program was found', async () => {
+    vi.setSystemTime(new Date('2022-07-15T09:00:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // no program is selected
+    expect(result.current.program).toBeUndefined();
+
+    // update time to next program
+    vi.setSystemTime(new Date('2022-07-15T10:01:00Z'));
+    vi.runOnlyPendingTimers();
+    await waitForNextUpdate();
+
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+  });
+
+  test('updates the program automatically when being live', async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // first program is selected
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+
+    // update time to next program
+    vi.setSystemTime(new Date('2022-07-15T10:31:00Z'));
+    vi.runOnlyPendingTimers();
+    await waitForNextUpdate();
+
+    expect(result.current.program).toMatchObject({ id: 'program2' });
+  });
+
+  test("doesn't update the program automatically when not being live", async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // first program is selected
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+
+    // update time to next program
+    vi.setSystemTime(new Date('2022-07-15T10:31:00Z'));
+    vi.runOnlyPendingTimers();
+    await waitForNextUpdate();
+
+    expect(result.current.program).toMatchObject({ id: 'program2' });
+  });
+
+  test('updates the channel and program when using the `setChannel` function', async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // first program is selected
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+
+    result.current.setActiveChannel('channel2');
+
+    // channel 2 should be selected and program 3 which is live
+    expect(result.current.channel).toMatchObject({ id: 'channel2' });
+    expect(result.current.program).toMatchObject({ id: 'program3' });
+
+    // update channel and program
+    result.current.setActiveChannel('channel1', 'program2');
+
+    expect(result.current.channel).toMatchObject({ id: 'channel1' });
+    expect(result.current.program).toMatchObject({ id: 'program2' });
+  });
+
+  test("doesn't update the channel or program when using the `setChannel` function with an invalid channelId ", async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // first program is selected
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+
+    result.current.setActiveChannel('channel3', 'program5');
+
+    // channel 1 should still be selected
+    expect(result.current.channel).toMatchObject({ id: 'channel1' });
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+  });
+
+  test('updates the channel and program when the data changes', async () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    const mock = vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // first program is selected
+    expect(result.current.program).toMatchObject({ id: 'program1' });
+    expect(mock).toHaveBeenCalledTimes(1);
+
+    mock.mockResolvedValue(scheduleUpdate);
+    vi.runOnlyPendingTimers();
+
+    await waitForNextUpdate();
+
+    // the endTime for program1 should be changed
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(result.current.program).toMatchObject({ id: 'program1', endTime: '2022-07-15T10:45:00Z' });
+  });
+
+  test('updates the channel and program when the data changes', async () => {
+    vi.setSystemTime(new Date('2022-07-15T11:05:00Z'));
+
+    const mock = vi.spyOn(epgService, 'getSchedules').mockResolvedValue(schedule);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // no program is selected (we have an outdated schedule)
+    expect(result.current.program).toBeUndefined();
+    expect(mock).toHaveBeenCalledTimes(1);
+
+    mock.mockResolvedValue(scheduleUpdate);
+    vi.runOnlyPendingTimers();
+
+    await waitForNextUpdate();
+
+    // the program should be updated to the live program with the updated data
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(result.current.program).toMatchObject({ id: 'program5' });
+  });
+
+  test("clears the program when the current program get's removed from the data", async () => {
+    vi.setSystemTime(new Date('2022-07-15T11:05:00Z'));
+
+    // start with update schedule (which has more programs)
+    const mock = vi.spyOn(epgService, 'getSchedules').mockResolvedValue(scheduleUpdate);
+    const { result, waitForNextUpdate } = renderHook(() => useLiveChannels(livePlaylist.playlist, undefined), { wrapper: createWrapper() });
+
+    await waitForNextUpdate();
+
+    // program 5 is selected
+    expect(result.current.program).toMatchObject({ id: 'program5' });
+
+    // we use the default schedule data which doesn't have program5
+    mock.mockResolvedValue(schedule);
+    vi.runOnlyPendingTimers();
+
+    await waitForNextUpdate();
+
+    // the program should be undefined since it couldn't be found in the latest data
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(result.current.program).toBeUndefined();
+  });
+});

--- a/src/hooks/useLiveProgram.test.ts
+++ b/src/hooks/useLiveProgram.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useLiveProgram from '#src/hooks/useLiveProgram';
+import epgChannelsFixture from '#src/fixtures/epgChannels.json';
+import type { EpgChannel } from '#src/services/epg.service';
+
+const schedule: EpgChannel[] = epgChannelsFixture;
+
+const program = schedule[0].programs[0];
+const program2 = schedule[0].programs[1];
+
+describe('useLiveProgram', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('should set isLive to true when the program is live', () => {
+    vi.setSystemTime(new Date('2022-07-15T10:05:00Z'));
+
+    const { result } = renderHook(() => useLiveProgram(program, 2));
+
+    expect(result.current.isLive).toBe(true);
+    expect(result.current.isVod).toBe(false);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+  });
+
+  test('should switch to isVod when the program is not live anymore', () => {
+    vi.setSystemTime(new Date('2022-07-15T10:05:00Z'));
+
+    const { result } = renderHook(() => useLiveProgram(program, 2));
+
+    expect(result.current.isLive).toBe(true);
+    expect(result.current.isVod).toBe(false);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+
+    vi.setSystemTime(new Date('2022-07-15T10:31:00Z'));
+    vi.runOnlyPendingTimers();
+
+    expect(result.current.isLive).toBe(false);
+    expect(result.current.isVod).toBe(true);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+  });
+
+  test('should return false when the program is not fully watchable anymore', () => {
+    // 1 minute before catchup expires (2 hours)
+    vi.setSystemTime(new Date('2022-07-15T11:59:00Z'));
+
+    const { result } = renderHook(() => useLiveProgram(program, 2));
+
+    expect(result.current.isLive).toBe(false);
+    expect(result.current.isVod).toBe(true);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+
+    // 1 minute after catchup expiry
+    vi.setSystemTime(new Date('2022-07-15T12:01:00Z'));
+    vi.runOnlyPendingTimers();
+
+    expect(result.current.isLive).toBe(false);
+    expect(result.current.isVod).toBe(true);
+    expect(result.current.isWatchableFromBeginning).toBe(false);
+  });
+
+  test('should update values when the program changes', () => {
+    vi.setSystemTime(new Date('2022-07-15T10:15:00Z'));
+
+    let currentProgram = program;
+    const { result, rerender } = renderHook(() => useLiveProgram(currentProgram, 2));
+
+    expect(result.current.isLive).toBe(true);
+    expect(result.current.isVod).toBe(false);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+
+    // update to program 2
+    currentProgram = program2;
+    rerender();
+
+    expect(result.current.isLive).toBe(false);
+    expect(result.current.isVod).toBe(false);
+    expect(result.current.isWatchableFromBeginning).toBe(true);
+  });
+});

--- a/src/hooks/usePlanByEpg.test.ts
+++ b/src/hooks/usePlanByEpg.test.ts
@@ -1,0 +1,104 @@
+import * as planby from 'planby';
+import { renderHook } from '@testing-library/react-hooks';
+import { describe, expect, test } from 'vitest';
+
+import usePlanByEpg, { makeTheme } from '#src/hooks/usePlanByEpg';
+import epgChannelsFixture from '#src/fixtures/epgChannels.json';
+import type { EpgChannel } from '#src/services/epg.service';
+
+const schedule: EpgChannel[] = epgChannelsFixture;
+
+describe('usePlanByEpg', () => {
+  beforeEach(() => {
+    vi.mock('planby', () => ({
+      useEpg: vi.fn(),
+    }));
+    vi.useFakeTimers();
+    vi.setSystemTime('2022-07-26T16:30:20.543Z');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('calls the `useEpg` hook with the correct parameters', () => {
+    renderHook(() => usePlanByEpg([], 100, 80));
+
+    expect(planby.useEpg).toBeCalled();
+    expect(planby.useEpg).toHaveBeenCalledWith({
+      channels: [],
+      epg: [],
+      dayWidth: 7200,
+      sidebarWidth: 100,
+      itemHeight: 80,
+      isSidebar: true,
+      isTimeline: true,
+      isLine: true,
+      isBaseTimeFormat: false,
+      startDate: new Date('2022-07-26T00:00:00.000Z'),
+      endDate: new Date('2022-07-26T23:59:59.999Z'),
+      theme: makeTheme(),
+    });
+  });
+
+  test('updates the startDate and endDate only when the date changes', () => {
+    const mockFn = vi.spyOn(planby, 'useEpg');
+
+    const { rerender } = renderHook(() => usePlanByEpg([], 100, 80));
+
+    expect(mockFn).toHaveBeenCalled();
+    expect(mockFn.mock.calls[0][0]).toMatchObject({
+      startDate: new Date('2022-07-26T00:00:00.000Z'),
+      endDate: new Date('2022-07-26T23:59:59.999Z'),
+    });
+
+    const startDate = mockFn.mock.calls[0][0].startDate;
+    const endDate = mockFn.mock.calls[0][0].endDate;
+
+    // 15 minutes later
+    vi.setSystemTime('2022-07-26T16:45:20.543Z');
+    rerender();
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
+    expect(mockFn.mock.calls[1][0]).toMatchObject({
+      startDate: new Date('2022-07-26T00:00:00.000Z'),
+      endDate: new Date('2022-07-26T23:59:59.999Z'),
+    });
+
+    // date instances should be the same
+    expect(mockFn.mock.calls[1][0].startDate).toStrictEqual(startDate);
+    expect(mockFn.mock.calls[1][0].endDate).toStrictEqual(endDate);
+
+    // next day
+    vi.setSystemTime('2022-07-27T16:30:20.543Z');
+    rerender();
+
+    expect(mockFn).toHaveBeenCalledTimes(3);
+    expect(mockFn.mock.calls[2][0]).toMatchObject({
+      startDate: new Date('2022-07-27T00:00:00.000Z'),
+      endDate: new Date('2022-07-27T23:59:59.999Z'),
+    });
+  });
+
+  test('transforms the channels and programs according to planby types', () => {
+    const mockFn = vi.spyOn(planby, 'useEpg');
+
+    renderHook(() => usePlanByEpg(schedule, 100, 80));
+
+    expect(mockFn.mock.calls[0][0].channels[0]).toMatchObject({
+      uuid: 'channel1',
+      logo: '',
+    });
+
+    expect(mockFn.mock.calls[0][0].epg[0]).toMatchObject({
+      id: 'program1',
+      channelUuid: 'channel1',
+      title: 'Program 1',
+      description: '',
+      image: '',
+      since: '2022-07-15T10:00:00Z',
+      till: '2022-07-15T10:30:00Z',
+    });
+  });
+});

--- a/src/hooks/usePlanByEpg.ts
+++ b/src/hooks/usePlanByEpg.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { useEpg } from 'planby';
 import { endOfDay, startOfDay } from 'date-fns';
 
-import type { Config } from '#types/Config';
 import type { EpgChannel } from '#src/services/epg.service';
 import { is12HourClock } from '#src/utils/datetime';
 
@@ -11,7 +10,7 @@ const isBaseTimeFormat = is12HourClock();
 /**
  * Return the Planby EPG props for the given channels
  */
-const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: number, config: Config) => {
+const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: number, highlightColor?: string | null, backgroundColor?: string | null) => {
   const [epgChannels, epgPrograms] = useMemo(() => {
     return [
       channels.map((channel) => ({ uuid: channel.id, logo: channel.image })),
@@ -29,7 +28,7 @@ const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: 
     ];
   }, [channels]);
 
-  const theme = useMemo(() => makeTheme(config.styling.highlightColor, config.styling.backgroundColor), [config]);
+  const theme = useMemo(() => makeTheme(highlightColor, backgroundColor), [highlightColor, backgroundColor]);
 
   // this mechanism updates the EPG component range when leaving the page open for a longer period
   // the useEpg hook doesn't accept a formatted date and re-renders when not memoize the start and end dates
@@ -55,7 +54,7 @@ const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: 
 // Theme configuration for the Planby EPG with only the colors set that are used
 // Fixed values are used because the default highlightColor and backgroundColor are only available in SCSS
 
-const makeTheme = (primaryColor?: string | null, backgroundColor?: string | null) => ({
+export const makeTheme = (primaryColor?: string | null, backgroundColor?: string | null) => ({
   primary: {
     600: backgroundColor || '#141523',
     900: backgroundColor || '#141523',

--- a/src/services/epg.service.test.ts
+++ b/src/services/epg.service.test.ts
@@ -54,6 +54,7 @@ describe('epgService', () => {
     expect(mock).toHaveFetched();
     expect(schedule.title).toEqual('Channel 1');
     expect(schedule.programs.length).toEqual(14);
+    expect(schedule.catchupHours).toEqual(7);
   });
 
   test('getSchedule enabled demo mode when scheduleDemo is set', async () => {

--- a/test/testUtils.tsx
+++ b/test/testUtils.tsx
@@ -17,7 +17,7 @@ export const createWrapper = () => {
       <QueryClientProvider client={client}>{children as ReactElement}</QueryClientProvider>
     </Router>
   );
-}
+};
 
 export const wrapper = ({ children }: WrapperProps) => (
   <Router>

--- a/test/testUtils.tsx
+++ b/test/testUtils.tsx
@@ -1,11 +1,22 @@
 import { BrowserRouter as Router } from 'react-router-dom';
-import React, { ReactNode, ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { render, RenderOptions } from '@testing-library/react';
 
 import QueryProvider from '../src/providers/QueryProvider';
 
 interface WrapperProps {
   children?: ReactNode;
+}
+
+export const createWrapper = () => {
+  const client = new QueryClient();
+
+  return ({ children }: WrapperProps) => (
+    <Router>
+      <QueryClientProvider client={client}>{children as ReactElement}</QueryClientProvider>
+    </Router>
+  );
 }
 
 export const wrapper = ({ children }: WrapperProps) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,6 +1644,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.2.6":
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
@@ -3402,7 +3410,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.2, debug@^4.3.3:
+debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3840,100 +3848,200 @@ esbuild-android-64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz#5b94a1306df31d55055f64a62ff6b763a47b7f64"
   integrity sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==
 
+esbuild-android-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz#414a087cb0de8db1e347ecca6c8320513de433db"
+  integrity sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==
+
 esbuild-android-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz#78acc80773d16007de5219ccce544c036abd50b8"
   integrity sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==
+
+esbuild-android-arm64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz#55de3bce2aab72bcd2b606da4318ad00fb9c8151"
+  integrity sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==
 
 esbuild-darwin-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz#e02b1291f629ebdc2aa46fabfacc9aa28ff6aa46"
   integrity sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==
 
+esbuild-darwin-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz#4259f23ed6b4cea2ec8a28d87b7fb9801f093754"
+  integrity sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==
+
 esbuild-darwin-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz#01eb6650ec010b18c990e443a6abcca1d71290a9"
   integrity sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==
+
+esbuild-darwin-arm64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz#d77b4366a71d84e530ba019d540b538b295d494a"
+  integrity sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==
 
 esbuild-freebsd-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz#790b8786729d4aac7be17648f9ea8e0e16475b5e"
   integrity sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==
 
+esbuild-freebsd-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz#27b6587b3639f10519c65e07219d249b01f2ad38"
+  integrity sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==
+
 esbuild-freebsd-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz#b66340ab28c09c1098e6d9d8ff656db47d7211e6"
   integrity sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==
+
+esbuild-freebsd-arm64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz#63c435917e566808c71fafddc600aca4d78be1ec"
+  integrity sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==
 
 esbuild-linux-32@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz#7927f950986fd39f0ff319e92839455912b67f70"
   integrity sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==
 
+esbuild-linux-32@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz#c3da774143a37e7f11559b9369d98f11f997a5d9"
+  integrity sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==
+
 esbuild-linux-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz#4893d07b229d9cfe34a2b3ce586399e73c3ac519"
   integrity sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==
+
+esbuild-linux-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz#5d92b67f674e02ae0b4a9de9a757ba482115c4ae"
+  integrity sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==
 
 esbuild-linux-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz#8442402e37d0b8ae946ac616784d9c1a2041056a"
   integrity sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==
 
+esbuild-linux-arm64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz#dac84740516e859d8b14e1ecc478dd5241b10c93"
+  integrity sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==
+
 esbuild-linux-arm@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz#d5dbf32d38b7f79be0ec6b5fb2f9251fd9066986"
   integrity sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==
+
+esbuild-linux-arm@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz#b3ae7000696cd53ed95b2b458554ff543a60e106"
+  integrity sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==
 
 esbuild-linux-mips64le@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz#95081e42f698bbe35d8ccee0e3a237594b337eb5"
   integrity sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==
 
+esbuild-linux-mips64le@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz#dad10770fac94efa092b5a0643821c955a9dd385"
+  integrity sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==
+
 esbuild-linux-ppc64le@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz#dceb0a1b186f5df679618882a7990bd422089b47"
   integrity sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==
+
+esbuild-linux-ppc64le@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz#b68c2f8294d012a16a88073d67e976edd4850ae0"
+  integrity sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==
 
 esbuild-linux-riscv64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz#61fb8edb75f475f9208c4a93ab2bfab63821afd2"
   integrity sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==
 
+esbuild-linux-riscv64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz#608a318b8697123e44c1e185cdf6708e3df50b93"
+  integrity sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==
+
 esbuild-linux-s390x@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz#34c7126a4937406bf6a5e69100185fd702d12fe0"
   integrity sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==
+
+esbuild-linux-s390x@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz#c9e7791170a3295dba79b93aa452beb9838a8625"
+  integrity sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==
 
 esbuild-netbsd-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz#322ea9937d9e529183ee281c7996b93eb38a5d95"
   integrity sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==
 
+esbuild-netbsd-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz#0abd40b8c2e37fda6f5cc41a04cb2b690823d891"
+  integrity sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==
+
 esbuild-openbsd-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz#1ca29bb7a2bf09592dcc26afdb45108f08a2cdbd"
   integrity sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==
+
+esbuild-openbsd-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz#4adba0b7ea7eb1428bb00d8e94c199a949b130e8"
+  integrity sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==
 
 esbuild-sunos-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz#c9446f7d8ebf45093e7bb0e7045506a88540019b"
   integrity sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==
 
+esbuild-sunos-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz#4b8a6d97dfedda30a6e39607393c5c90ebf63891"
+  integrity sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==
+
 esbuild-windows-32@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz#f8e9b4602fd0ccbd48e5c8d117ec0ba4040f2ad1"
   integrity sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==
+
+esbuild-windows-32@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz#d31d8ca0c1d314fb1edea163685a423b62e9ac17"
+  integrity sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==
 
 esbuild-windows-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz#280f58e69f78535f470905ce3e43db1746518107"
   integrity sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==
 
+esbuild-windows-64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz#7d3c09c8652d222925625637bdc7e6c223e0085d"
+  integrity sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==
+
 esbuild-windows-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz#d97e9ac0f95a4c236d9173fa9f86c983d6a53f54"
   integrity sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==
+
+esbuild-windows-arm64@0.14.51:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz#0220d2304bfdc11bc27e19b2aaf56edf183e4ae9"
+  integrity sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==
 
 esbuild@^0.14.27:
   version "0.14.38"
@@ -3960,6 +4068,32 @@ esbuild@^0.14.27:
     esbuild-windows-32 "0.14.38"
     esbuild-windows-64 "0.14.38"
     esbuild-windows-arm64 "0.14.38"
+
+esbuild@^0.14.47:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.51.tgz#1c8ecbc8db3710da03776211dc3ee3448f7aa51e"
+  integrity sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==
+  optionalDependencies:
+    esbuild-android-64 "0.14.51"
+    esbuild-android-arm64 "0.14.51"
+    esbuild-darwin-64 "0.14.51"
+    esbuild-darwin-arm64 "0.14.51"
+    esbuild-freebsd-64 "0.14.51"
+    esbuild-freebsd-arm64 "0.14.51"
+    esbuild-linux-32 "0.14.51"
+    esbuild-linux-64 "0.14.51"
+    esbuild-linux-arm "0.14.51"
+    esbuild-linux-arm64 "0.14.51"
+    esbuild-linux-mips64le "0.14.51"
+    esbuild-linux-ppc64le "0.14.51"
+    esbuild-linux-riscv64 "0.14.51"
+    esbuild-linux-s390x "0.14.51"
+    esbuild-netbsd-64 "0.14.51"
+    esbuild-openbsd-64 "0.14.51"
+    esbuild-sunos-64 "0.14.51"
+    esbuild-windows-32 "0.14.51"
+    esbuild-windows-64 "0.14.51"
+    esbuild-windows-arm64 "0.14.51"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5985,10 +6119,10 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-local-pkg@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
-  integrity sha512-lL87ytIGP2FU5PWwNDo0w3WhIo2gopIAxPg9RxDYF7m4rr5ahuZxP22xnJHIvaLTe4Z9P6uKKY2UHiwyB4pcrw==
+local-pkg@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
+  integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -6533,7 +6667,7 @@ nanoid@^3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
-nanoid@^3.3.3:
+nanoid@^3.3.3, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
@@ -7280,6 +7414,15 @@ postcss@^8.4.12:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7546,6 +7689,13 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.1.1:
   version "3.2.0"
@@ -7944,7 +8094,7 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.12.0:
+resolve@^1.12.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -8058,6 +8208,13 @@ rollup@^2.59.0, rollup@^2.60.2, rollup@^2.70.2:
   version "2.70.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
   integrity sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^2.75.6:
+  version "2.77.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.77.2.tgz#6b6075c55f9cc2040a5912e6e062151e42e2c4e3"
+  integrity sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -8856,15 +9013,10 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tinypool@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.1.3.tgz#b5570b364a1775fd403de5e7660b325308fee26b"
-  integrity sha512-2IfcQh7CP46XGWGGbdyO4pjcKqsmVqFAPcXfPxcPXmOWt9cYkTP9HcDmGgsfijYoAEc4z9qcpM/BaBz46Y9/CQ==
-
-tinyspy@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-0.3.2.tgz#2f95cb14c38089ca690385f339781cd35faae566"
-  integrity sha512-2+40EP4D3sFYy42UkgkFFB+kiX2Tg3URG/lVvAZFfLxgGpnWl5qQJuBw1gaLttq8UOS+2p3C0WrhJnQigLTT2Q==
+tinypool@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.2.4.tgz#4d2598c4689d1a2ce267ddf3360a9c6b3925a20c"
+  integrity sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==
 
 tinyspy@^1.0.0:
   version "1.0.0"
@@ -9411,7 +9563,7 @@ vite-plugin-stylelint@^2.1.0:
   dependencies:
     "@rollup/pluginutils" "^4.2.1"
 
-vite@^2.9.0, vite@^2.9.5:
+vite@^2.9.0:
   version "2.9.6"
   resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.6.tgz#29f1b33193b0de9e155d67ba0dd097501c3c3281"
   integrity sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==
@@ -9423,18 +9575,32 @@ vite@^2.9.0, vite@^2.9.5:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.10.0.tgz#ab8930194f2a8943c533cca735cba2bca705d5bc"
-  integrity sha512-8UXemUg9CA4QYppDTsDV76nH0e1p6C8lV9q+o9i0qMSK9AQ7vA2sjoxtkDP0M+pwNmc3ZGYetBXgSJx0M1D/gg==
+"vite@^2.9.12 || ^3.0.0-0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.4.tgz#c61688d6b97573e96cf5ac25f2d68597b5ce68e8"
+  integrity sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==
+  dependencies:
+    esbuild "^0.14.47"
+    postcss "^8.4.14"
+    resolve "^1.22.1"
+    rollup "^2.75.6"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+vitest@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.19.1.tgz#8a89f4c873132d778d4206dbfbd6791c12f6d921"
+  integrity sha512-E/ZXpFMUahn731wzhMBNzWRp4mGgiZFT0xdHa32cbNO0CSaHpE9hTfteEU247Gi2Dula8uXo5vvrNB6dtszmQA==
   dependencies:
     "@types/chai" "^4.3.1"
     "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
     chai "^4.3.6"
-    local-pkg "^0.4.1"
-    tinypool "^0.1.2"
-    tinyspy "^0.3.2"
-    vite "^2.9.5"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    tinypool "^0.2.4"
+    tinyspy "^1.0.0"
+    vite "^2.9.12 || ^3.0.0-0"
 
 void-elements@3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,231 +3843,105 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-android-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz#5b94a1306df31d55055f64a62ff6b763a47b7f64"
-  integrity sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==
-
 esbuild-android-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz#414a087cb0de8db1e347ecca6c8320513de433db"
   integrity sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==
-
-esbuild-android-arm64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz#78acc80773d16007de5219ccce544c036abd50b8"
-  integrity sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==
 
 esbuild-android-arm64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz#55de3bce2aab72bcd2b606da4318ad00fb9c8151"
   integrity sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==
 
-esbuild-darwin-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz#e02b1291f629ebdc2aa46fabfacc9aa28ff6aa46"
-  integrity sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==
-
 esbuild-darwin-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz#4259f23ed6b4cea2ec8a28d87b7fb9801f093754"
   integrity sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==
-
-esbuild-darwin-arm64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz#01eb6650ec010b18c990e443a6abcca1d71290a9"
-  integrity sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==
 
 esbuild-darwin-arm64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz#d77b4366a71d84e530ba019d540b538b295d494a"
   integrity sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==
 
-esbuild-freebsd-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz#790b8786729d4aac7be17648f9ea8e0e16475b5e"
-  integrity sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==
-
 esbuild-freebsd-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz#27b6587b3639f10519c65e07219d249b01f2ad38"
   integrity sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==
-
-esbuild-freebsd-arm64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz#b66340ab28c09c1098e6d9d8ff656db47d7211e6"
-  integrity sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==
 
 esbuild-freebsd-arm64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz#63c435917e566808c71fafddc600aca4d78be1ec"
   integrity sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==
 
-esbuild-linux-32@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz#7927f950986fd39f0ff319e92839455912b67f70"
-  integrity sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==
-
 esbuild-linux-32@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz#c3da774143a37e7f11559b9369d98f11f997a5d9"
   integrity sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==
-
-esbuild-linux-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz#4893d07b229d9cfe34a2b3ce586399e73c3ac519"
-  integrity sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==
 
 esbuild-linux-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz#5d92b67f674e02ae0b4a9de9a757ba482115c4ae"
   integrity sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==
 
-esbuild-linux-arm64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz#8442402e37d0b8ae946ac616784d9c1a2041056a"
-  integrity sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==
-
 esbuild-linux-arm64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz#dac84740516e859d8b14e1ecc478dd5241b10c93"
   integrity sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==
-
-esbuild-linux-arm@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz#d5dbf32d38b7f79be0ec6b5fb2f9251fd9066986"
-  integrity sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==
 
 esbuild-linux-arm@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz#b3ae7000696cd53ed95b2b458554ff543a60e106"
   integrity sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==
 
-esbuild-linux-mips64le@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz#95081e42f698bbe35d8ccee0e3a237594b337eb5"
-  integrity sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==
-
 esbuild-linux-mips64le@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz#dad10770fac94efa092b5a0643821c955a9dd385"
   integrity sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==
-
-esbuild-linux-ppc64le@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz#dceb0a1b186f5df679618882a7990bd422089b47"
-  integrity sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==
 
 esbuild-linux-ppc64le@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz#b68c2f8294d012a16a88073d67e976edd4850ae0"
   integrity sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==
 
-esbuild-linux-riscv64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz#61fb8edb75f475f9208c4a93ab2bfab63821afd2"
-  integrity sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==
-
 esbuild-linux-riscv64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz#608a318b8697123e44c1e185cdf6708e3df50b93"
   integrity sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==
-
-esbuild-linux-s390x@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz#34c7126a4937406bf6a5e69100185fd702d12fe0"
-  integrity sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==
 
 esbuild-linux-s390x@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz#c9e7791170a3295dba79b93aa452beb9838a8625"
   integrity sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==
 
-esbuild-netbsd-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz#322ea9937d9e529183ee281c7996b93eb38a5d95"
-  integrity sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==
-
 esbuild-netbsd-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz#0abd40b8c2e37fda6f5cc41a04cb2b690823d891"
   integrity sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==
-
-esbuild-openbsd-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz#1ca29bb7a2bf09592dcc26afdb45108f08a2cdbd"
-  integrity sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==
 
 esbuild-openbsd-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz#4adba0b7ea7eb1428bb00d8e94c199a949b130e8"
   integrity sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==
 
-esbuild-sunos-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz#c9446f7d8ebf45093e7bb0e7045506a88540019b"
-  integrity sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==
-
 esbuild-sunos-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz#4b8a6d97dfedda30a6e39607393c5c90ebf63891"
   integrity sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==
-
-esbuild-windows-32@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz#f8e9b4602fd0ccbd48e5c8d117ec0ba4040f2ad1"
-  integrity sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==
 
 esbuild-windows-32@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz#d31d8ca0c1d314fb1edea163685a423b62e9ac17"
   integrity sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==
 
-esbuild-windows-64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz#280f58e69f78535f470905ce3e43db1746518107"
-  integrity sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==
-
 esbuild-windows-64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz#7d3c09c8652d222925625637bdc7e6c223e0085d"
   integrity sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==
 
-esbuild-windows-arm64@0.14.38:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz#d97e9ac0f95a4c236d9173fa9f86c983d6a53f54"
-  integrity sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==
-
 esbuild-windows-arm64@0.14.51:
   version "0.14.51"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz#0220d2304bfdc11bc27e19b2aaf56edf183e4ae9"
   integrity sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==
-
-esbuild@^0.14.27:
-  version "0.14.38"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.38.tgz#99526b778cd9f35532955e26e1709a16cca2fb30"
-  integrity sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==
-  optionalDependencies:
-    esbuild-android-64 "0.14.38"
-    esbuild-android-arm64 "0.14.38"
-    esbuild-darwin-64 "0.14.38"
-    esbuild-darwin-arm64 "0.14.38"
-    esbuild-freebsd-64 "0.14.38"
-    esbuild-freebsd-arm64 "0.14.38"
-    esbuild-linux-32 "0.14.38"
-    esbuild-linux-64 "0.14.38"
-    esbuild-linux-arm "0.14.38"
-    esbuild-linux-arm64 "0.14.38"
-    esbuild-linux-mips64le "0.14.38"
-    esbuild-linux-ppc64le "0.14.38"
-    esbuild-linux-riscv64 "0.14.38"
-    esbuild-linux-s390x "0.14.38"
-    esbuild-netbsd-64 "0.14.38"
-    esbuild-openbsd-64 "0.14.38"
-    esbuild-sunos-64 "0.14.38"
-    esbuild-windows-32 "0.14.38"
-    esbuild-windows-64 "0.14.38"
-    esbuild-windows-arm64 "0.14.38"
 
 esbuild@^0.14.47:
   version "0.14.51"
@@ -7405,15 +7279,6 @@ postcss@^8.3.5:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.4.12:
-  version "8.4.12"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
-  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
-  dependencies:
-    nanoid "^3.3.1"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 postcss@^8.4.14:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
@@ -8204,7 +8069,7 @@ rollup@^2.43.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-rollup@^2.59.0, rollup@^2.60.2, rollup@^2.70.2:
+rollup@^2.60.2, rollup@^2.70.2:
   version "2.70.2"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
   integrity sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==
@@ -9563,19 +9428,7 @@ vite-plugin-stylelint@^2.1.0:
   dependencies:
     "@rollup/pluginutils" "^4.2.1"
 
-vite@^2.9.0:
-  version "2.9.6"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-2.9.6.tgz#29f1b33193b0de9e155d67ba0dd097501c3c3281"
-  integrity sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==
-  dependencies:
-    esbuild "^0.14.27"
-    postcss "^8.4.12"
-    resolve "^1.22.0"
-    rollup "^2.59.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-"vite@^2.9.12 || ^3.0.0-0":
+"vite@^2.9.12 || ^3.0.0-0", vite@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/vite/-/vite-3.0.4.tgz#c61688d6b97573e96cf5ac25f2d68597b5ce68e8"
   integrity sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==


### PR DESCRIPTION
This PR adds some unit tests for the custom hooks made for the EPG features.

Also, Vitest is updated because I ran into the following error consistently when using timers:

> Error: [birpc] timeout on calling "onTaskUpdate"

This has been solved recently: https://github.com/vitest-dev/vitest/pull/1379