### PR TITLE
feat(project): remove deprecated app config props

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 APP_API_BASE_URL=https://cdn.jwplayer.com
+
+APP_DEFAULT_PLAYER=M4qoGvUk

--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
 APP_API_BASE_URL=https://cdn.jwplayer.com
-
 APP_DEFAULT_PLAYER=M4qoGvUk

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ These are the available configuration parameters for the JW OTT Webapp's config.
 
 **player**
 
-Player key of your custom created player in the [JW Player dashboard](https://dashboard.jwplayer.com).
+Player key of the default player.
 
 ---
 
@@ -166,6 +166,12 @@ You can change the background color of the shelf with the help of this property 
 
 ---
 
+**custom.enableSharing** (optional)
+
+Set this parameter to `true` if you want to enable the "Share" button on the video and series detail screen.
+
+---
+
 **styling**
 
 Use the `styling` object to define extra styles for your application.
@@ -237,7 +243,6 @@ Use the `features` object to define extra properties for your app.
 ```
 {
   "features": {
-    "enableSharing": true,
     "recommendationsPlaylist": "IHBjjkSN",
     "searchPlaylist": "D4soEviP"
 }
@@ -245,11 +250,6 @@ Use the `features` object to define extra properties for your app.
 
 ---
 
-**features.enableSharing** (optional)
-
-Set this parameter to `false` if you want to disable the "Share" button on the video and series detail screen.
-
----
 
 **features.recommendationsPlaylist** (optional)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,12 +28,6 @@ Even sharing URL's should work as long as the query parameter of the desired con
 
 These are the available configuration parameters for the JW OTT Webapp's config.json file.
 
-**player**
-
-Player key of the default player.
-
----
-
 **siteName**
 
 Title of your website. JW OTT Webapp will automatically update the `<title>` tag of your site to this value when the site loads. If **siteName** is not set, the default name `My OTT Application` will be used.

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,3 +14,6 @@ export const ADYEN_LIVE_CLIENT_KEY = 'live_BQDOFBYTGZB3XKF62GBYSLPUJ4YW2TPL';
 
 // how often the live channel schedule is refetched in ms
 export const LIVE_CHANNELS_REFETCH_INTERVAL = 15 * 60_000;
+
+// OTT shared player
+export const DEFAULT_PLAYER_ID: string = 'M4qoGvUk';

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,4 +16,4 @@ export const ADYEN_LIVE_CLIENT_KEY = 'live_BQDOFBYTGZB3XKF62GBYSLPUJ4YW2TPL';
 export const LIVE_CHANNELS_REFETCH_INTERVAL = 15 * 60_000;
 
 // OTT shared player
-export const DEFAULT_PLAYER_ID: string = 'M4qoGvUk';
+export const DEFAULT_PLAYER_ID: string = import.meta.env.APP_DEFAULT_PLAYER ?? 'M4qoGvUk';

--- a/src/containers/PlayerContainer/PlayerContainer.tsx
+++ b/src/containers/PlayerContainer/PlayerContainer.tsx
@@ -8,7 +8,7 @@ import { useConfigStore } from '#src/stores/ConfigStore';
 import Player from '#components/Player/Player';
 import type { JWPlayer } from '#types/jwplayer';
 import { useWatchHistoryStore } from '#src/stores/WatchHistoryStore';
-import { VideoProgressMinMax } from '#src/config';
+import { DEFAULT_PLAYER_ID, VideoProgressMinMax } from '#src/config';
 
 type Props = {
   item: PlaylistItem;
@@ -40,7 +40,7 @@ const PlayerContainer: React.FC<Props> = ({
   liveStartDateTime,
   autostart,
 }: Props) => {
-  const { player, features } = useConfigStore((s) => s.config);
+  const { features } = useConfigStore((s) => s.config);
   const continueWatchingList = features?.continueWatchingList;
   const watchHistoryEnabled = !!continueWatchingList;
 
@@ -116,7 +116,7 @@ const PlayerContainer: React.FC<Props> = ({
 
   return (
     <Player
-      playerId={player}
+      playerId={DEFAULT_PLAYER_ID}
       feedId={feedId}
       item={item}
       onReady={handleReady}

--- a/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -26,6 +26,7 @@ import Button from '#components/Button/Button';
 import type { ScreenComponent } from '#types/screens';
 import useQueryParam from '#src/hooks/useQueryParam';
 import InlinePlayer from '#src/containers/InlinePlayer/InlinePlayer';
+import { isTruthyCustomParamValue } from '#src/utils/common';
 
 const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
   const { t } = useTranslation('video');
@@ -46,7 +47,7 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
   const { siteName, styling, features, custom } = config;
 
   const posterFading: boolean = styling?.posterFading === true;
-  const enableSharing: boolean = features?.enableSharing === true;
+  const enableSharing: boolean = isTruthyCustomParamValue(custom?.enableSharing);
   const isFavoritesEnabled: boolean = Boolean(features?.favoritesList);
   const inlineLayout = Boolean(custom?.inlinePlayer);
 

--- a/src/pages/ScreenRouting/mediaScreens/MediaSeriesEpisode/MediaSeriesEpisode.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaSeriesEpisode/MediaSeriesEpisode.tsx
@@ -31,6 +31,7 @@ import type { ScreenComponent } from '#types/screens';
 import useQueryParam from '#src/hooks/useQueryParam';
 import useGetSeriesId from '#src/hooks/useGetSeriesId';
 import Loading from '#src/pages/Loading/Loading';
+import { isTruthyCustomParamValue } from '#src/utils/common';
 
 const MediaSeriesEpisode: ScreenComponent<PlaylistItem> = ({ data }) => {
   const breakpoint = useBreakpoint();
@@ -47,7 +48,7 @@ const MediaSeriesEpisode: ScreenComponent<PlaylistItem> = ({ data }) => {
   const { config, accessModel } = useConfigStore(({ config, accessModel }) => ({ config, accessModel }), shallow);
   const { styling, features, siteName, custom } = config;
   const posterFading: boolean = styling?.posterFading === true;
-  const enableSharing: boolean = features?.enableSharing === true;
+  const enableSharing: boolean = isTruthyCustomParamValue(custom?.enableSharing);
   const isFavoritesEnabled: boolean = Boolean(features?.favoritesList);
   const inlineLayout = Boolean(custom?.inlinePlayer);
 

--- a/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -25,16 +25,17 @@ import { generateMovieJSONLD } from '#src/utils/structuredData';
 import type { ScreenComponent } from '#types/screens';
 import type { Playlist } from '#types/playlist';
 import Loading from '#src/pages/Loading/Loading';
+import { isTruthyCustomParamValue } from '#src/utils/common';
 
 const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playlist } }) => {
   const { t } = useTranslation('epg');
 
   // Config
   const { config, accessModel } = useConfigStore(({ config, accessModel }) => ({ config, accessModel }), shallow);
-  const { siteName, styling, features } = config;
+  const { siteName, styling, custom } = config;
 
   const posterFading: boolean = styling?.posterFading === true;
-  const enableSharing: boolean = features?.enableSharing === true;
+  const enableSharing: boolean = isTruthyCustomParamValue(custom?.enableSharing);
 
   const updateBlurImage = useBlurImageUpdater(playlist);
 

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -25,8 +25,6 @@ const menuSchema: SchemaOf<Menu> = object().shape({
 });
 
 const featuresSchema: SchemaOf<Features> = object({
-  enableCasting: boolean().notRequired(),
-  enableSharing: boolean().notRequired(),
   recommendationsPlaylist: string().nullable(),
   searchPlaylist: string().nullable(),
   continueWatchingList: string().nullable(),

--- a/src/utils/configLoad.ts
+++ b/src/utils/configLoad.ts
@@ -84,9 +84,6 @@ export async function loadAndValidateConfig(configSource: string | undefined) {
   let config = await loadConfig(configSource);
   config.assets = config.assets || {};
 
-  //set default value for the OTT shared player
-  config.player = 'M4qoGvUk';
-
   // make sure the banner always defaults to the JWP banner when not defined in the config
   if (!config.assets.banner) {
     config.assets.banner = defaultConfig.assets.banner;

--- a/src/utils/configLoad.ts
+++ b/src/utils/configLoad.ts
@@ -73,9 +73,7 @@ export async function loadAndValidateConfig(configSource: string | undefined) {
       footerText: '',
       shelfTitles: true,
     },
-    features: {
-      enableSharing: true,
-    },
+    features: {},
   };
 
   if (!configSource) {
@@ -85,6 +83,9 @@ export async function loadAndValidateConfig(configSource: string | undefined) {
 
   let config = await loadConfig(configSource);
   config.assets = config.assets || {};
+
+  //set default value for the OTT shared player
+  config.player = 'M4qoGvUk';
 
   // make sure the banner always defaults to the JWP banner when not defined in the config
   if (!config.assets.banner) {

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -67,8 +67,6 @@ export type InPlayer = {
   useSandbox?: boolean;
 };
 export type Features = {
-  enableCasting?: boolean;
-  enableSharing?: boolean;
   recommendationsPlaylist?: string | null;
   searchPlaylist?: string | null;
   favoritesList?: string | null;


### PR DESCRIPTION
## Description

- Replace 'Share' button to be set from a custom param
- Remove Casting, as it doesn't reflect any changes 
- Set the default player to M4qoGvUk which is the OTT shared player


This PR solves #213 .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
