### PR TITLE
feat(user): export account data

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "deploy:github": "node ./scripts/deploy-github.js"
   },
   "dependencies": {
-    "@inplayer-org/inplayer.js": "^3.13.7",
+    "@inplayer-org/inplayer.js": "^3.13.11",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/src/components/Account/Account.module.scss
+++ b/src/components/Account/Account.module.scss
@@ -1,0 +1,5 @@
+.exportDataContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/components/Account/Account.tsx
+++ b/src/components/Account/Account.tsx
@@ -5,11 +5,10 @@ import shallow from 'zustand/shallow';
 import DOMPurify from 'dompurify';
 import { useMutation } from 'react-query';
 
-import Alert from '../Alert/Alert';
-
 import styles from './Account.module.scss';
 
 import type { FormSectionContentArgs, FormSectionProps } from '#components/Form/FormSection';
+import Alert from '#components/Alert/Alert';
 import Visibility from '#src/icons/Visibility';
 import VisibilityOff from '#src/icons/VisibilityOff';
 import Button from '#components/Button/Button';

--- a/src/components/Account/Account.tsx
+++ b/src/components/Account/Account.tsx
@@ -280,7 +280,7 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
                           type="button"
                           disabled={exportData.isLoading}
                           onClick={async () => {
-                            exportData.mutate(''); // TODO: remove password once backend is updated
+                            exportData.mutate();
                           }}
                         />
                       </div>

--- a/src/components/Account/Account.tsx
+++ b/src/components/Account/Account.tsx
@@ -7,6 +7,8 @@ import { useMutation } from 'react-query';
 
 import Alert from '../Alert/Alert';
 
+import styles from './Account.module.scss';
+
 import type { FormSectionContentArgs, FormSectionProps } from '#components/Form/FormSection';
 import Visibility from '#src/icons/Visibility';
 import VisibilityOff from '#src/icons/VisibilityOff';
@@ -268,23 +270,11 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
                 formSection({
                   label: t('account.export_data_title'),
                   content: (section) => (
-                    // TODO: pull css out into a module
-                    <div
-                      style={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '1rem',
-                      }}
-                    >
+                    <div className={styles.exportDataContainer}>
                       <div>
                         <Trans t={t} i18nKey="account.export_data_body" values={{ email: section.values.email }} />
                       </div>
-                      <div
-                        style={{
-                          display: 'flex',
-                          flexGrow: 1,
-                        }}
-                      >
+                      <div>
                         <Button
                           label={t('account.export_data_title')}
                           type="button"
@@ -301,7 +291,9 @@ const Account = ({ panelClassName, panelHeaderClassName, canUpdateEmail = true }
             : []),
         ]}
       </Form>
-      <Alert open={isAlertVisible} message={exportDataMessage} onClose={() => setIsAlertVisible(false)} isSuccess={exportData.isSuccess} />
+      {canExportAccountData && (
+        <Alert open={isAlertVisible} message={exportDataMessage} onClose={() => setIsAlertVisible(false)} isSuccess={exportData.isSuccess} />
+      )}
     </>
   );
 };

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -10,14 +10,15 @@ type Props = {
   open: boolean;
   message: string | null;
   onClose: () => void;
+  isSuccess?: boolean;
 };
 
