### PR TITLE
chore: add inplayer configs, add config workaround, add preview mode

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build
-        run: yarn && yarn build --mode demo
+        run: yarn && yarn build --mode preview
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/ini/.webapp.dev.ini
+++ b/ini/.webapp.dev.ini
@@ -1,4 +1,0 @@
-; This is a basic Blender demo
-defaultConfigSource = gnnuzabk
-; When developing, switching between configs is useful for test and debug
-UNSAFE_allowAnyConfigSource = true

--- a/ini/templates/.webapp.preview.ini
+++ b/ini/templates/.webapp.preview.ini
@@ -1,0 +1,4 @@
+; No default so it behaves like demo mode
+defaultConfigSource =
+; Allow any config
+UNSAFE_allowAnyConfigSource = true

--- a/src/components/DevConfigSelector/DevConfigSelector.tsx
+++ b/src/components/DevConfigSelector/DevConfigSelector.tsx
@@ -14,7 +14,7 @@ interface Props {
 const configs = import.meta.env.MODE === 'jwdev' ? jwDevEnvConfigs : testConfigs;
 const configOptions: { value: string; label: string }[] = [
   { label: 'Select an App Config', value: '' },
-  ...Object.values(configs).map(({ id, label }) => ({ value: id, label: `${id} - ${label}` })),
+  ...Object.values(configs).map(({ id, label }) => ({ value: id, label: `${id.length > 8 ? 'ext-json' : id} - ${label}` })),
 ];
 
 const DevConfigSelector = ({ selectedConfig }: Props) => {

--- a/src/components/ErrorPage/ErrorPage.tsx
+++ b/src/components/ErrorPage/ErrorPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import styles from './ErrorPage.module.scss';
 
-import { IS_DEMO_MODE, IS_DEVELOPMENT_BUILD } from '#src/utils/common';
+import { IS_DEMO_MODE, IS_DEVELOPMENT_BUILD, IS_PREVIEW_MODE } from '#src/utils/common';
 import DevStackTrace from '#components/DevStackTrace/DevStackTrace';
 import { useConfigStore } from '#src/stores/ConfigStore';
 import { getPublicUrl } from '#src/utils/domHelpers';
@@ -44,12 +44,12 @@ export const ErrorPageWithoutTranslation = ({ title, children, message, learnMor
         <main className={styles.main}>
           <>
             {children || <p>{message || 'Try refreshing this page or come back later.'}</p>}
-            {(IS_DEVELOPMENT_BUILD || IS_DEMO_MODE) && helpLink && (
+            {(IS_DEVELOPMENT_BUILD || IS_DEMO_MODE || IS_PREVIEW_MODE) && helpLink && (
               <p className={styles.links}>
                 <a href={helpLink} target={'_blank'} rel={'noreferrer'}>
                   {learnMoreLabel || 'Learn More'}
                 </a>
-                {IS_DEVELOPMENT_BUILD && error?.stack && (
+                {(IS_DEVELOPMENT_BUILD || IS_PREVIEW_MODE) && error?.stack && (
                   <span className={styles.stack}>
                     <DevStackTrace error={error} />
                   </span>

--- a/src/components/Root/Root.tsx
+++ b/src/components/Root/Root.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'react-router-dom';
 
 import ErrorPage from '#components/ErrorPage/ErrorPage';
 import AccountModal from '#src/containers/AccountModal/AccountModal';
-import { IS_DEMO_MODE, IS_DEVELOPMENT_BUILD } from '#src/utils/common';
+import { IS_DEMO_MODE, IS_DEVELOPMENT_BUILD, IS_PREVIEW_MODE } from '#src/utils/common';
 import DemoConfigDialog from '#components/DemoConfigDialog/DemoConfigDialog';
 import LoadingOverlay from '#components/LoadingOverlay/LoadingOverlay';
 import DevConfigSelector from '#components/DevConfigSelector/DevConfigSelector';
@@ -40,8 +40,10 @@ const Root: FC = () => {
     refetchInterval: false,
   });
 
+  const IS_DEMO_OR_PREVIEW = IS_DEMO_MODE || IS_PREVIEW_MODE;
+
   // Show the spinner while loading except in demo mode (the demo config shows its own loading status)
-  if (settingsQuery.isLoading || (!IS_DEMO_MODE && configQuery.isLoading)) {
+  if (settingsQuery.isLoading || (!IS_DEMO_OR_PREVIEW && configQuery.isLoading)) {
     return <LoadingOverlay />;
   }
 
@@ -60,7 +62,7 @@ const Root: FC = () => {
     <>
       {!configQuery.isError && !configQuery.isLoading && <AppRoutes />}
       {/*Show the error page when error except in demo mode (the demo mode shows its own error)*/}
-      {configQuery.isError && !IS_DEMO_MODE && (
+      {configQuery.isError && !IS_DEMO_OR_PREVIEW && (
         <ErrorPage
           title={t('config_invalid')}
           message={t('check_your_config')}
@@ -68,10 +70,10 @@ const Root: FC = () => {
           helpLink={'https://github.com/jwplayer/ott-web-app/blob/develop/docs/configuration.md'}
         />
       )}
-      {IS_DEMO_MODE && <DemoConfigDialog selectedConfigSource={configSource} configQuery={configQuery} />}
+      {IS_DEMO_OR_PREVIEW && <DemoConfigDialog selectedConfigSource={configSource} configQuery={configQuery} />}
       <AccountModal />
       {/* Config select control to improve testing experience */}
-      {IS_DEVELOPMENT_BUILD && <DevConfigSelector selectedConfig={configSource} />}
+      {(IS_DEVELOPMENT_BUILD || IS_PREVIEW_MODE) && <DevConfigSelector selectedConfig={configSource} />}
     </>
   );
 };

--- a/src/i18n/locales/en_US/demo.json
+++ b/src/i18n/locales/en_US/demo.json
@@ -3,7 +3,7 @@
   "cancel_config_id": "Cancel",
   "click_to_unselect_config": "(click here to unselect this config)",
   "currently_previewing_config": "You are currently previewing config: '{{configSource}}'",
-  "demo_note": "Note: The chosen app config will be temporarily stored in this browser only. Close the tab or use the link at the bottom of the main page to clear the setting and return to this dialog.",
+  "demo_note": "Note: The chosen app config ID will be stored locally in this browser only. Use the link at the bottom of the main page to clear the setting and return to this dialog.",
   "enter_8_digits": "The App Config ID should be 8 digits long. Please correct your input and try again.",
   "enter_a_value": "Please enter an App Config ID",
   "invalid_config_id_format": "The App Config ID should consist of only numbers and lowercase letters. Please check your input and then try again.",

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -110,6 +110,15 @@ const enrichConfig = (config: Config): Config => {
   const { content, siteName } = config;
   const updatedContent = content.map((content) => Object.assign({ enableText: true, featured: false }, content));
 
+  // TODO: Remove this once the inplayer integration structure is added to the dashboard
+  if (!config.integrations.inplayer?.clientId && config.custom?.['inplayer.clientId']) {
+    config.integrations.inplayer = {
+      clientId: config.custom?.['inplayer.clientId'] as string,
+      assetId: Number(config.custom?.['inplayer.assetId']),
+      useSandbox: ['true', '1', 'yes'].indexOf((config.custom?.['inplayer.useSandbox'] as string)?.toLowerCase()) >= 0,
+    };
+  }
+
   return { ...config, siteName: siteName || i18next.t('common:default_site_name'), content: updatedContent };
 };
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -54,11 +54,15 @@ export function calculateContrastColor(color: string) {
 // Build is either Development or Production
 // Mode can be dev, jwdev, demo, test, prod, etc.
 export const IS_DEVELOPMENT_BUILD = import.meta.env.DEV;
+// Demo mode is used to run our firebase demo instance
 export const IS_DEMO_MODE = import.meta.env.MODE === 'demo';
+// Test mode is used for e2e and unit tests
 export const IS_TEST_MODE = import.meta.env.MODE === 'test';
+// Preview mode is used for previewing Pull Requests on github
+export const IS_PREVIEW_MODE = import.meta.env.MODE === 'preview';
 
 export function logDev(message: unknown, ...optionalParams: unknown[]) {
-  if (IS_DEVELOPMENT_BUILD) {
+  if (IS_DEVELOPMENT_BUILD || IS_PREVIEW_MODE) {
     if (optionalParams.length > 0) {
       console.info(message, optionalParams);
     } else {
@@ -68,7 +72,7 @@ export function logDev(message: unknown, ...optionalParams: unknown[]) {
 }
 
 export function getOverrideIP() {
-  if (!IS_TEST_MODE && !IS_DEVELOPMENT_BUILD) {
+  if (!IS_TEST_MODE && !IS_DEVELOPMENT_BUILD && !IS_PREVIEW_MODE) {
     return undefined;
   }
 
@@ -80,5 +84,5 @@ export function getOverrideIP() {
 }
 
 export function testId(value: string | undefined) {
-  return IS_DEVELOPMENT_BUILD || IS_TEST_MODE ? value : undefined;
+  return IS_DEVELOPMENT_BUILD || IS_TEST_MODE || IS_PREVIEW_MODE ? value : undefined;
 }

--- a/src/utils/configOverride.ts
+++ b/src/utils/configOverride.ts
@@ -3,8 +3,8 @@ import type { NavigateFunction } from 'react-router/dist/lib/hooks';
 import { logDev } from '#src/utils/common';
 import type { Settings } from '#src/stores/SettingsStore';
 
-// Use session storage so the override persists until the tab is closed and then resets
-const storage = window.sessionStorage;
+// Use local storage so the override persists until cleared
+const storage = window.localStorage;
 
 const configQueryKey = 'app-config';
 const configLegacyQueryKey = 'c';

--- a/test-e2e/tests/favorites_test.ts
+++ b/test-e2e/tests/favorites_test.ts
@@ -53,7 +53,7 @@ Scenario('I can see my favorited videos on the home page', async ({ I }) => {
 Scenario('I do not see favorited videos on the home page and video page if there is not such config setting', async ({ I }) => {
   await addVideoToFavorites(I);
 
-  I.useConfig(testConfigs.authvodNoWatchlist);
+  I.useConfig(testConfigs.cleengAuthvodNoWatchlist);
 
   // No favorites section
   I.seeInCurrentUrl(constants.baseUrl);

--- a/test-e2e/tests/login/account_test.ts
+++ b/test-e2e/tests/login/account_test.ts
@@ -11,7 +11,7 @@ const formFeedback = 'div[class*=formFeedback]';
 Feature('login - account').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(async ({ I }) => {
-  I.useConfig(testConfigs.authvod);
+  I.useConfig(testConfigs.cleengAuthvod);
 
   if (await I.isMobile()) {
     I.openMenuDrawer();

--- a/test-e2e/tests/login/home_test.ts
+++ b/test-e2e/tests/login/home_test.ts
@@ -7,7 +7,7 @@ let loginContext: LoginContext;
 Feature('login - home').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(({ I }) => {
-  I.useConfig(testConfigs.authvod);
+  I.useConfig(testConfigs.cleengAuthvod);
 });
 
 Scenario('Sign-in buttons show for accounts config', async ({ I }) => {

--- a/test-e2e/tests/register_test.ts
+++ b/test-e2e/tests/register_test.ts
@@ -5,7 +5,7 @@ import { testConfigs } from '#test/constants';
 Feature('register').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(async ({ I }) => {
-  I.useConfig(testConfigs.authvod);
+  I.useConfig(testConfigs.cleengAuthvod);
 
   if (await I.isMobile()) {
     I.openMenuDrawer();

--- a/test-e2e/tests/video_detail_test.ts
+++ b/test-e2e/tests/video_detail_test.ts
@@ -12,7 +12,7 @@ const loginContext: LoginContext = {
 Feature('video_detail').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(({ I }) => {
-  I.useConfig(testConfigs.authvod);
+  I.useConfig(testConfigs.cleengAuthvod);
 });
 
 Scenario('Video detail screen loads', async ({ I }) => {

--- a/test-e2e/tests/watch_history/local_test.ts
+++ b/test-e2e/tests/watch_history/local_test.ts
@@ -88,7 +88,7 @@ Scenario('Video removed from continue watching when finished', async ({ I }) => 
 });
 
 Scenario('I do not see continue_watching videos on the home page and video page if there is not such config setting', async ({ I }) => {
-  I.useConfig(testConfigs.authvodNoWatchlist);
+  I.useConfig(testConfigs.cleengAuthvodNoWatchlist);
 
   await I.openVideoCard(videoTitle);
   I.dontSee(constants.continueWatchingButton);

--- a/test-e2e/tests/watch_history/logged_in_test.ts
+++ b/test-e2e/tests/watch_history/logged_in_test.ts
@@ -11,7 +11,7 @@ let loginContext: LoginContext;
 Feature('watch_history - logged in').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(({ I }) => {
-  I.useConfig(testConfigs.authvod);
+  I.useConfig(testConfigs.cleengAuthvod);
 });
 
 Scenario('I can get my watch history when logged in', async ({ I }) => {
@@ -77,7 +77,7 @@ Scenario('I can see my watch history on the Home screen when logged in', async (
 });
 
 Scenario('I do not see continue_watching videos on the home page and video page if there is not such config setting', async ({ I }) => {
-  I.useConfig(testConfigs.authvodNoWatchlist);
+  I.useConfig(testConfigs.cleengAuthvodNoWatchlist);
 
   await registerOrLogin(I);
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -4,30 +4,38 @@ export interface TestConfig {
 }
 
 export const testConfigs = {
+  inplayerAuth: {
+    id: 'https://web-ott.s3.eu-west-1.amazonaws.com/apps/configs/demo.json',
+    label: 'InPlayer Authvod',
+  },
+  inplayerHosted: {
+    id: 'a2kbjdv0',
+    label: 'InPlayer Hosted',
+  },
   basicNoAuth: {
     id: 'gnnuzabk',
     label: 'Demo App (No Auth)',
-  } as TestConfig,
+  },
   noStyling: {
     id: 'kujzeu1b',
     label: 'No Styling (No Auth)',
-  } as TestConfig,
+  },
   inlinePlayer: {
     id: 'ata6ucb8',
     label: 'Inline Player',
-  } as TestConfig,
-  authvod: {
+  },
+  cleengAuthvod: {
     id: 'nvqkufhy',
-    label: 'Authvod',
-  } as TestConfig,
-  authvodNoWatchlist: {
+    label: 'Cleeng Authvod',
+  },
+  cleengAuthvodNoWatchlist: {
     id: '7weyqrua',
-    label: 'Authvod (No Watchlists)',
-  } as TestConfig,
+    label: 'Cleeng Authvod (No WL)',
+  },
   svod: {
     id: 'ozylzc5m',
     label: 'SVOD',
-  } as TestConfig,
+  },
 };
 
 export const jwDevEnvConfigs = {


### PR DESCRIPTION
## Description

This PR adds 2 inplayer configs to the dev selector - the hardcoded one from S3 and a hosted one, which is loaded with a temporary workaround until the dashboard types are updated.

I also added 'preview' mode so that github PR previews show debug logging, the dev selector, etc.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [x] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
