### PR TITLE
fix: handle split full name

### DIFF
--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -67,6 +67,10 @@ export const register: Register = async ({ config, email, password }) => {
       password,
       passwordConfirmation: password,
       fullName: email,
+      metadata: {
+        first_name: ' ',
+        surname: ' ',
+      },
       type: 'consumer',
       clientId: config.integrations.jwp?.clientId || '',
       referrer: window.location.href,


### PR DESCRIPTION
## Description

This is needed because we have an option to split `fullName` to be `first_name` and `surname`, but in that case validation error occurs because the fields are required as an additional metadata. 
This way, that's fixed.

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
