### PR TITLE
fix: update inplayer.js version and types

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-# yarn commit-msg
+yarn commit-msg

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commit-msg
+# yarn commit-msg

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@codeceptjs/allure-legacy": "^1.0.2",
-    "@inplayer-org/inplayer.js": "^3.13.10",
+    "@inplayer-org/inplayer.js": "^3.13.12",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "deploy:github": "node ./scripts/deploy-github.js"
   },
   "dependencies": {
-    "@inplayer-org/inplayer.js": "^3.13.7",
+    "@inplayer-org/inplayer.js": "^3.13.9",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "deploy:github": "node ./scripts/deploy-github.js"
   },
   "dependencies": {
-    "@inplayer-org/inplayer.js": "^3.13.9",
+    "@inplayer-org/inplayer.js": "^3.13.10",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -1,11 +1,4 @@
-import InPlayer, {
-  AccountData,
-  Env,
-  RegisterField,
-  UpdateAccountData,
-  FavoritesData,
-  WatchHistory,
-} from '@inplayer-org/inplayer.js';
+import InPlayer, { AccountData, Env, RegisterField, UpdateAccountData, FavoritesData, WatchHistory } from '@inplayer-org/inplayer.js';
 import i18next from 'i18next';
 
 import type {
@@ -143,9 +136,7 @@ export const getPublisherConsents: GetPublisherConsents = async (config) => {
     const { jwp } = config.integrations;
     const { data } = await InPlayer.Account.getRegisterFields(jwp?.clientId || '');
 
-    const result: Consent[] = data?.collection
-      .filter((field) => field.type === 'checkbox')
-      .map((consent) => formatPublisherConsents(consent));
+    const result: Consent[] = data?.collection.filter((field) => field.type === 'checkbox').map((consent) => formatPublisherConsents(consent));
 
     return {
       consents: [getTermsConsent(), ...result],

--- a/src/services/inplayer.account.service.ts
+++ b/src/services/inplayer.account.service.ts
@@ -1,4 +1,11 @@
-import InPlayer, { AccountData, Env, GetRegisterField, UpdateAccountData, FavoritesData, WatchHistory } from '@inplayer-org/inplayer.js';
+import InPlayer, {
+  AccountData,
+  Env,
+  RegisterField,
+  UpdateAccountData,
+  FavoritesData,
+  WatchHistory,
+} from '@inplayer-org/inplayer.js';
 import i18next from 'i18next';
 
 import type {
@@ -136,11 +143,9 @@ export const getPublisherConsents: GetPublisherConsents = async (config) => {
     const { jwp } = config.integrations;
     const { data } = await InPlayer.Account.getRegisterFields(jwp?.clientId || '');
 
-    // @ts-ignore
-    // wrong data type from InPlayer SDK (will be updated in the SDK)
     const result: Consent[] = data?.collection
-      .filter((field: GetRegisterField) => field.type === 'checkbox')
-      .map((consent: GetRegisterField) => formatPublisherConsents(consent));
+      .filter((field) => field.type === 'checkbox')
+      .map((consent) => formatPublisherConsents(consent));
 
     return {
       consents: [getTermsConsent(), ...result],
@@ -389,7 +394,7 @@ function formatAuth(auth: InPlayerAuthData): AuthData {
   };
 }
 
-function formatPublisherConsents(consent: Partial<GetRegisterField>) {
+function formatPublisherConsents(consent: Partial<RegisterField>) {
   return {
     broadcasterId: 0,
     enabledByDefault: false,

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -149,10 +149,8 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
 };
 
 export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData, order: Order) => {
-  const number = parseInt(String(cardPaymentPayload.cardNumber).replace(/\s/g, ''), 10);
-
   const payload = {
-    number,
+    number: parseInt(String(cardPaymentPayload.cardNumber).replace(/\s/g, ''), 10),
     cardName: cardPaymentPayload.cardholderName,
     expMonth: cardPaymentPayload.cardExpMonth || '',
     expYear: cardPaymentPayload.cardExpYear || '',

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -83,12 +83,9 @@ export const paymentWithPayPal: PaymentWithPayPal = async (payload) => {
       origin: `${window.location.origin}?u=waiting-for-payment`,
       accessFeeId: payload.order.id,
       paymentMethod: 2,
-      // TODO: add voucherCode in sdk types
-      // @ts-ignore
       voucherCode: payload.couponCode,
     });
 
-    // @ts-ignore
     if (response.data?.id) {
       return {
         errors: ['Already have an active access'],

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -83,9 +83,12 @@ export const paymentWithPayPal: PaymentWithPayPal = async (payload) => {
       origin: `${window.location.origin}?u=waiting-for-payment`,
       accessFeeId: payload.order.id,
       paymentMethod: 2,
+      // TODO: add voucherCode in sdk types
+      // @ts-ignore
       voucherCode: payload.couponCode,
     });
-    
+
+    // @ts-ignore
     if (response.data?.id) {
       return {
         errors: ['Already have an active access'],

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -150,7 +150,7 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
 
 export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData, order: Order) => {
   const payload = {
-    number: parseInt(`${cardPaymentPayload.cardNumber}`),
+    number: cardPaymentPayload.cardNumber,
     cardName: cardPaymentPayload.cardholderName,
     expMonth: cardPaymentPayload.cardExpMonth || '',
     expYear: cardPaymentPayload.cardExpYear || '',
@@ -164,6 +164,7 @@ export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData,
 
   try {
     if (isSVODOffer(order)) {
+      // @ts-ignore
       await InPlayer.Subscription.createSubscription(payload);
     } else {
       await InPlayer.Payment.createPayment(payload);

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -149,8 +149,10 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
 };
 
 export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData, order: Order) => {
+  const number = parseInt(String(cardPaymentPayload.cardNumber).replace(/\s/g, ''), 10);
+
   const payload = {
-    number: cardPaymentPayload.cardNumber,
+    number,
     cardName: cardPaymentPayload.cardholderName,
     expMonth: cardPaymentPayload.cardExpMonth || '',
     expYear: cardPaymentPayload.cardExpYear || '',
@@ -164,7 +166,6 @@ export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData,
 
   try {
     if (isSVODOffer(order)) {
-      // @ts-ignore
       await InPlayer.Subscription.createSubscription(payload);
     } else {
       await InPlayer.Payment.createPayment(payload);

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -1,4 +1,4 @@
-import InPlayer, { GetAccessFee, MerchantPaymentMethod } from '@inplayer-org/inplayer.js';
+import InPlayer, { AccessFee, MerchantPaymentMethod } from '@inplayer-org/inplayer.js';
 
 import type {
   CardPaymentData,
@@ -36,8 +36,7 @@ export const getOffers: GetOffers = async (payload) => {
       try {
         const { data } = await InPlayer.Asset.getAssetAccessFees(parseInt(`${assetId}`));
 
-        // TODO fix this type in the InPlayer SDK, because the actual type of `data` is GetAccessFee[], not GetAccessFee
-        return (data as unknown as GetAccessFee[])?.map((offer) => formatOffer(offer));
+        return data?.map((offer) => formatOffer(offer));
       } catch {
         throw new Error('Failed to get offers');
       }
@@ -84,11 +83,9 @@ export const paymentWithPayPal: PaymentWithPayPal = async (payload) => {
       origin: `${window.location.origin}?u=waiting-for-payment`,
       accessFeeId: payload.order.id,
       paymentMethod: 2,
-      //@ts-ignore
       voucherCode: payload.couponCode,
     });
-    //@ts-ignore
-    //TODO fix this type in InPlayer SDK
+    
     if (response.data?.id) {
       return {
         errors: ['Already have an active access'],
@@ -131,8 +128,6 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
     order.discount = {
       applied: true,
       type: 'coupon',
-      //@ts-ignore
-      // TODO fix this type in InPlayer SDK
       periods: response.data.discount_duration,
     };
 
@@ -155,13 +150,13 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
 
 export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData, order: Order) => {
   const payload = {
-    number: cardPaymentPayload.cardNumber,
+    number: parseInt(`${cardPaymentPayload.cardNumber}`),
     cardName: cardPaymentPayload.cardholderName,
     expMonth: cardPaymentPayload.cardExpMonth || '',
     expYear: cardPaymentPayload.cardExpYear || '',
     cvv: parseInt(cardPaymentPayload.cardCVC),
     accessFee: order.id,
-    paymentMethod: '1',
+    paymentMethod: 1,
     voucherCode: cardPaymentPayload.couponCode,
     referrer: window.location.href,
     returnUrl: `${window.location.href}&u=waiting-for-payment`,
@@ -169,8 +164,6 @@ export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData,
 
   try {
     if (isSVODOffer(order)) {
-      //@ts-ignore
-      //Fix this type in InPlayer SDK
       await InPlayer.Subscription.createSubscription(payload);
     } else {
       await InPlayer.Payment.createPayment(payload);
@@ -201,7 +194,7 @@ const formatEntitlements = (expiresAt: number = 0, accessGranted: boolean = fals
   };
 };
 
-const formatOffer = (offer: GetAccessFee): Offer => {
+const formatOffer = (offer: AccessFee): Offer => {
   const offerId = offer.access_type.name === 'ppv' ? `C${offer.id}` : `S${offer.id}`;
   return {
     id: offer.id,

--- a/src/services/inplayer.subscription.service.ts
+++ b/src/services/inplayer.subscription.service.ts
@@ -64,8 +64,6 @@ export async function getActivePayment() {
 
     return cards.find((paymentDetails) => paymentDetails.active) || null;
   } catch {
-    //TODO Fix response code in the InPlayer API
-    //throw new Error('Failed to get payment details');
     return null;
   }
 }
@@ -107,7 +105,6 @@ const formatCardDetails = (card: Card): PaymentDetail => {
   } as PaymentDetail;
 };
 
-// TODO: fix PurchaseDetails type in InPlayer SDK
 const formatTransaction = (transaction: PurchaseDetails): Transaction => {
   const purchasedAmount = transaction?.purchased_amount?.toString() || '0';
 

--- a/src/services/inplayer.subscription.service.ts
+++ b/src/services/inplayer.subscription.service.ts
@@ -1,9 +1,9 @@
 import i18next from 'i18next';
-import InPlayer, { Card, GetItemAccessV1, SubscriptionDetails as InplayerSubscription } from '@inplayer-org/inplayer.js';
+import InPlayer, { PurchaseDetails, Card, GetItemAccessV1, SubscriptionDetails as InplayerSubscription } from '@inplayer-org/inplayer.js';
 
 import type { PaymentDetail, Subscription, Transaction, UpdateSubscription } from '#types/subscription';
 import type { Config } from '#types/Config';
-import type { InPlayerError, InPlayerPurchaseDetails } from '#types/inplayer';
+import type { InPlayerError } from '#types/inplayer';
 
 interface SubscriptionDetails extends InplayerSubscription {
   item_id?: number;
@@ -47,9 +47,8 @@ export async function getActiveSubscription({ config }: { config: Config }) {
 export async function getAllTransactions() {
   try {
     const { data } = await InPlayer.Payment.getPurchaseHistory('active', 0, 30);
-    // @ts-ignore
-    // TODO fix PurchaseHistoryCollection type in InPlayer SDK
-    return data?.collection?.map((transaction: InPlayerPurchaseDetails) => formatTransaction(transaction));
+
+    return data?.collection?.map((transaction) => formatTransaction(transaction));
   } catch {
     throw new Error('Failed to get transactions');
   }
@@ -60,8 +59,6 @@ export async function getActivePayment() {
     const { data } = await InPlayer.Payment.getDefaultCreditCard();
     const cards: PaymentDetail[] = [];
     for (const currency in data?.cards) {
-      // @ts-ignore
-      // TODO fix Card type in InPlayer SDK
       cards.push(formatCardDetails(data.cards?.[currency]));
     }
 
@@ -95,7 +92,7 @@ export const updateSubscription: UpdateSubscription = async ({ offerId, unsubscr
   }
 };
 
-const formatCardDetails = (card: Card & { card_type: string; account_id: number }): PaymentDetail => {
+const formatCardDetails = (card: Card): PaymentDetail => {
   const { number, exp_month, exp_year, card_name, card_type, account_id } = card;
   const zeroFillExpMonth = `0${exp_month}`.slice(-2);
   return {
@@ -111,7 +108,7 @@ const formatCardDetails = (card: Card & { card_type: string; account_id: number 
 };
 
 // TODO: fix PurchaseDetails type in InPlayer SDK
-const formatTransaction = (transaction: InPlayerPurchaseDetails): Transaction => {
+const formatTransaction = (transaction: PurchaseDetails): Transaction => {
   const purchasedAmount = transaction?.purchased_amount?.toString() || '0';
 
   return {

--- a/types/inplayer.d.ts
+++ b/types/inplayer.d.ts
@@ -1,4 +1,4 @@
-import type { PurchaseDetails, PurchaseHistoryCollection } from '@inplayer-org/inplayer.js';
+import type { PurchaseHistoryCollection } from '@inplayer-org/inplayer.js';
 
 export type InPlayerAuthData = {
   access_token: string;
@@ -21,6 +21,3 @@ export type InPlayerResponse<T> = {
   config: AxiosRequestConfig;
 };
 
-export type InPlayerPurchaseDetails = PurchaseDetails & {
-  purchased_access_fee_description: Record<string>;
-};

--- a/types/inplayer.d.ts
+++ b/types/inplayer.d.ts
@@ -20,4 +20,3 @@ export type InPlayerResponse<T> = {
   statusText: string;
   config: AxiosRequestConfig;
 };
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,10 +1557,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@inplayer-org/inplayer.js@^3.13.9":
-  version "3.13.9"
-  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.9.tgz#05b3ef6338ff48d0a7f97f0bae98aaa356034dec"
-  integrity sha512-V5CrjpGYysH1CHUgtfcXv5usIZG4HC/eo77rWjzX2/IGDpFHxpHHzbtdiy+n3qEIIybv0BPU3LWHfYRxQETZzQ==
+"@inplayer-org/inplayer.js@^3.13.10":
+  version "3.13.10"
+  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.10.tgz#4c8d0873f43577229ca6ed76dad8ed60e9301093"
+  integrity sha512-9Ws4VvKBkfBeOZQZNlv0XdyzI2FLTbg1UfeGdJsnWmWwnjOwEqXPEReF5ZV5jwjStXk8y5LWeb4siLltP/RCUg==
   dependencies:
     aws-iot-device-sdk "^2.2.6"
     axios "^0.21.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,10 +1557,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@inplayer-org/inplayer.js@^3.13.7":
-  version "3.13.7"
-  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.7.tgz#8a3ebb52ffc90622c6be7618d9d767c4c7125167"
-  integrity sha512-7xx1/HDd2/UTZGW7MWoqdgbgkVA63iSJDecAn2Mho5JpdD35OfQMT514otNKkw0nNbDU5/Lj0cTnEsfN1a1QxQ==
+"@inplayer-org/inplayer.js@^3.13.9":
+  version "3.13.9"
+  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.9.tgz#05b3ef6338ff48d0a7f97f0bae98aaa356034dec"
+  integrity sha512-V5CrjpGYysH1CHUgtfcXv5usIZG4HC/eo77rWjzX2/IGDpFHxpHHzbtdiy+n3qEIIybv0BPU3LWHfYRxQETZzQ==
   dependencies:
     aws-iot-device-sdk "^2.2.6"
     axios "^0.21.2"
@@ -3425,9 +3425,9 @@ core-js@^3.19.2:
   integrity sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==
 
 core-js@^3.8.2:
-  version "3.29.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.0.tgz#0273e142b67761058bcde5615c503c7406b572d6"
-  integrity sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==
+  version "3.30.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.1.tgz#fc9c5adcc541d8e9fa3e381179433cbf795628ba"
+  integrity sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ==
 
 core-util-is@~1.0.0:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,14 +1598,14 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@inplayer-org/inplayer.js@^3.13.10":
-  version "3.13.10"
-  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.10.tgz#4c8d0873f43577229ca6ed76dad8ed60e9301093"
-  integrity sha512-9Ws4VvKBkfBeOZQZNlv0XdyzI2FLTbg1UfeGdJsnWmWwnjOwEqXPEReF5ZV5jwjStXk8y5LWeb4siLltP/RCUg==
+"@inplayer-org/inplayer.js@^3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.12.tgz#6a8ff6516ff92fd1a38ef4e2854de512c29ad44b"
+  integrity sha512-NYmpZINBxu/vR4eTFtT84NfN0TcHH1Tplf+j36lQeiSa6Xj0mN6BlTUpZYXVseuOb9SePvGUbPyjXBCIAhALrg==
   dependencies:
     aws-iot-device-sdk "^2.2.6"
     axios "^0.21.2"
-    core-js "^3.8.2"
+    core-js "^3.19.2"
     fingerprintjs2 "^2.1.2"
     lodash "^4.17.20"
     qs "^6.9.4"
@@ -3447,11 +3447,6 @@ core-js@^3.19.2:
   version "3.22.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.3.tgz#498c41d997654cb00e81c7a54b44f0ab21ab01d5"
   integrity sha512-1t+2a/d2lppW1gkLXx3pKPVGbBdxXAkqztvWb1EJ8oF8O2gIGiytzflNiFEehYwVK/t2ryUsGBoOFFvNx95mbg==
-
-core-js@^3.8.2:
-  version "3.30.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.2.tgz#6528abfda65e5ad728143ea23f7a14f0dcf503fc"
-  integrity sha512-uBJiDmwqsbJCWHAwjrx3cvjbMXP7xD72Dmsn5LOJpiRmE3WbBbN5rCqQ2Qh6Ek6/eOrjlWngEynBWo4VxerQhg==
 
 core-util-is@~1.0.0:
   version "1.0.3"


### PR DESCRIPTION
## Description

- Types available from Inplayer SDK `inplayer.js` were not consistent with some of its endpoints' response types, so a new version `3.13.9` (edit: we eventually got to version `3.13.12`) was published with this inconsistency fixed, making previous temporarily done TypeScript workarounds with `// @ts-ignore`, `as unknown as any` or similar techniques no longer necessary.

This PR solves https://www.notion.so/Update-Publish-SDK-types-and-refactor-the-usage-in-the-OTT-App-93077f3eb74b4dc581cc508f84d00259.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
