### PR TITLE
chore: increase codecept wait-on timeout

### DIFF
--- a/.github/workflows/codeceptjs.yml
+++ b/.github/workflows/codeceptjs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Start preview server
         run: yarn start:test &
       - name: Run tests
-        run: wait-on -v -t 30000 -c ./scripts/waitOnConfig.js http-get://localhost:8080 && yarn codecept:${{ matrix.config }}
+        run: wait-on -v -t 60000 -c ./scripts/waitOnConfig.js http-get://localhost:8080 && yarn codecept:${{ matrix.config }}
         env:
           TEST_RETRY_COUNT: 2
           WORKER_COUNT: 2


### PR DESCRIPTION
## Description

Since refactoring the e2e tests to do a build and then vite preview, we've had a couple timeouts waiting for the app to spin up.  So I increase the timeout from 30s to 60s.

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [x] Unit tests added
- [x] Docs updated (including config and env variables)
- [x] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
