### PR TITLE
chore: fix release email link

### DIFF
--- a/.github/RELEASE_BODY_TEMPLATE.md
+++ b/.github/RELEASE_BODY_TEMPLATE.md
@@ -11,4 +11,4 @@ We are looking forward to see what you create!
 
 # Changes
 
-Check the [`CHANGELOG`](CHANGELOG.md) for detailed notes about the changes in each version.
+Check the [`CHANGELOG`](https://github.com/jwplayer/ott-web-app/blob/develop/CHANGELOG.md) for detailed notes about the changes in each version.


### PR DESCRIPTION
## Description

Quick fix to point the link in the release email to the latest changelog on develop.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] ~~Acceptance criteria met~~
- [ ] ~~Unit tests added~~
- [ ] ~~Docs updated (including config and env variables)~~
- [ ] ~~Translations added~~
- [ ] ~~UX tested~~
- [ ] ~~Browsers / platforms tested~~
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
