### PR TITLE
fix(player): hide inside player title and description

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -156,7 +156,6 @@ const Player: React.FC<Props> = ({
       if (!window.jwplayer || !playerElementRef.current) return;
 
       playerRef.current = window.jwplayer(playerElementRef.current) as JWPlayer;
-
       // player options are untyped
       const playerOptions: { [key: string]: unknown } = {
         aspectratio: false,
@@ -165,19 +164,19 @@ const Player: React.FC<Props> = ({
         height: '100%',
         mute: false,
         repeat: false,
+        displaytitle: false,
+        displaydescription: false,
       };
 
       // only set the autostart parameter when it is defined or it will override the player.defaults autostart setting
       if (typeof autostart !== 'undefined') {
         playerOptions.autostart = autostart;
       }
-
       playerRef.current.setup(playerOptions);
 
       setPlayer(playerRef.current);
       attachEvents();
     };
-
     if (playerRef.current) {
       return loadPlaylist();
     }


### PR DESCRIPTION
## Description

Add 

- displaytitle: false,

- displaydescription: false 

to the player settings, so the displayed title and description inside of the player can be hidden, when the corresponding values are selected for the player settings.
The initial title and description stay on. 

This PR solves #194 .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
