### PR TITLE
fix(project): home button always in active state

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -56,7 +56,7 @@ const Button: React.FC<Props> = ({
   const span = <span className={styles.buttonLabel}>{label}</span>;
 
   return to ? (
-    <NavLink className={({ isActive }) => buttonClassName(isActive)} to={to} {...rest}>
+    <NavLink className={({ isActive }) => buttonClassName(isActive)} to={to} {...rest} end>
       {icon}
       {span}
       {children}

--- a/src/components/MenuButton/MenuButton.tsx
+++ b/src/components/MenuButton/MenuButton.tsx
@@ -25,6 +25,7 @@ const MenuButton: React.FC<Props> = ({ label, to, onClick, tabIndex = 0, active 
         onClick={onClick}
         to={to}
         tabIndex={tabIndex}
+        end
       >
         {icon}
         <span className={styles.label}>{label}</span>


### PR DESCRIPTION
The home button in the menu and header was always in the active state. This was fixed by adding the `<NavLink />` end prop.

https://reactrouter.com/en/v6.3.0/api#navlink
