### PR TITLE
Feat / add live channel e2e tests

### DIFF
--- a/src/components/EpgChannel/EpgChannelItem.tsx
+++ b/src/components/EpgChannel/EpgChannelItem.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWidth, onClick, isActive }) => {
-  const { position, logo } = channel;
+  const { position, logo, uuid } = channel;
   const style = { top: position.top, height: position.height, width: sidebarWidth };
 
   return (
@@ -22,6 +22,7 @@ const EpgChannelItem: React.VFC<Props> = ({ channel, channelItemWidth, sidebarWi
         className={classNames(styles.epgChannel, { [styles.active]: isActive })}
         style={{ width: channelItemWidth }}
         onClick={() => onClick && onClick(channel)}
+        data-testid={uuid}
       >
         <img className={styles.epgChannelLogo} src={logo} alt="Logo" />
       </div>

--- a/src/components/EpgProgramItem/EpgProgramItem.tsx
+++ b/src/components/EpgProgramItem/EpgProgramItem.tsx
@@ -45,6 +45,7 @@ const ProgramItem: React.VFC<Props> = ({ program, onClick, isActive, compact, di
           [styles.disabled]: disabled,
         })}
         style={{ width: styles.width }}
+        data-testid={program.data.id}
       >
         {showImage && <img className={styles.epgProgramImage} src={image} alt="Preview" />}
         {showLiveTagInImage && <div className={styles.epgLiveTag}>{t('live')}</div>}

--- a/src/components/VideoDetails/VideoDetails.tsx
+++ b/src/components/VideoDetails/VideoDetails.tsx
@@ -40,7 +40,7 @@ const VideoDetails: React.FC<Props> = ({
   const isMobile = breakpoint === Breakpoint.xs;
 
   return (
-    <div className={styles.video} data-testid="video-detail">
+    <div className={styles.video} data-testid="video-details">
       <div
         className={classNames(styles.main, styles.mainPadding, {
           [styles.posterNormal]: poster === 'normal',

--- a/src/components/VideoDetails/VideoDetails.tsx
+++ b/src/components/VideoDetails/VideoDetails.tsx
@@ -40,7 +40,7 @@ const VideoDetails: React.FC<Props> = ({
   const isMobile = breakpoint === Breakpoint.xs;
 
   return (
-    <div className={styles.video}>
+    <div className={styles.video} data-testid="video-detail">
       <div
         className={classNames(styles.main, styles.mainPadding, {
           [styles.posterNormal]: poster === 'normal',

--- a/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
 <div>
   <div
     class="video"
-    data-testid="video-detail"
+    data-testid="video-details"
   >
     <div
       class="main mainPadding"

--- a/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
 <div>
   <div
     class="video"
+    data-testid="video-detail"
   >
     <div
       class="main mainPadding"

--- a/test-e2e/codecept.desktop.js
+++ b/test-e2e/codecept.desktop.js
@@ -14,7 +14,7 @@ exports.config = {
   helpers: {
     Playwright: {
       url: 'http://localhost:8080',
-      show: true,
+      show: false,
       channel: 'chrome',
     },
   },

--- a/test-e2e/codecept.desktop.js
+++ b/test-e2e/codecept.desktop.js
@@ -14,7 +14,7 @@ exports.config = {
   helpers: {
     Playwright: {
       url: 'http://localhost:8080',
-      show: false,
+      show: true,
       channel: 'chrome',
     },
   },

--- a/test-e2e/data/config.test--blender.json
+++ b/test-e2e/data/config.test--blender.json
@@ -33,6 +33,11 @@
       "enableText": true,
       "type": "playlist",
       "contentId": "xQaFzykq"
+    },
+    {
+      "enableText": true,
+      "type": "playlist",
+      "contentId": "fWpLtzVh"
     }
   ],
   "menu": [
@@ -47,6 +52,11 @@
       "contentId": "xQaFzykq",
       "type": "playlist",
       "filterTags": "Beginner,Advanced"
+    },
+    {
+      "label": "Live",
+      "contentId": "fWpLtzVh",
+      "type": "playlist"
     }
   ],
   "custom": {},

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -67,7 +67,7 @@ Scenario('I can watch the current live program on the live channel screen', asyn
   I.see('Start watching');
 
   I.click('Start watching');
-  await I.waitForPlayerPlaying('The Flash');
+  I.seeElement('video');
 
   // to make sure the back button is visible and can be clicked on
   I.click('video');
@@ -154,7 +154,7 @@ Scenario('I can select a previous program on the same channel, and watch the vid
   I.see('The Flash', locate('h2').inside(videoDetailLocator));
 
   I.click('Start watching');
-  await I.waitForPlayerPlaying('The Flash');
+  I.seeElement('video');
 });
 
 Scenario('I can select an program on a other channel', async ({ I }) => {

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -1,0 +1,242 @@
+import assert from 'assert';
+
+import constants from '../utils/constants';
+
+const selectedProgramBackgroundColor = 'rgb(204, 204, 204)';
+const liveProgramOutline = 'rgb(255, 255, 255) solid 2px';
+
+const programBackgroundColor = 'rgba(255, 255, 255, 0.08)';
+const programOutline = 'rgb(255, 255, 255) none 0px';
+
+const channel1Id = 'Uh7zcqVm';
+const channel2Id = 'Z2evecey';
+
+const channel1LiveProgramId = 'f99402a4-783d-4298-9ca2-d392db317927';
+const channel1PreviousProgramId = 'a2f80690-86e6-46e7-8a78-b243d5c8237e';
+const channel1UpcomingProgram = '6ffd595b-3cdb-431b-b444-934a0e4f63dc';
+const channel2LiveProgramId = 'b628784b-1061-4a61-98f3-fa48ce3ce81f';
+
+Feature('live channel').retry(3).tag('@desktop-only');
+
+Before(({ I }) => {
+  I.useConfig('test--blender');
+});
+
+const videoDetailLocator = locate({ css: 'div[data-testid="video-detail"]' });
+
+const shelfContainerLocator = locate({ css: 'div[role="row"]' });
+const shelfLocator = locate({ css: 'div[role="cell"]' }).inside(shelfContainerLocator);
+const epgContainer = locate({ css: 'div[data-testid="container"]' });
+const epgProgram = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainer);
+const epgChannel = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainer);
+const amountOfLiveChannels = 5;
+
+Scenario('I can navigate to live channels from the live channels shelf', async ({ I }) => {
+  I.see('Blender');
+  I.see('Agent 327');
+
+  await I.scrollToShelf(constants.playlistLiveChannelId);
+
+  for (let i = 1; i <= amountOfLiveChannels; i++) {
+    I.see(`Channel ${i}`, shelfLocator);
+  }
+
+  I.see('Live Channels');
+  I.click('Play Channel 1');
+
+  // to account for the transition time
+  I.wait(0.4);
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+});
+
+Scenario('I can navigate to live channels from the header', ({ I }) => {
+  I.see('Live');
+  I.click('Live');
+  // to account for the transition time
+  I.wait(0.4);
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+});
+
+Scenario('I can watch the current live program on the live channel screen', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.see('The Daily Show with Trevor Noah: Ears Edition', locate('h2').inside(videoDetailLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.see('Start watching');
+
+  I.click('Start watching');
+  await I.waitForPlayerPlaying('The Flash');
+
+  // to make sure the back button is visible and can be clicked on
+  I.click('video');
+
+  I.click('div[aria-label="Back"]');
+  await I.checkPlayerClosed();
+});
+
+Scenario('I see the epg on the live channel screen', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.see('The Daily Show with Trevor Noah: Ears Edition');
+  I.see('Live');
+
+  I.see('LIVEOn Channel 1');
+  I.see('Start watching');
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
+
+  I.seeElement(epgProgram(channel1PreviousProgramId));
+  await isProgram(I, channel1PreviousProgramId, 'channel 1');
+
+  I.seeElement(epgProgram(channel1UpcomingProgram));
+  await isProgram(I, channel1UpcomingProgram, 'channel 1');
+
+  I.seeElement(epgProgram(channel2LiveProgramId));
+  await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
+
+  I.see('The Flash');
+});
+
+Scenario('I can select a upcoming program on the same channel', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
+
+  I.seeElement(epgProgram(channel1UpcomingProgram));
+  await isProgram(I, channel1UpcomingProgram, 'channel 1');
+
+  I.click(epgProgram(channel1UpcomingProgram));
+
+  // to account for the transition time
+  I.wait(0.4);
+  await isSelectedProgram(I, channel1UpcomingProgram, 'channel 1');
+
+  I.see('The Flash', locate('div').inside(videoDetailLocator));
+
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+
+  I.seeElement(locate('button[disabled]').withText('Start watching'));
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
+});
+
+Scenario('I can select a previous program on the same channel, and watch the video', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
+
+  I.seeElement(epgProgram(channel1PreviousProgramId));
+  await isProgram(I, channel1PreviousProgramId, 'channel 1');
+
+  I.click(epgProgram(channel1PreviousProgramId));
+
+  // to account for the transition time
+  I.wait(0.4);
+  await isSelectedProgram(I, channel1PreviousProgramId, 'channel 1');
+
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
+
+  I.see('The Flash', locate('h2').inside(videoDetailLocator));
+
+  I.click('Start watching');
+  await I.waitForPlayerPlaying('The Flash');
+});
+
+Scenario('I can select an program on a other channel', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.click(epgChannel(channel2Id));
+
+  // to account for the transition time
+  I.wait(0.4);
+
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+
+  I.see('The Flash', locate('h2').inside(videoDetailLocator));
+  I.see('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
+
+  I.seeElement(epgProgram(channel2LiveProgramId));
+  await isSelectedProgram(I, channel2LiveProgramId, 'channel 2');
+
+  I.click(epgChannel(channel1Id));
+  // to account for the transition time
+  I.wait(0.4);
+  I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+});
+
+Scenario('I can navigate through the epg', async ({ I }) => {
+  I.mockTimeAs('10:00:00');
+
+  I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
+
+  I.see('The Silent Sea');
+  I.dontSee('House');
+
+  // to account for the transition time of smooth scroll
+  I.wait(1);
+  I.click('Slide right');
+
+  I.dontSee('The Silent Sea');
+  I.see('Peaky Blinders');
+
+  I.click('Slide right');
+  // to account for the transition time
+  I.wait(0.5);
+
+  I.dontSee('Euphoria');
+  I.see('Peaky Blinders');
+
+  I.click('Now');
+
+  // to account for the transition time
+  I.wait(0.5);
+
+  I.seeElement(epgProgram(channel1LiveProgramId));
+  await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
+
+  I.seeElement(epgProgram(channel2LiveProgramId));
+  await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
+});
+
+async function isSelectedProgram(I: CodeceptJS.I, programId: string, channel: string) {
+  await checkStyle(I, epgProgram(programId), { 'background-color': selectedProgramBackgroundColor, outline: liveProgramOutline });
+  I.say(`I see the program is selected on ${channel}`);
+}
+
+async function isLiveProgram(I: CodeceptJS.I, programId: string, channel: string) {
+  await checkStyle(I, epgProgram(programId), { 'background-color': programBackgroundColor, outline: liveProgramOutline });
+  I.say(`I see the program is live on ${channel}`);
+}
+
+async function isProgram(I: CodeceptJS.I, programId: string, channel: string) {
+  await checkStyle(I, epgProgram(programId), { 'background-color': programBackgroundColor, outline: programOutline });
+  I.say(`I see the program is not active nor selected on ${channel}`);
+}
+
+async function checkStyle(I: CodeceptJS.I, locator: CodeceptJS.LocatorOrString, styles: Record<string, string>) {
+  for (const style in styles) {
+    const value = await I.grabCssPropertyFrom(locator, style);
+
+    assert.strictEqual(styles[style], value);
+  }
+
+  return true;
+}

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -3,10 +3,10 @@ import assert from 'assert';
 import constants from '../utils/constants';
 
 const programSelectedBackgroundColor = 'rgb(204, 204, 204)';
-const programLiveOutline = 'rgb(255, 255, 255) solid 2px';
+const programLiveBorder = '2px solid rgb(255, 255, 255)';
 
 const programBackgroundColor = 'rgba(255, 255, 255, 0.08)';
-const programOutline = 'rgb(255, 255, 255) none 0px';
+const programBorder = '2px solid rgba(0, 0, 0, 0)';
 
 const channel1Id = 'Uh7zcqVm';
 const channel2Id = 'Z2evecey';
@@ -22,13 +22,13 @@ Before(({ I }) => {
   I.useConfig('test--blender');
 });
 
-const videoDetailLocator = locate({ css: 'div[data-testid="video-details"]' });
+const videoDetailsLocator = locate({ css: 'div[data-testid="video-details"]' });
 
 const shelfContainerLocator = locate({ css: 'div[role="row"]' });
 const shelfLocator = locate({ css: 'div[role="cell"]' }).inside(shelfContainerLocator);
 const epgContainerLocator = locate({ css: 'div[data-testid="container"]' });
-const makeEpgProgram = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
-const makeEpgChannel = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
+const makeEpgProgramLocator = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
+const makeEpgChannelLocator = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
 const liveChannelsCount = 5;
 
 Scenario('I can navigate to live channels from the live channels shelf', async ({ I }) => {
@@ -45,7 +45,7 @@ Scenario('I can navigate to live channels from the live channels shelf', async (
   I.click('Play Channel 1');
 
   waitForEpgAnimation(I);
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can navigate to live channels from the header', ({ I }) => {
@@ -53,7 +53,7 @@ Scenario('I can navigate to live channels from the header', ({ I }) => {
   I.click('Live');
 
   waitForEpgAnimation(I);
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can watch the current live program on the live channel screen', async ({ I }) => {
@@ -62,9 +62,10 @@ Scenario('I can watch the current live program on the live channel screen', asyn
   // pause();
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.see('The Daily Show with Trevor Noah: Ears Edition', locate('h2').inside(videoDetailLocator));
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.see('The Daily Show with Trevor Noah: Ears Edition', locate('h2').inside(videoDetailsLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
   I.see('Start watching');
+  I.see('Watch from begin');
 
   I.click('Start watching');
   I.seeElement('video');
@@ -87,16 +88,16 @@ Scenario('I see the epg on the live channel screen', async ({ I }) => {
   I.see('LIVEOn Channel 1');
   I.see('Start watching');
 
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel1PreviousProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1PreviousProgramId));
   await isProgram(I, channel1PreviousProgramId, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel1UpcomingProgram));
+  I.seeElement(makeEpgProgramLocator(channel1UpcomingProgram));
   await isProgram(I, channel1UpcomingProgram, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel2LiveProgramId));
   await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
 
   I.see('The Flash');
@@ -107,24 +108,24 @@ Scenario('I can select an upcoming program on the same channel', async ({ I }) =
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel1UpcomingProgram));
+  I.seeElement(makeEpgProgramLocator(channel1UpcomingProgram));
   await isProgram(I, channel1UpcomingProgram, 'channel 1');
 
-  I.click(makeEpgProgram(channel1UpcomingProgram));
+  I.click(makeEpgProgramLocator(channel1UpcomingProgram));
 
   waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1UpcomingProgram, 'channel 1');
 
-  I.see('The Flash', locate('div').inside(videoDetailLocator));
+  I.see('The Flash', locate('div').inside(videoDetailsLocator));
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 
   I.seeElement(locate('button[disabled]').withText('Start watching'));
 
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
 });
 
@@ -133,23 +134,23 @@ Scenario('I can select a previous program on the same channel and watch the vide
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel1PreviousProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1PreviousProgramId));
   await isProgram(I, channel1PreviousProgramId, 'channel 1');
 
-  I.click(makeEpgProgram(channel1PreviousProgramId));
+  I.click(makeEpgProgramLocator(channel1PreviousProgramId));
 
   waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1PreviousProgramId, 'channel 1');
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.see('The Flash', locate('h2').inside(videoDetailLocator));
+  I.see('The Flash', locate('h2').inside(videoDetailsLocator));
 
   I.click('Start watching');
   I.seeElement('video');
@@ -160,22 +161,22 @@ Scenario('I can select a program on another channel', async ({ I }) => {
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.click(makeEpgChannel(channel2Id));
+  I.click(makeEpgChannelLocator(channel2Id));
 
   waitForEpgAnimation(I);
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 
-  I.see('The Flash', locate('h2').inside(videoDetailLocator));
-  I.see('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
+  I.see('The Flash', locate('h2').inside(videoDetailsLocator));
+  I.see('LIVEOn Channel 2', locate('div').inside(videoDetailsLocator));
 
-  I.seeElement(makeEpgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel2LiveProgramId));
   await isSelectedProgram(I, channel2LiveProgramId, 'channel 2');
 
-  I.click(makeEpgChannel(channel1Id));
+  I.click(makeEpgChannelLocator(channel1Id));
   waitForEpgAnimation(I);
-  I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
+  I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailsLocator));
+  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can navigate through the epg', async ({ I }) => {
@@ -201,25 +202,34 @@ Scenario('I can navigate through the epg', async ({ I }) => {
   I.click('Now');
 
   waitForEpgAnimation(I);
-  I.seeElement(makeEpgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(makeEpgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgramLocator(channel2LiveProgramId));
   await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
 });
 
 async function isSelectedProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programSelectedBackgroundColor, outline: programLiveOutline });
+  await checkStyle(I, makeEpgProgramLocator(programId), {
+    'background-color': programSelectedBackgroundColor,
+    border: programLiveBorder,
+  });
   I.say(`I see the program is selected on ${channel}`);
 }
 
 async function isLiveProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programBackgroundColor, outline: programLiveOutline });
+  await checkStyle(I, makeEpgProgramLocator(programId), {
+    'background-color': programBackgroundColor,
+    border: programLiveBorder,
+  });
   I.say(`I see the program is live on ${channel}`);
 }
 
 async function isProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programBackgroundColor, outline: programOutline });
+  await checkStyle(I, makeEpgProgramLocator(programId), {
+    'background-color': programBackgroundColor,
+    border: programBorder,
+  });
   I.say(`I see the program is not active nor selected on ${channel}`);
 }
 

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -2,8 +2,8 @@ import assert from 'assert';
 
 import constants from '../utils/constants';
 
-const selectedProgramBackgroundColor = 'rgb(204, 204, 204)';
-const liveProgramOutline = 'rgb(255, 255, 255) solid 2px';
+const programSelectedBackgroundColor = 'rgb(204, 204, 204)';
+const programLiveOutline = 'rgb(255, 255, 255) solid 2px';
 
 const programBackgroundColor = 'rgba(255, 255, 255, 0.08)';
 const programOutline = 'rgb(255, 255, 255) none 0px';
@@ -22,14 +22,14 @@ Before(({ I }) => {
   I.useConfig('test--blender');
 });
 
-const videoDetailLocator = locate({ css: 'div[data-testid="video-detail"]' });
+const videoDetailLocator = locate({ css: 'div[data-testid="video-details"]' });
 
 const shelfContainerLocator = locate({ css: 'div[role="row"]' });
 const shelfLocator = locate({ css: 'div[role="cell"]' }).inside(shelfContainerLocator);
-const epgContainer = locate({ css: 'div[data-testid="container"]' });
-const epgProgram = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainer);
-const epgChannel = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainer);
-const amountOfLiveChannels = 5;
+const epgContainerLocator = locate({ css: 'div[data-testid="container"]' });
+const makeEpgProgram = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
+const makeEpgChannel = (id: string) => locate({ css: `div[data-testid="${id}"]` }).inside(epgContainerLocator);
+const liveChannelsCount = 5;
 
 Scenario('I can navigate to live channels from the live channels shelf', async ({ I }) => {
   I.see('Blender');
@@ -37,7 +37,7 @@ Scenario('I can navigate to live channels from the live channels shelf', async (
 
   await I.scrollToShelf(constants.playlistLiveChannelId);
 
-  for (let i = 1; i <= amountOfLiveChannels; i++) {
+  for (let i = 1; i <= liveChannelsCount; i++) {
     I.see(`Channel ${i}`, shelfLocator);
   }
 
@@ -57,8 +57,9 @@ Scenario('I can navigate to live channels from the header', ({ I }) => {
 });
 
 Scenario('I can watch the current live program on the live channel screen', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
-
+  await I.mockTimeAs(8, 0, 0);
+  // eslint-disable-next-line codeceptjs/no-pause-in-scenario
+  // pause();
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
   I.see('The Daily Show with Trevor Noah: Ears Edition', locate('h2').inside(videoDetailLocator));
@@ -76,7 +77,7 @@ Scenario('I can watch the current live program on the live channel screen', asyn
 });
 
 Scenario('I see the epg on the live channel screen', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
+  await I.mockTimeAs(8, 0, 0);
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
@@ -86,33 +87,33 @@ Scenario('I see the epg on the live channel screen', async ({ I }) => {
   I.see('LIVEOn Channel 1');
   I.see('Start watching');
 
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(epgProgram(channel1PreviousProgramId));
+  I.seeElement(makeEpgProgram(channel1PreviousProgramId));
   await isProgram(I, channel1PreviousProgramId, 'channel 1');
 
-  I.seeElement(epgProgram(channel1UpcomingProgram));
+  I.seeElement(makeEpgProgram(channel1UpcomingProgram));
   await isProgram(I, channel1UpcomingProgram, 'channel 1');
 
-  I.seeElement(epgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgram(channel2LiveProgramId));
   await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
 
   I.see('The Flash');
 });
 
-Scenario('I can select a upcoming program on the same channel', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
+Scenario('I can select an upcoming program on the same channel', async ({ I }) => {
+  await I.mockTimeAs(8, 0, 0);
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(epgProgram(channel1UpcomingProgram));
+  I.seeElement(makeEpgProgram(channel1UpcomingProgram));
   await isProgram(I, channel1UpcomingProgram, 'channel 1');
 
-  I.click(epgProgram(channel1UpcomingProgram));
+  I.click(makeEpgProgram(channel1UpcomingProgram));
 
   waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1UpcomingProgram, 'channel 1');
@@ -123,29 +124,29 @@ Scenario('I can select a upcoming program on the same channel', async ({ I }) =>
 
   I.seeElement(locate('button[disabled]').withText('Start watching'));
 
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
 });
 
-Scenario('I can select a previous program on the same channel, and watch the video', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
+Scenario('I can select a previous program on the same channel and watch the video', async ({ I }) => {
+  await I.mockTimeAs(8, 0, 0);
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(epgProgram(channel1PreviousProgramId));
+  I.seeElement(makeEpgProgram(channel1PreviousProgramId));
   await isProgram(I, channel1PreviousProgramId, 'channel 1');
 
-  I.click(epgProgram(channel1PreviousProgramId));
+  I.click(makeEpgProgram(channel1PreviousProgramId));
 
   waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1PreviousProgramId, 'channel 1');
 
   I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isLiveProgram(I, channel1LiveProgramId, 'channel 1');
 
   I.see('The Flash', locate('h2').inside(videoDetailLocator));
@@ -154,12 +155,12 @@ Scenario('I can select a previous program on the same channel, and watch the vid
   I.seeElement('video');
 });
 
-Scenario('I can select an program on a other channel', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
+Scenario('I can select a program on another channel', async ({ I }) => {
+  await I.mockTimeAs(8, 0, 0);
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
-  I.click(epgChannel(channel2Id));
+  I.click(makeEpgChannel(channel2Id));
 
   waitForEpgAnimation(I);
 
@@ -168,17 +169,17 @@ Scenario('I can select an program on a other channel', async ({ I }) => {
   I.see('The Flash', locate('h2').inside(videoDetailLocator));
   I.see('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
 
-  I.seeElement(epgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgram(channel2LiveProgramId));
   await isSelectedProgram(I, channel2LiveProgramId, 'channel 2');
 
-  I.click(epgChannel(channel1Id));
+  I.click(makeEpgChannel(channel1Id));
   waitForEpgAnimation(I);
   I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
   I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 });
 
 Scenario('I can navigate through the epg', async ({ I }) => {
-  I.mockTimeAs('10:00:00');
+  await I.mockTimeAs(8, 0, 0);
 
   I.amOnPage(`${constants.baseUrl}p/${constants.playlistLiveChannelId}`);
 
@@ -200,25 +201,25 @@ Scenario('I can navigate through the epg', async ({ I }) => {
   I.click('Now');
 
   waitForEpgAnimation(I);
-  I.seeElement(epgProgram(channel1LiveProgramId));
+  I.seeElement(makeEpgProgram(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
-  I.seeElement(epgProgram(channel2LiveProgramId));
+  I.seeElement(makeEpgProgram(channel2LiveProgramId));
   await isLiveProgram(I, channel2LiveProgramId, 'channel 2');
 });
 
 async function isSelectedProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, epgProgram(programId), { 'background-color': selectedProgramBackgroundColor, outline: liveProgramOutline });
+  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programSelectedBackgroundColor, outline: programLiveOutline });
   I.say(`I see the program is selected on ${channel}`);
 }
 
 async function isLiveProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, epgProgram(programId), { 'background-color': programBackgroundColor, outline: liveProgramOutline });
+  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programBackgroundColor, outline: programLiveOutline });
   I.say(`I see the program is live on ${channel}`);
 }
 
 async function isProgram(I: CodeceptJS.I, programId: string, channel: string) {
-  await checkStyle(I, epgProgram(programId), { 'background-color': programBackgroundColor, outline: programOutline });
+  await checkStyle(I, makeEpgProgram(programId), { 'background-color': programBackgroundColor, outline: programOutline });
   I.say(`I see the program is not active nor selected on ${channel}`);
 }
 

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -44,16 +44,15 @@ Scenario('I can navigate to live channels from the live channels shelf', async (
   I.see('Live Channels');
   I.click('Play Channel 1');
 
-  // to account for the transition time
-  I.wait(0.4);
+  waitForEpgAnimation(I);
   I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 });
 
 Scenario('I can navigate to live channels from the header', ({ I }) => {
   I.see('Live');
   I.click('Live');
-  // to account for the transition time
-  I.wait(0.4);
+
+  waitForEpgAnimation(I);
   I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 });
 
@@ -115,8 +114,7 @@ Scenario('I can select a upcoming program on the same channel', async ({ I }) =>
 
   I.click(epgProgram(channel1UpcomingProgram));
 
-  // to account for the transition time
-  I.wait(0.4);
+  waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1UpcomingProgram, 'channel 1');
 
   I.see('The Flash', locate('div').inside(videoDetailLocator));
@@ -142,8 +140,7 @@ Scenario('I can select a previous program on the same channel, and watch the vid
 
   I.click(epgProgram(channel1PreviousProgramId));
 
-  // to account for the transition time
-  I.wait(0.4);
+  waitForEpgAnimation(I);
   await isSelectedProgram(I, channel1PreviousProgramId, 'channel 1');
 
   I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
@@ -164,8 +161,7 @@ Scenario('I can select an program on a other channel', async ({ I }) => {
 
   I.click(epgChannel(channel2Id));
 
-  // to account for the transition time
-  I.wait(0.4);
+  waitForEpgAnimation(I);
 
   I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 
@@ -176,8 +172,7 @@ Scenario('I can select an program on a other channel', async ({ I }) => {
   await isSelectedProgram(I, channel2LiveProgramId, 'channel 2');
 
   I.click(epgChannel(channel1Id));
-  // to account for the transition time
-  I.wait(0.4);
+  waitForEpgAnimation(I);
   I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailLocator));
   I.see('LIVEOn Channel 1', locate('div').inside(videoDetailLocator));
 });
@@ -190,25 +185,21 @@ Scenario('I can navigate through the epg', async ({ I }) => {
   I.see('The Silent Sea');
   I.dontSee('House');
 
-  // to account for the transition time of smooth scroll
-  I.wait(1);
+  waitForEpgAnimation(I);
   I.click('Slide right');
 
   I.dontSee('The Silent Sea');
   I.see('Peaky Blinders');
 
   I.click('Slide right');
-  // to account for the transition time
-  I.wait(0.5);
 
+  waitForEpgAnimation(I);
   I.dontSee('Euphoria');
   I.see('Peaky Blinders');
 
   I.click('Now');
 
-  // to account for the transition time
-  I.wait(0.5);
-
+  waitForEpgAnimation(I);
   I.seeElement(epgProgram(channel1LiveProgramId));
   await isSelectedProgram(I, channel1LiveProgramId, 'channel 1');
 
@@ -239,4 +230,8 @@ async function checkStyle(I: CodeceptJS.I, locator: CodeceptJS.LocatorOrString, 
   }
 
   return true;
+}
+
+function waitForEpgAnimation(I: CodeceptJS.I, sec: number = 1) {
+  return I.wait(sec);
 }

--- a/test-e2e/utils/constants.ts
+++ b/test-e2e/utils/constants.ts
@@ -22,4 +22,5 @@ export default {
   agent327Description:
     'Hendrik IJzerbroot – Agent 327 – is a secret agent working for the Netherlands secret service agency. In the twenty comic books that were published since 1968, Martin Lodewijk created a rich universe with international conspiracies, hilarious characters and a healthy dose of Dutch humour.',
   bigBuckBunnyDetailUrl: `${baseUrl}m/awWEFyPu/big-buck-bunny?r=${filmsPlaylistId}`,
+  playlistLiveChannelId: 'fWpLtzVh',
 };

--- a/test-e2e/utils/steps_file.ts
+++ b/test-e2e/utils/steps_file.ts
@@ -258,10 +258,10 @@ const stepsObj = {
 
     this.scrollTo(targetSelector);
   },
-  mockTimeAs: async function (this: CodeceptJS.I, time: string, locale: string = 'nl-NL') {
-    return this.usePlaywrightTo(`Mock current time as ${time}`, async ({ page }) => {
-      const currentDate = new Date().toLocaleDateString(locale);
-      const mockedNow = new Date(`${currentDate} ${time}`).valueOf();
+  mockTimeAs: async function (this: CodeceptJS.I, hours: number, minutes: number, seconds: number) {
+    return this.usePlaywrightTo(`Mock current time as ${hours}:${minutes}:${seconds}`, async ({ page }) => {
+      const today = new Date().setUTCHours(hours, minutes, seconds, 0);
+      const mockedNow = today.valueOf();
 
       await page.addInitScript(`{
         // Extend Date constructor to default to mockedNow

--- a/test-e2e/utils/steps_file.ts
+++ b/test-e2e/utils/steps_file.ts
@@ -258,9 +258,9 @@ const stepsObj = {
 
     this.scrollTo(targetSelector);
   },
-  mockTimeAs: async function (this: CodeceptJS.I, time: string) {
+  mockTimeAs: async function (this: CodeceptJS.I, time: string, locale: string = 'nl-NL') {
     return this.usePlaywrightTo(`Mock current time as ${time}`, async ({ page }) => {
-      const currentDate = new Date().toISOString().split('T')[0];
+      const currentDate = new Date().toLocaleDateString(locale);
       const mockedNow = new Date(`${currentDate} ${time}`).valueOf();
 
       await page.addInitScript(`{

--- a/test-e2e/utils/steps_file.ts
+++ b/test-e2e/utils/steps_file.ts
@@ -239,6 +239,48 @@ const stepsObj = {
   writeClipboard: async function (this: CodeceptJS.I, text: string) {
     await this.executeScript((text) => navigator.clipboard.writeText(text), text);
   },
+  scrollToShelf: async function (this: CodeceptJS.I, playlistId: string) {
+    const targetSelector = `[data-mediaid="${playlistId}"]`;
+
+    let tries = 5;
+    let visible = 0;
+
+    do {
+      visible = await this.grabNumberOfVisibleElements(targetSelector);
+
+      if (visible === 0) {
+        this.scrollTo('[role="row"]:last-child');
+        this.wait(0.2);
+      }
+    } while (visible === 0 && tries--);
+
+    assert.strictEqual(visible, 1, `Shelf row not found with id '${playlistId}'`);
+
+    this.scrollTo(targetSelector);
+  },
+  mockTimeAs: async function (this: CodeceptJS.I, time: string) {
+    return this.usePlaywrightTo(`Mock current time as ${time}`, async ({ page }) => {
+      const currentDate = new Date().toISOString().split('T')[0];
+      const mockedNow = new Date(`${currentDate} ${time}`).valueOf();
+
+      await page.addInitScript(`{
+        // Extend Date constructor to default to mockedNow
+        Date = class extends Date {
+          constructor(...args) {
+            if (args.length === 0) {
+              super(${mockedNow});
+            } else {
+              super(...args);
+            }
+          }
+        }
+        // Override Date.now() to start from mockedNow
+        const __DateNowOffset = ${mockedNow} - Date.now();
+        const __DateNow = Date.now;
+        Date.now = () => __DateNow() + __DateNowOffset;
+      }`);
+    });
+  },
 };
 declare global {
   type Steps = typeof stepsObj;


### PR DESCRIPTION
## Description

This PR adds:

- Date mocker for end2end test
- Scroll to shelf util for end2end test
- live channel e2e tests scenario's (desktop only)
   - Navigate from live channels shelf to live channel screen
   - Navigate header to live channel screen
   - Watch the current live program on the live channel screen
   - Validation Epg live programs, selected program, previous program and up next program
   - Basic epg navigation

Notes:
-  Mobile tests should be added, most of the tests will be fine but I didn't have time to check which ones are stable so excluded them all.
-  Replace the `checkElement('video')` with `waitForPlayerPlaying` 
    I couldn't check if the video is playable without the tests becoming flaky. 
    Because of the limited time-window of the stream's 
   



   

