### PR TITLE
fix: tvod ppv_custom access type

### DIFF
--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -202,7 +202,8 @@ const formatEntitlements = (expiresAt: number = 0, accessGranted: boolean = fals
 };
 
 const formatOffer = (offer: GetAccessFee): Offer => {
-  const offerId = offer.access_type.name === 'ppv' ? `C${offer.id}` : `S${offer.id}`;
+  const ppvOffers = ['ppv', 'ppv_custom'];
+  const offerId = ppvOffers.includes(offer.access_type.name) ? `C${offer.id}` : `S${offer.id}`;
   return {
     id: offer.id,
     offerId,


### PR DESCRIPTION
## Description

Quick fix so that we are able to support `ppv_custom` as access type, which means handling prices that can have different start/end time (defined by the customer in the InPlayer dashboard).

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