-const Alert: React.FC<Props> = ({ open, message, onClose }: Props) => {
+const Alert: React.FC<Props> = ({ open, message, onClose, isSuccess }: Props) => {
   const { t } = useTranslation('common');
 
   return (
     <Dialog open={open} onClose={onClose}>
-      <h2 className={styles.title}>{t('alert.title')}</h2>
+      <h2 className={styles.title}>{t(`${isSuccess ? 'alert.success' : 'alert.title'}`)}</h2>
       <p className={styles.body}>{message}</p>
       <Button label={t('alert.close')} variant="outlined" onClick={onClose} fullWidth />
     </Dialog>

--- a/src/i18n/locales/en_US/common.json
+++ b/src/i18n/locales/en_US/common.json
@@ -1,7 +1,8 @@
 {
   "alert": {
     "close": "Close",
-    "title": "An error occurred"
+    "title": "An error occurred",
+    "success": "Success"
   },
   "back": "Back",
   "card_lock": "Item locked",

--- a/src/i18n/locales/en_US/user.json
+++ b/src/i18n/locales/en_US/user.json
@@ -25,7 +25,11 @@
     "security": "Security",
     "terms_and_tracking": "Terms & tracking",
     "update_consents": "Update consents",
-    "view_password": "View password"
+    "view_password": "View password",
+    "export_data_title": "Export account data",
+    "export_data_body": "Export all of your personal account data to <strong>{{email}}</strong> as an attachment.",
+    "export_data_success": "Please check your email.",
+    "export_data_error": "An error occurred while exporting your account data."
   },
   "favorites": {
     "clear": "Clear favorites",

--- a/src/services/cleeng.account.service.ts
+++ b/src/services/cleeng.account.service.ts
@@ -220,6 +220,7 @@ const handleErrors = (errors: ApiResponse['errors']) => {
 export const updatePersonalShelves: UpdatePersonalShelves = async (payload, sandbox, jwt) => {
   return await updateCustomer(payload, sandbox, jwt);
 };
+export const exportAccountData = () => null;
 
 export const canUpdateEmail = true;
 
@@ -228,3 +229,4 @@ export const canSupportEmptyFullName = true;
 export const canChangePasswordWithOldPassword = false;
 export const subscribeToNotifications = async () => true;
 export const canRenewSubscription = true;
+export const canExportAccountData = false;

--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -1,4 +1,4 @@
-import InPlayer, { AccountData, Env, GetRegisterField, UpdateAccountData, FavoritesData, WatchHistory } from '@inplayer-org/inplayer.js';
+import InPlayer, { AccountData, Env, RegisterField, UpdateAccountData, FavoritesData, WatchHistory } from '@inplayer-org/inplayer.js';
 import i18next from 'i18next';
 
 import type {
@@ -140,8 +140,8 @@ export const getPublisherConsents: GetPublisherConsents = async (config) => {
     // @ts-ignore
     // wrong data type from InPlayer SDK (will be updated in the SDK)
     const result: Consent[] = data?.collection
-      .filter((field: GetRegisterField) => field.type === 'checkbox')
-      .map((consent: GetRegisterField) => formatPublisherConsents(consent));
+      .filter((field: RegisterField) => field.type === 'checkbox')
+      .map((consent: RegisterField) => formatPublisherConsents(consent));
 
     return {
       consents: [getTermsConsent(), ...result],
@@ -315,9 +315,8 @@ export const updatePersonalShelves: UpdatePersonalShelves = async (payload) => {
   }
 };
 
-export const exportAccountData: ExportAccountData = async ({ password }) => {
-  // TODO: remove password once backend is updated
-  const response = await InPlayer.Account.exportData({ password, brandingId: 0 });
+export const exportAccountData: ExportAccountData = async () => {
+  const response = await InPlayer.Account.exportData({ password: undefined, brandingId: 0 });
   const { code, message } = response.data;
   if (code !== 200) {
     throw new Error(message);
@@ -406,7 +405,7 @@ function formatAuth(auth: InPlayerAuthData): AuthData {
   };
 }
 
-function formatPublisherConsents(consent: Partial<GetRegisterField>) {
+function formatPublisherConsents(consent: Partial<RegisterField>) {
   return {
     broadcasterId: 0,
     enabledByDefault: false,

--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -9,6 +9,7 @@ import type {
   Consent,
   Customer,
   CustomerConsent,
+  ExportAccountData,
   ExternalData,
   GetCaptureStatus,
   GetCustomerConsents,
@@ -314,6 +315,22 @@ export const updatePersonalShelves: UpdatePersonalShelves = async (payload) => {
   }
 };
 
+export const exportAccountData: ExportAccountData = async ({ password }) => {
+  // TODO: remove password once backend is updated
+  const response = await InPlayer.Account.exportData({ password, brandingId: 0 });
+  const { code, message } = response.data;
+  if (code !== 200) {
+    throw new Error(message);
+  }
+  return {
+    errors: [],
+    responseData: {
+      message,
+      code,
+    },
+  };
+};
+
 const getCustomerExternalData = async (): Promise<ExternalData> => {
   const [favoritesData, historyData] = await Promise.all([InPlayer.Account.getFavorites(), await InPlayer.Account.getWatchHistory({})]);
 
@@ -425,3 +442,5 @@ export const canSupportEmptyFullName = false;
 export const canChangePasswordWithOldPassword = true;
 
 export const canRenewSubscription = false;
+
+export const canExportAccountData = true;

--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -316,6 +316,7 @@ export const updatePersonalShelves: UpdatePersonalShelves = async (payload) => {
 };
 
 export const exportAccountData: ExportAccountData = async () => {
+  // password is sent as undefined because it is now optional on BE
   const response = await InPlayer.Account.exportData({ password: undefined, brandingId: 0 });
   const { code, message } = response.data;
   if (code !== 200) {

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -1,4 +1,4 @@
-import InPlayer, { GetAccessFee, MerchantPaymentMethod } from '@inplayer-org/inplayer.js';
+import InPlayer, { AccessFee, MerchantPaymentMethod } from '@inplayer-org/inplayer.js';
 
 import type {
   CardPaymentData,
@@ -36,8 +36,8 @@ export const getOffers: GetOffers = async (payload) => {
       try {
         const { data } = await InPlayer.Asset.getAssetAccessFees(parseInt(`${assetId}`));
 
-        // TODO fix this type in the InPlayer SDK, because the actual type of `data` is GetAccessFee[], not GetAccessFee
-        return (data as unknown as GetAccessFee[])?.map((offer) => formatOffer(offer));
+        // TODO fix this type in the InPlayer SDK, because the actual type of `data` is AccessFee[], not AccessFee
+        return (data as unknown as AccessFee[])?.map((offer) => formatOffer(offer));
       } catch {
         throw new Error('Failed to get offers');
       }
@@ -161,7 +161,7 @@ export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData,
     expYear: cardPaymentPayload.cardExpYear || '',
     cvv: parseInt(cardPaymentPayload.cardCVC),
     accessFee: order.id,
-    paymentMethod: '1',
+    paymentMethod: 1,
     voucherCode: cardPaymentPayload.couponCode,
     referrer: window.location.href,
     returnUrl: `${window.location.href}&u=waiting-for-payment`,
@@ -201,7 +201,7 @@ const formatEntitlements = (expiresAt: number = 0, accessGranted: boolean = fals
   };
 };
 
-const formatOffer = (offer: GetAccessFee): Offer => {
+const formatOffer = (offer: AccessFee): Offer => {
   const offerId = offer.access_type.name === 'ppv' ? `C${offer.id}` : `S${offer.id}`;
   return {
     id: offer.id,

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -461,8 +461,7 @@ export async function reloadActiveSubscription({ delay }: { delay: number } = { 
 export async function exportAccountData() {
   return await useAccount(async ({ auth: { jwt } }) => {
     return await useService(async ({ accountService }) => {
-      const reponse = await accountService.exportAccountData(undefined, true, jwt);
-      return reponse;
+      return await accountService.exportAccountData(undefined, true, jwt);
     });
   });
 }

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -458,10 +458,10 @@ export async function reloadActiveSubscription({ delay }: { delay: number } = { 
   });
 }
 
-export async function exportAccountData(password: string) {
+export async function exportAccountData() {
   return await useAccount(async ({ auth: { jwt } }) => {
     return await useService(async ({ accountService }) => {
-      const reponse = await accountService.exportAccountData({ password }, true, jwt);
+      const reponse = await accountService.exportAccountData(undefined, true, jwt);
       return reponse;
     });
   });

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -78,6 +78,7 @@ export const initializeAccount = async () => {
       canUpdateEmail: accountService.canUpdateEmail,
       canRenewSubscription: accountService.canRenewSubscription,
       canChangePasswordWithOldPassword: accountService.canChangePasswordWithOldPassword,
+      canExportAccountData: accountService.canExportAccountData,
     });
     accountService.setEnvironment(config);
 
@@ -453,6 +454,15 @@ export async function reloadActiveSubscription({ delay }: { delay: number } = { 
         transactions,
         activePayment,
       });
+    });
+  });
+}
+
+export async function exportAccountData(password: string) {
+  return await useAccount(async ({ auth: { jwt } }) => {
+    return await useService(async ({ accountService }) => {
+      const reponse = await accountService.exportAccountData({ password }, true, jwt);
+      return reponse;
     });
   });
 }

--- a/src/stores/AccountStore.ts
+++ b/src/stores/AccountStore.ts
@@ -14,6 +14,7 @@ type AccountStore = {
   canUpdateEmail: boolean;
   canRenewSubscription: boolean;
   canChangePasswordWithOldPassword: boolean;
+  canExportAccountData: boolean;
   setLoading: (loading: boolean) => void;
 };
 
@@ -29,5 +30,6 @@ export const useAccountStore = createStore<AccountStore>('AccountStore', (set) =
   canUpdateEmail: false,
   canRenewSubscription: false,
   canChangePasswordWithOldPassword: false,
+  canExportAccountData: false,
   setLoading: (loading: boolean) => set({ loading }),
 }));

--- a/types/account.d.ts
+++ b/types/account.d.ts
@@ -320,11 +320,6 @@ export type EmailConfirmPasswordInput = {
   confirmationPassword: string;
 };
 
-export type ExportAccountDataPayload = {
-  // TODO: remove password once backend is updated
-  password: string;
-};
-
 export type ExportAccountDataResponse = {
   message: string;
   code: number;
@@ -346,4 +341,4 @@ type ChangePasswordWithOldPassword = EnvironmentServiceRequest<ChangePasswordWit
 type UpdatePersonalShelves = AuthServiceRequest<UpdatePersonalShelvesArgs, Customer | Record<string>>;
 type RefreshToken = EnvironmentServiceRequest<RefreshTokenPayload, AuthData>;
 type GetLocales = EmptyServiceRequest<LocalesData>;
-type ExportAccountData = AuthServiceRequest<ExportAccountDataPayload, ExportAccountDataResponse>;
+type ExportAccountData = AuthServiceRequest<undefined, ExportAccountDataResponse>;

--- a/types/account.d.ts
+++ b/types/account.d.ts
@@ -320,6 +320,17 @@ export type EmailConfirmPasswordInput = {
   confirmationPassword: string;
 };
 
+export type ExportAccountDataPayload = {
+  // TODO: remove password once backend is updated
+  password: string;
+};
+
+export type ExportAccountDataResponse = {
+  message: string;
+  code: number;
+  errors?: Record<string, string>;
+};
+
 type Login = PromiseRequest<AuthArgs, AuthResponse>;
 type Register = PromiseRequest<AuthArgs, AuthResponse>;
 type GetCustomer = AuthServiceRequest<GetCustomerPayload, Customer>;
@@ -335,3 +346,4 @@ type ChangePasswordWithOldPassword = EnvironmentServiceRequest<ChangePasswordWit
 type UpdatePersonalShelves = AuthServiceRequest<UpdatePersonalShelvesArgs, Customer | Record<string>>;
 type RefreshToken = EnvironmentServiceRequest<RefreshTokenPayload, AuthData>;
 type GetLocales = EmptyServiceRequest<LocalesData>;
+type ExportAccountData = AuthServiceRequest<ExportAccountDataPayload, ExportAccountDataResponse>;


### PR DESCRIPTION
## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

Notion card: https://www.notion.so/Viewer-export-account-data-from-web-app-238244719f544d6892b26c7225e776a5

Implements the required methods in the InPlayer account service and the AccountController to handle account data export calls. Adds the data export section to the account page. Modifies the Alert component to allow for successful alerts.


![image](https://user-images.githubusercontent.com/111125899/235906543-9050cfa3-ea6f-4229-904a-af7d0b32e4f3.png)
![image](https://user-images.githubusercontent.com/111125899/235906565-37a15f63-060e-48f8-9411-761770070f1e.png)
![image](https://user-images.githubusercontent.com/111125899/235906625-60490101-4bfe-4ca6-b6fb-49c03425ce28.png)


### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
