### PR TITLE
chore: fix race condition in e2e test from url nav

### DIFF
--- a/test-e2e/tests/inline_layout_test.ts
+++ b/test-e2e/tests/inline_layout_test.ts
@@ -85,7 +85,10 @@ Scenario('I switch to another season in the video list', async ({ I }) => {
 
 Scenario('I can see the video auto play when play=1 is set', async ({ I }) => {
   I.seeInCurrentUrl(constants.baseUrl);
-  I.amOnPage(`${constants.baseUrl}m/${constants.bigBuckBunnyPath}&play=1`);
+  await I.openVideoCard(constants.bigBuckBunnyTitle);
+  await I.executeScript(() => {
+    window.location.href += '&play=1';
+  });
 
   I.waitForElement('video', normalTimeout);
   await I.waitForPlayerPlaying(constants.bigBuckBunnyTitle);
@@ -93,7 +96,8 @@ Scenario('I can see the video auto play when play=1 is set', async ({ I }) => {
 
 Scenario("I don't see the video auto play when play=1 is not set", async ({ I }) => {
   I.seeInCurrentUrl(constants.baseUrl);
-  I.amOnPage(`${constants.baseUrl}m/${constants.bigBuckBunnyPath}`);
+
+  await I.openVideoCard(constants.bigBuckBunnyTitle);
 
   I.waitForElement('video', normalTimeout);
   await I.waitForPlayerState('idle');

--- a/test-e2e/tests/payments/coupons_test.ts
+++ b/test-e2e/tests/payments/coupons_test.ts
@@ -1,7 +1,6 @@
 import { LoginContext } from '#utils/password_utils';
 import { overrideIP, goToCheckout, formatPrice, finishAndCheckSubscription, addYear, cancelPlan, renewPlan } from '#utils/payments';
 import { testConfigs } from '#test/constants';
-import skipped = CodeceptJS.output.test.skipped;
 
 let couponLoginContext: LoginContext;
 
@@ -46,15 +45,13 @@ Scenario('I can redeem coupons', async ({ I }) => {
   await finishAndCheckSubscription(I, addYear(today), today);
 });
 
-// TODO: Re-enable this when the cleeng bug is fixed
-Scenario.todo('I can cancel a free subscription', async ({ I }) => {
+Scenario('I can cancel a free subscription', async ({ I }) => {
   couponLoginContext = await I.registerOrLogin(couponLoginContext);
 
   cancelPlan(I, addYear(today));
 });
 
-// TODO: Re-enable this when the cleeng bug is fixed
-Scenario.todo('I can renew a free subscription', async ({ I }) => {
+Scenario('I can renew a free subscription', async ({ I }) => {
   couponLoginContext = await I.registerOrLogin(couponLoginContext);
 
   renewPlan(I, addYear(today));

--- a/test-e2e/tests/payments/subscription_test.ts
+++ b/test-e2e/tests/payments/subscription_test.ts
@@ -164,8 +164,7 @@ Scenario('I can finish my subscription', async ({ I }) => {
   I.seeAll(cardInfo);
 });
 
-// TODO: Re-enable this when the cleeng bug is fixed
-Scenario.todo('I can cancel my subscription', async ({ I }) => {
+Scenario('I can cancel my subscription', async ({ I }) => {
   paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
   cancelPlan(I, addDays(today, 365));
@@ -174,8 +173,7 @@ Scenario.todo('I can cancel my subscription', async ({ I }) => {
   I.seeAll(cardInfo);
 });
 
-// TODO: Re-enable this when the cleeng bug is fixed
-Scenario.todo('I can renew my subscription', async ({ I }) => {
+Scenario('I can renew my subscription', async ({ I }) => {
   paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
   renewPlan(I, addDays(today, 365));

--- a/test-e2e/utils/constants.ts
+++ b/test-e2e/utils/constants.ts
@@ -30,7 +30,6 @@ export default {
   agent327Title: 'Agent 327',
   agent327Description:
     'Hendrik IJzerbroot – Agent 327 – is a secret agent working for the Netherlands secret service agency. In the twenty comic books that were published since 1968, Martin Lodewijk created a rich universe with international conspiracies, hilarious characters and a healthy dose of Dutch humour.',
-  bigBuckBunnyPath: 'awWEFyPu/big-buck-bunny?r=dGSUzs9o',
   bigBuckBunnyTitle: 'Big Buck Bunny',
   bigBuckBunnyDescription:
     "Big Buck Bunny (code-named Project Peach) is a 2008 short computer-animated comedy film featuring animals of the forest, made by the Blender Institute, part of the Blender Foundation. Like the foundation's previous film, Elephants Dream, the film was made using Blender, a free and open-source software application for 3D computer modeling and animation developed by the same foundation.",


### PR DESCRIPTION
## Description

I don't know why, but 2 of the inline player tests started failing out of the blue. There appears to be a race condition caused by using direct url navigation. Since we want to avoid hard coding media ID's and URL paths anyhow, I updated the tests to follow manual clicks and it works again.

### Steps completed:

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
