### PR TITLE
fix(inlineplayer): display correct video title after play next clicked

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -23,6 +23,7 @@ type Props = {
   onBeforePlay?: () => void;
   onFirstFrame?: () => void;
   onRemove?: () => void;
+  onNext?: () => void;
   onPlaylistItem?: () => void;
   onPlaylistItemCallback?: (item: PlaylistItem) => Promise<undefined | PlaylistItem>;
   startTime?: number;
@@ -43,6 +44,7 @@ const Player: React.FC<Props> = ({
   onRemove,
   onPlaylistItem,
   onPlaylistItemCallback,
+  onNext,
   feedId,
   startTime = 0,
   autostart,
@@ -65,6 +67,7 @@ const Player: React.FC<Props> = ({
   const handleRemove = useEventCallback(onRemove);
   const handlePlaylistItem = useEventCallback(onPlaylistItem);
   const handlePlaylistItemCallback = useEventCallback(onPlaylistItemCallback);
+  const handleNextClick = useEventCallback(onNext);
   const handleReady = useEventCallback(() => onReady && onReady(playerRef.current));
 
   const attachEvents = useCallback(() => {
@@ -78,6 +81,7 @@ const Player: React.FC<Props> = ({
     playerRef.current?.on('firstFrame', handleFirstFrame);
     playerRef.current?.on('remove', handleRemove);
     playerRef.current?.on('playlistItem', handlePlaylistItem);
+    playerRef.current?.on('nextClick', handleNextClick);
     playerRef.current?.setPlaylistItemCallback(handlePlaylistItemCallback);
   }, [
     handleReady,
@@ -90,6 +94,7 @@ const Player: React.FC<Props> = ({
     handleFirstFrame,
     handleRemove,
     handlePlaylistItem,
+    handleNextClick,
     handlePlaylistItemCallback,
   ]);
 

--- a/src/containers/Cinema/Cinema.tsx
+++ b/src/containers/Cinema/Cinema.tsx
@@ -16,6 +16,7 @@ type Props = {
   onPause?: () => void;
   onComplete?: () => void;
   onClose?: () => void;
+  onNext?: () => void;
   feedId?: string;
   title: string;
   primaryMetadata: React.ReactNode;
@@ -35,6 +36,7 @@ const Cinema: React.FC<Props> = ({
   onPause,
   onComplete,
   onClose,
+  onNext,
   feedId,
   liveStartDateTime,
   liveEndDateTime,
@@ -59,6 +61,10 @@ const Cinema: React.FC<Props> = ({
   const handleComplete = useCallback(() => {
     onComplete && onComplete();
   }, [onComplete]);
+
+  const handleNext = useCallback(() => {
+    onNext && onNext();
+  }, [onNext]);
 
   const handleUserActive = useCallback(() => setUserActive(true), []);
   const handleUserInactive = useCallback(() => setUserActive(false), []);
@@ -87,6 +93,7 @@ const Cinema: React.FC<Props> = ({
           onComplete={handleComplete}
           onUserActive={handleUserActive}
           onUserInActive={handleUserInactive}
+          onNext={handleNext}
           liveEndDateTime={liveEndDateTime}
           liveFromBeginning={liveFromBeginning}
           liveStartDateTime={liveStartDateTime}

--- a/src/containers/PlayerContainer/PlayerContainer.tsx
+++ b/src/containers/PlayerContainer/PlayerContainer.tsx
@@ -18,6 +18,7 @@ type Props = {
   onClose?: () => void;
   onUserActive?: () => void;
   onUserInActive?: () => void;
+  onNext?: () => void;
   feedId?: string;
   liveStartDateTime?: string | null;
   liveEndDateTime?: string | null;
@@ -33,6 +34,7 @@ const PlayerContainer: React.FC<Props> = ({
   onComplete,
   onUserActive,
   onUserInActive,
+  onNext,
   liveEndDateTime,
   liveFromBeginning,
   liveStartDateTime,
@@ -125,6 +127,7 @@ const PlayerContainer: React.FC<Props> = ({
       onRemove={handleRemove}
       onUserActive={onUserActive}
       onUserInActive={onUserInActive}
+      onNext={onNext}
       onPlaylistItemCallback={handlePlaylistItemCallback}
       startTime={startTime}
       autostart={autostart}

--- a/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -168,6 +168,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
               primaryMetadata={primaryMetadata}
               onComplete={handleComplete}
               feedId={feedId ?? undefined}
+              onNext={handleComplete}
             />
           )
         }


### PR DESCRIPTION
[BC-229](https://jwplayer.atlassian.net/browse/BC-229)

## Description

Add configurations to the player, so we can control "Next up" section and display the correct video title.

This PR solves # .

### Steps completed:

- Add 'nextClick' handler to Player's configs
- Pass 'handleComplete' to 'onNext' function from MediaMovie.tsx

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
