### PR TITLE
feat(project): remove enable_text setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,6 @@ Use the `content` array to define which and how content playlists should be disp
   }, {
     "type": "favorites",
     "title": "Best videos",
-    "enableText": false
   }, {
     "contentId": "WXu7kuaW"
     "type": "playlist"
@@ -130,15 +129,8 @@ If you want to include `favorites` / `continue_watching` shelf, you should also 
 ```
 {
   "type": "continue_watching",
-  "enableText": false
 }
 ```
-
----
-
-**content[].enableText** (optional)
-
-Controls whether or not title and description text overlays appear on the poster images. It is "true" by default. If your poster images contain a lot of text, we recommend setting this to "false."
 
 ---
 

--- a/docs/features/shelves-and-libraries.md
+++ b/docs/features/shelves-and-libraries.md
@@ -58,12 +58,10 @@ Shelves and libraries can be defined in the [app config](/docs/configuration.md)
 {
   "content": [
     {
-      "enableText": true,
       "featured": true,
       "playlistId": "JSKF03bk"
     },
     {
-      "enableText": true,
       "playlistId": "dGSUzs9o"
     }
   ],

--- a/src/components/Shelf/Shelf.tsx
+++ b/src/components/Shelf/Shelf.tsx
@@ -55,7 +55,6 @@ const Shelf = ({
   onCardHover,
   title,
   watchHistory,
-  enableTitle = true,
   featured = false,
   loading = false,
   error = null,
@@ -140,7 +139,7 @@ const Shelf = ({
 
   return (
     <div className={classNames(styles.shelf, { [styles.featured]: featured })}>
-      {!featured && enableTitle ? <h2 className={classNames(styles.title, { [styles.loading]: loading })}>{title || playlist.title}</h2> : null}
+      {!featured ? <h2 className={classNames(styles.title, { [styles.loading]: loading })}>{title || playlist.title}</h2> : null}
       <TileDock<PlaylistItem>
         items={playlist.playlist}
         tilesToShow={tilesToShow}

--- a/src/containers/ShelfList/ShelfList.tsx
+++ b/src/containers/ShelfList/ShelfList.tsx
@@ -78,7 +78,6 @@ const ShelfList = ({ rows }: Props) => {
                       playlist={playlist}
                       watchHistory={row.type === PersonalShelf.ContinueWatching ? watchHistoryDictionary : undefined}
                       onCardClick={onCardClick}
-                      enableTitle={row.enableText}
                       title={title}
                       featured={row.featured === true}
                       accessModel={accessModel}

--- a/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub.tsx
@@ -9,7 +9,7 @@ import type { PlaylistItem } from '#types/playlist';
 const parsePlaylistIds = (input: unknown): Content[] => {
   const playlistIds = typeof input === 'string' ? input.replace(/\s+/g, '').split(',') : [];
 
-  return playlistIds.map((id) => ({ type: 'playlist', contentId: id, enableText: true }));
+  return playlistIds.map((id) => ({ type: 'playlist', contentId: id }));
 };
 
 const MediaHub: ScreenComponent<PlaylistItem> = ({ data }) => {

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -12,7 +12,6 @@ const contentSchema: SchemaOf<Content> = object({
   contentId: string().notRequired(),
   title: string().notRequired(),
   featured: boolean().notRequired(),
-  enableText: boolean().notRequired(),
   backgroundColor: string().nullable().notRequired(),
   type: mixed().oneOf(['playlist', 'continue_watching', 'favorites']),
 }).defined();
@@ -104,7 +103,7 @@ const loadConfig = async (configLocation: string) => {
 
 const enrichConfig = (config: Config): Config => {
   const { content, siteName } = config;
-  const updatedContent = content.map((content) => Object.assign({ enableText: true, featured: false }, content));
+  const updatedContent = content.map((content) => Object.assign({ featured: false }, content));
 
   // TODO: Remove this once the inplayer integration structure is added to the dashboard
   if (!config.integrations.inplayer?.clientId && config.custom?.['inplayer.clientId']) {

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -4,31 +4,25 @@
   },
   "content": [
     {
-      "enableText": true,
       "featured": true,
       "type": "playlist",
       "contentId": "JSKF03bk"
     },
     {
-      "enableText": true,
       "type": "favorites"
     },
     {
-      "enableText": true,
       "type": "continue_watching"
     },
     {
-      "enableText": true,
       "type": "playlist",
       "contentId": "dGSUzs9o"
     },
     {
-      "enableText": true,
       "type": "playlist",
       "contentId": "xQaFzykq"
     },
     {
-      "enableText": true,
       "type": "playlist",
       "contentId": "fWpLtzVh"
     }

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -34,7 +34,6 @@ export type Content = {
   title?: string;
   type: ContentType;
   featured?: boolean;
-  enableText?: boolean;
   backgroundColor?: string | null;
 };
 


### PR DESCRIPTION
## Description

- titles are shown by default for ordinary playlists

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
