### PR TITLE
Fix / infinite scroll not rendering all content

### DIFF
--- a/src/components/CardGrid/CardGrid.tsx
+++ b/src/components/CardGrid/CardGrid.tsx
@@ -94,7 +94,7 @@ function CardGrid({
     <InfiniteScroll
       pageStart={0}
       loadMore={() => setRowCount((current) => current + LOAD_ROWS_COUNT)}
-      hasMore={rowCount * LOAD_ROWS_COUNT < playlist.playlist.length - 1}
+      hasMore={rowCount * visibleTiles < playlist.playlist.length}
       loader={<InfiniteScrollLoader key="loader" />}
     >
       <div className={classNames(styles.container, styles[`cols-${visibleTiles}`])} role="grid">

--- a/src/containers/ShelfList/ShelfList.tsx
+++ b/src/containers/ShelfList/ShelfList.tsx
@@ -64,7 +64,7 @@ const ShelfList = ({ rows }: Props) => {
         pageStart={0}
         style={{ overflow: 'hidden' }}
         loadMore={() => setRowCount((current) => current + LOAD_ROWS_COUNT)}
-        hasMore={rowCount < rows.length - 1}
+        hasMore={rowCount < rows.length}
         role="grid"
         loader={<InfiniteScrollLoader key="loader" />}
       >

--- a/test-e2e/tests/home_test.ts
+++ b/test-e2e/tests/home_test.ts
@@ -95,8 +95,8 @@ Scenario('I can slide within non-featured shelves', async ({ I }) => {
   const rightMedia = isDesktop
     ? { name: 'Cosmos Laundromat', duration: '13 min' }
     : {
-        name: 'Big Buck Bunny',
-        duration: '10 min',
+        name: 'Elephants Dream',
+        duration: '11 min',
       };
 
   I.see('All Films');


### PR DESCRIPTION
Two small fixes:

1) Since posterAspect we're rendering two cards on mobile. The expected card on mobile is shifted by 1.
2) Fixed the `hasMore` calculations in the ShelfList and CardGrid components