### PR TITLE
POC: Cleeng/JWP integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@codeceptjs/allure-legacy": "^1.0.2",
     "@inplayer-org/inplayer.js": "^3.13.7",
+    "axios": "^1.4.0",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/src/components/Form/FormSection.tsx
+++ b/src/components/Form/FormSection.tsx
@@ -7,6 +7,7 @@ import Button from '#components/Button/Button';
 import LoadingOverlay from '#components/LoadingOverlay/LoadingOverlay';
 import useOpaqueId from '#src/hooks/useOpaqueId';
 import type { GenericFormValues } from '#types/form';
+import { FormErrors } from '#src/errors/FormErrors';
 
 export interface FormSectionContentArgs<T extends GenericFormValues, TErrors> {
   values: T;
@@ -24,7 +25,7 @@ export interface FormSectionProps<TData extends GenericFormValues, TErrors> {
   saveButton?: string;
   cancelButton?: string;
   canSave?: (values: TData) => boolean;
-  onSubmit?: (values: TData) => Promise<{ errors?: string[] }>;
+  onSubmit?: (values: TData) => Promise<void>;
   content: (args: FormSectionContentArgs<TData, TErrors>) => ReactNode;
   children?: never;
   readOnly?: boolean;
@@ -91,25 +92,28 @@ export function FormSection<TData extends GenericFormValues>({
   const handleSubmit = useCallback(
     async function handleSubmit(event?: React.FormEvent) {
       event && event.preventDefault();
+      let errors: string[] = [];
 
       if (onSubmit) {
-        let response: { errors?: string[] };
-
         try {
           setFormState((s) => {
             return { ...s, isBusy: true };
           });
-          response = await onSubmit(values);
+          await onSubmit(values);
         } catch (error: unknown) {
-          response = { errors: Array.of(error instanceof Error ? error.message : (error as string)) };
+          if (error instanceof FormErrors) {
+            errors = error.errors;
+          } else if (error instanceof Error) {
+            errors = [error.message];
+          }
         }
 
         // Don't leave edit mode if there are errors
-        if (response?.errors?.length) {
+        if (errors.length) {
           setFormState((s) => {
             return {
               ...s,
-              errors: response?.errors,
+              errors,
               isBusy: false,
             };
           });

--- a/src/errors/FormErrors.ts
+++ b/src/errors/FormErrors.ts
@@ -1,0 +1,8 @@
+export class FormErrors extends Error {
+  errors: string[];
+
+  constructor (errors: string[]) {
+    super('Form errors: ' + errors.join('\n'));
+    this.errors = errors;
+  }
+}

--- a/src/integration/cleeng/CleengIntegration.ts
+++ b/src/integration/cleeng/CleengIntegration.ts
@@ -1,0 +1,247 @@
+import jwtDecode from 'jwt-decode';
+
+import * as client from '#src/integration/cleeng/client';
+import * as favoritesService from '#src/services/favorites.service';
+import * as watchHistoryService from '#src/services/watchHistory.service';
+import type { AccountDetails } from '#types/app';
+import type { Config } from '#types/Config';
+import type { AuthData, EmailConfirmPasswordInput, FirstLastNameInput, JwtDetails, LocalesData } from '#types/account';
+import type { Customer } from '#types/cleeng';
+import { Integration } from '#src/integration/integration';
+import { formatAccountDetails } from '#src/integration/cleeng/formatters';
+import type { PlaylistItem } from '#types/playlist';
+import * as persist from '#src/utils/persist';
+import { logDev } from '#src/utils/common';
+
+const PERSIST_KEY_ACCOUNT = 'auth';
+
+export class CleengIntegration extends Integration {
+
+  sandbox: boolean = false;
+  publisherId: string = '';
+
+  locales: LocalesData | null = null;
+  authData: AuthData | null = null;
+  customer: Customer | null = null;
+
+  static IsSupported(config: Config) {
+    return !!config.integrations.cleeng?.id;
+  }
+
+  async isLoggedIn() {
+    return !!this.authData;
+  }
+
+  async getFeatures() {
+    return {
+      canUpdateEmail: true,
+      canRenewSubscription: true,
+      canChangePasswordWithOldPassword: false,
+    };
+  }
+
+  async initialize() {
+    this.sandbox = !!this.config.integrations.cleeng?.useSandbox;
+    this.publisherId = this.config.integrations.cleeng?.id || '';
+
+    this.locales = await client.getLocales({ sandbox: this.sandbox });
+
+    const storedAuthData: AuthData | null = persist.getItem(PERSIST_KEY_ACCOUNT) as AuthData | null;
+
+    try {
+      if (storedAuthData) {
+        this.authData = storedAuthData;
+
+        // try getting a new access token
+        await this.refreshAccessToken();
+
+        // get customer information
+        await this.getCustomer();
+      }
+    } catch (error: unknown) {
+      logDev('Error while restoring Cleeng session', error);
+      this.authData = null;
+    }
+
+    return this.customer ? formatAccountDetails(this.customer) : null;
+  }
+
+  async login(email: string, password: string, _stayLoggedIn?: boolean): Promise<AccountDetails> {
+    this.authData = await client.login({
+      publisherId: this.publisherId,
+      sandbox: this.sandbox,
+      email,
+      password,
+    });
+
+    persist.setItem(PERSIST_KEY_ACCOUNT, this.authData);
+
+    return this.getCustomer();
+  }
+
+  async register(email: string, password: string): Promise<AccountDetails> {
+    if (!this.locales) throw new Error('Locale data is missing');
+
+    this.authData = await client.register({
+      publisherId: this.publisherId,
+      sandbox: this.sandbox,
+      locale: this.locales.locale,
+      currency: this.locales.currency,
+      country: this.locales.country,
+      email,
+      password,
+    });
+
+    persist.setItem(PERSIST_KEY_ACCOUNT, this.authData);
+
+    return this.getCustomer();
+  }
+
+  async refreshAccessToken() {
+    if (!this.authData) throw new Error('User not logged in');
+
+    const { data: { responseData } } = await client.refreshToken({ sandbox: this.sandbox, refreshToken: this.authData.refreshToken })
+
+    this.authData = responseData;
+
+    persist.setItem(PERSIST_KEY_ACCOUNT, this.authData);
+  }
+
+  async getCustomer() {
+    if (!this.authData) throw new Error('User not signed in');
+
+    const decodedToken: JwtDetails = jwtDecode(this.authData.jwt);
+    const customerId = decodedToken.customerId;
+
+    this.customer = await client.getCustomer({
+      publisherId: this.publisherId,
+      sandbox: this.sandbox,
+      jwt: this.authData.jwt,
+      customerId,
+    });
+
+    return formatAccountDetails(this.customer);
+  }
+
+  async logout() {
+    this.authData = null;
+    this.customer = null;
+  }
+
+  async updateUserEmail (formData: EmailConfirmPasswordInput): Promise<AccountDetails> {
+    if (!this.customer || !this.authData) throw new Error('Not logged in');
+
+    const updatedCustomer = await client.updateCustomer({
+      sandbox: this.sandbox,
+      publisherId: this.publisherId,
+      jwt: this.authData.jwt,
+      customerId: this.customer.id,
+      payload: {
+        id: this.customer.id, // JWP specific??
+        ...formData,
+      },
+    });
+
+    return formatAccountDetails(updatedCustomer);
+  }
+
+  async updateUserProfile (formData: FirstLastNameInput): Promise<AccountDetails> {
+    if (!this.customer || !this.authData) throw new Error('Not logged in');
+
+    const updatedCustomer = await client.updateCustomer({
+      sandbox: this.sandbox,
+      publisherId: this.publisherId,
+      jwt: this.authData.jwt,
+      customerId: this.customer.id,
+      payload: {
+        id: this.customer.id, // JWP specific??
+        ...formData,
+      },
+    });
+
+    return formatAccountDetails(updatedCustomer);
+  }
+
+  // Personal Shelves
+
+  async saveFavorite(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // store in account
+    }
+
+    return await favoritesService.saveFavorite(item);
+  }
+
+  async removeFavorite(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // remove from account
+    }
+
+    return await favoritesService.removeFavorite(item);
+  }
+
+  async getFavorites() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    return await favoritesService.getFavorites();
+  }
+
+  async clearFavorites() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    await favoritesService.clearFavorites();
+  }
+
+  async saveWatchHistory(item: PlaylistItem, progress: number) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // store in account
+    }
+
+    return await watchHistoryService.saveWatchHistory(item, progress);
+  }
+
+  async removeWatchHistory(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // remove from account
+    }
+
+    return await watchHistoryService.removeWatchHistory(item);
+  }
+
+  async getWatchHistory() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    return await watchHistoryService.getWatchHistory();
+  }
+
+  async clearWatchHistory() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    await watchHistoryService.clearWatchHistory();
+  }
+
+}

--- a/src/integration/cleeng/client.ts
+++ b/src/integration/cleeng/client.ts
@@ -1,0 +1,118 @@
+import axios from 'axios';
+
+import type { CleengResponse, AuthData, LoginPayload, RegisterPayload, Customer, WithCleengParams, CleengParams, LocalesData } from '#types/cleeng';
+import type { UpdateCustomerPayload } from '#types/account';
+import { getOverrideIP } from '#src/utils/common';
+
+// config
+
+export const getBaseUrl = (sandbox: boolean) => (sandbox ? 'https://mediastore-sandbox.cleeng.com' : 'https://mediastore.cleeng.com');
+
+const api = axios.create({
+  baseURL: getBaseUrl(false),
+});
+
+const handleErrors = (errors: string[]) => {
+  if (errors.length > 0) {
+    throw new Error(errors[0]);
+  }
+};
+
+const withAuth = (jwt?: string) => {
+  return {
+    headers: { Authorization: jwt ? `Bearer ${jwt}` : undefined },
+  };
+};
+
+// global
+
+export const getLocales = async ({ sandbox }: CleengParams) => {
+  const {
+    data: { responseData },
+  } = await api.get<CleengResponse<LocalesData>>(getBaseUrl(sandbox) + `/locales${getOverrideIP() ? '?customerIP=' + getOverrideIP() : ''}`);
+
+  return responseData;
+};
+
+// account
+
+/**
+ * Log in to an existing account
+ */
+export const login = async ({ sandbox, publisherId, email, password }: WithCleengParams<{ email: string; password: string }>) => {
+  const payload: LoginPayload = {
+    email,
+    password,
+    publisherId,
+    customerIP: getOverrideIP(),
+  };
+
+  const {
+    data: { responseData, errors },
+  } = await api.post<CleengResponse<AuthData>>(getBaseUrl(sandbox) + '/auths', payload);
+
+  handleErrors(errors);
+
+  return responseData;
+};
+
+/**
+ * Register a new account
+ */
+export const register = async ({
+  sandbox,
+  publisherId,
+  email,
+  password,
+  locale,
+  country,
+  currency,
+}: WithCleengParams<{ email: string; password: string; locale: string; country: string; currency: string }>) => {
+  const payload: RegisterPayload = {
+    email,
+    password,
+    publisherId,
+    locale,
+    country,
+    currency,
+    customerIP: getOverrideIP(),
+  };
+
+  const {
+    data: { responseData, errors },
+  } = await api.post<CleengResponse<AuthData>>(getBaseUrl(sandbox) + '/customers', payload);
+
+  handleErrors(errors);
+
+  return responseData;
+};
+
+export const refreshToken = async ({ refreshToken, sandbox }: WithCleengParams<{ refreshToken: string }>) => {
+  return api.post<CleengResponse<AuthData>>(getBaseUrl(sandbox) + '/auths/refresh_token', { refreshToken });
+};
+
+/**
+ * Get the customer data
+ */
+export const getCustomer = async ({ sandbox, customerId, jwt }: WithCleengParams<{ customerId: string }>) => {
+  const {
+    data: { responseData, errors },
+  } = await api.get<CleengResponse<Customer>>(getBaseUrl(sandbox) + `/customers/${customerId}`, withAuth(jwt));
+
+  handleErrors(errors);
+
+  return responseData;
+};
+
+/**
+ * Update customer data
+ */
+export const updateCustomer = async ({ sandbox, customerId, jwt, payload }: WithCleengParams<{ customerId: string, payload: UpdateCustomerPayload }>) => {
+  const {
+    data: { responseData, errors },
+  } = await api.patch<CleengResponse<Customer>>(getBaseUrl(sandbox) + `/customers/${customerId}`, payload, withAuth(jwt));
+
+  handleErrors(errors);
+
+  return responseData;
+};

--- a/src/integration/cleeng/formatters.ts
+++ b/src/integration/cleeng/formatters.ts
@@ -1,0 +1,14 @@
+import type { Customer } from '#types/cleeng';
+import type { AccountDetails } from '#types/app';
+import { isString } from '#src/utils/common';
+
+export const formatAccountDetails = (customer: Customer): AccountDetails => {
+  return {
+    id: customer.id,
+    email: customer.email,
+    profile: {
+      firstName: isString(customer.metadata?.first_name) ? customer.metadata?.first_name : '',
+      lastName: isString(customer.metadata?.surname) ? customer.metadata?.surname : '',
+    },
+  };
+};

--- a/src/integration/index.ts
+++ b/src/integration/index.ts
@@ -1,0 +1,33 @@
+import type { Config } from '#types/Config';
+import type { Integration } from '#src/integration/integration';
+import { CleengIntegration } from '#src/integration/cleeng/CleengIntegration';
+import { JwpIntegration } from '#src/integration/jwp/JwpIntegration';
+
+const supportedIntegrations = [CleengIntegration, JwpIntegration];
+
+let currentIntegration: Integration | null = null;
+
+export const createIntegration = async (config: Config) => {
+  for (let i = 0; i < supportedIntegrations.length; i++) {
+    if (supportedIntegrations[i].IsSupported(config)) {
+      currentIntegration = new supportedIntegrations[i](config);
+      break;
+    }
+  }
+
+  return currentIntegration;
+};
+
+export const hasIntegration = () => !!currentIntegration;
+
+export const getIntegration = () => currentIntegration;
+
+export const withIntegration = async <T>(callback: (integration: Integration) => Promise<T> | T) => {
+  if (!currentIntegration) throw new Error('Integration is not initialized');
+
+  return callback(currentIntegration);
+};
+
+export const withOptionalIntegration = async (callback: (integration: Integration) => Promise<void> | void) => {
+  if (currentIntegration) return callback(currentIntegration);
+};

--- a/src/integration/integration.ts
+++ b/src/integration/integration.ts
@@ -1,0 +1,64 @@
+import type { Config } from '#types/Config';
+import type { AccountDetails } from '#types/app';
+import type { SerializedFavorite } from '#types/favorite';
+import type { SerializedWatchHistoryItem } from '#types/watchHistory';
+import type { PlaylistItem } from '#types/playlist';
+import type { EmailConfirmPasswordInput, FirstLastNameInput } from '#types/account';
+
+type IntegrationFeatures = {
+  canUpdateEmail: boolean;
+  canRenewSubscription: boolean;
+  canChangePasswordWithOldPassword: boolean;
+};
+
+export abstract class Integration {
+  static IsSupported(_config: Config) {
+    return false;
+  }
+
+  config: Config;
+
+  constructor (config: Config) {
+    this.config = config;
+  }
+
+  abstract initialize (): Promise<AccountDetails | null>;
+
+  abstract getFeatures (): Promise<IntegrationFeatures>;
+
+  // Account
+
+  abstract isLoggedIn (): Promise<boolean>;
+
+  abstract getCustomer (): Promise<AccountDetails>;
+
+  abstract login (email: string, password: string, stayLoggedIn?: boolean): Promise<AccountDetails>;
+
+  abstract logout (): Promise<void>;
+
+  abstract register (email: string, password: string): Promise<AccountDetails>;
+
+  abstract updateUserProfile (formData : FirstLastNameInput): Promise<AccountDetails>;
+
+  abstract updateUserEmail (formData : EmailConfirmPasswordInput): Promise<AccountDetails>;
+
+  // Personal Shelves
+
+  abstract getFavorites (): Promise<SerializedFavorite[]>;
+
+  abstract saveFavorite (item: PlaylistItem): Promise<SerializedFavorite[]>;
+
+  abstract removeFavorite (item: PlaylistItem): Promise<SerializedFavorite[]>;
+
+  abstract clearFavorites (): Promise<void>;
+
+  abstract getWatchHistory (): Promise<SerializedWatchHistoryItem[]>;
+
+  abstract saveWatchHistory (item: PlaylistItem, progress: number): Promise<SerializedWatchHistoryItem[]>;
+
+  abstract removeWatchHistory (item: PlaylistItem): Promise<SerializedWatchHistoryItem[]>;
+
+  abstract clearWatchHistory (): Promise<void>;
+
+}
+

--- a/src/integration/jwp/JwpIntegration.ts
+++ b/src/integration/jwp/JwpIntegration.ts
@@ -1,0 +1,224 @@
+import InPlayer, { AccountData, Env } from '@inplayer-org/inplayer.js';
+
+import { Integration } from '#src/integration/integration';
+import type { AccountDetails } from '#types/app';
+import type { Config } from '#types/Config';
+import { formatAccountDetails } from '#src/integration/jwp/formatters';
+import type { InPlayerError } from '#types/inplayer';
+import type { PlaylistItem } from '#types/playlist';
+import * as favoritesService from '#src/services/favorites.service';
+import * as watchHistoryService from '#src/services/watchHistory.service';
+import type { EmailConfirmPasswordInput, FirstLastNameInput } from '#types/account';
+
+enum InPlayerEnv {
+  Development = 'development',
+  Production = 'production',
+  Daily = 'daily',
+}
+
+export class JwpIntegration extends Integration {
+  clientId: string = '';
+
+  account: AccountData | null = null;
+
+  static IsSupported(config: Config) {
+    return !!config.integrations.jwp?.clientId;
+  }
+
+  // feature flags should only be used to show/hide certain parts of the UI
+  async getFeatures() {
+    return {
+      canUpdateEmail: false,
+      canRenewSubscription: false,
+      canChangePasswordWithOldPassword: true,
+    };
+  }
+
+  async initialize(): Promise<AccountDetails | null> {
+    if (!this.config.integrations.jwp) throw new Error('Failed to initialize JWP integration due to missing config');
+    if (!this.config.integrations.jwp.clientId) throw new Error('Failed to initialize JWP integration due to missing `clientId`');
+
+    const env: string = this.config.integrations.jwp.useSandbox ? InPlayerEnv.Development : InPlayerEnv.Production;
+
+    InPlayer.setConfig(env as Env);
+
+    this.clientId = this.config.integrations.jwp.clientId;
+
+    // restore logic
+    if (await this.isLoggedIn()) {
+      return this.getCustomer();
+    }
+
+    return null;
+  }
+
+  async isLoggedIn() {
+    return InPlayer.Account.isAuthenticated();
+  }
+
+  async login(email: string, password: string, _stayLoggedIn?: boolean): Promise<AccountDetails> {
+    try {
+      const { data } = await InPlayer.Account.signInV2({
+        email,
+        password,
+        clientId: this.clientId,
+        referrer: window.location.href,
+      });
+
+      // save account
+      this.account = data.account;
+
+      return formatAccountDetails(this.account);
+    } catch {
+      throw new Error('Failed to authenticate user.');
+    }
+  }
+
+  async register(email: string, password: string): Promise<AccountDetails> {
+    try {
+      const { data } = await InPlayer.Account.signUpV2({
+        email,
+        password,
+        passwordConfirmation: password,
+        fullName: email,
+        metadata: {
+          first_name: ' ',
+          surname: ' ',
+        },
+        type: 'consumer',
+        clientId: this.clientId,
+        referrer: window.location.href,
+      });
+
+      this.account = data.account;
+
+      return formatAccountDetails(this.account);
+    } catch (error: unknown) {
+      // not TS friendly
+      const { response } = error as InPlayerError;
+      throw new Error(response.data.message);
+    }
+  }
+
+  async getCustomer(): Promise<AccountDetails> {
+    try {
+      const { data } = await InPlayer.Account.getAccountInfo();
+
+      this.account = data;
+
+      return formatAccountDetails(data);
+    } catch (error: unknown) {
+      // not TS friendly
+      const { response } = error as InPlayerError;
+      throw new Error(response.data.message);
+    }
+  }
+
+  async logout() {
+    await InPlayer.Account.signOut();
+
+    this.account = null;
+  }
+
+  async updateUserEmail (_formData: EmailConfirmPasswordInput): Promise<AccountDetails> {
+    throw new Error('JWP doesn\'t support email update');
+  }
+
+  async updateUserProfile (formData: FirstLastNameInput): Promise<AccountDetails> {
+    try {
+      const { data } = await InPlayer.Account.updateAccount({
+        fullName: this.account?.email || ' ',
+        metadata: {
+            first_name: formData.firstName,
+            surname: formData.lastName,
+        },
+      });
+
+      return formatAccountDetails(data);
+    } catch {
+      throw new Error('Failed to update user data.');
+    }
+  }
+
+  // Personal Shelves
+
+  async saveFavorite(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // store in account
+    }
+
+    return await favoritesService.saveFavorite(item);
+  }
+
+  async removeFavorite(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // remove from account
+    }
+
+    return await favoritesService.removeFavorite(item);
+  }
+
+  async getFavorites() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    return await favoritesService.getFavorites();
+  }
+
+  async clearFavorites() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    await favoritesService.clearFavorites();
+  }
+
+  async saveWatchHistory(item: PlaylistItem, progress: number) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // store in account
+    }
+
+    return await watchHistoryService.saveWatchHistory(item, progress);
+  }
+
+  async removeWatchHistory(item: PlaylistItem) {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // remove from account
+    }
+
+    return await watchHistoryService.removeWatchHistory(item);
+  }
+
+  async getWatchHistory() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    return await watchHistoryService.getWatchHistory();
+  }
+
+  async clearWatchHistory() {
+    const isLoggedIn = await this.isLoggedIn();
+
+    if (isLoggedIn) {
+      // get from account
+    }
+
+    await watchHistoryService.clearWatchHistory();
+  }
+}

--- a/src/integration/jwp/formatters.ts
+++ b/src/integration/jwp/formatters.ts
@@ -1,0 +1,15 @@
+import type { AccountData } from '@inplayer-org/inplayer.js';
+
+import type { AccountDetails } from '#types/app';
+import { isString } from '#src/utils/common';
+
+export const formatAccountDetails = (account: AccountData): AccountDetails => {
+  return {
+    id: String(account.id),
+    email: account.email,
+    profile: {
+      firstName: isString(account.metadata.first_name) ? account.metadata.first_name : '',
+      lastName: isString(account.metadata.surname) ? account.metadata.surname : '',
+    },
+  };
+};

--- a/src/services/favorites.service.ts
+++ b/src/services/favorites.service.ts
@@ -1,0 +1,33 @@
+import * as persist from '#src/utils/persist';
+import type { SerializedFavorite } from '#types/favorite';
+import type { PlaylistItem } from '#types/playlist';
+
+const PERSIST_KEY_FAVORITES = `favorites${window.configId ? `-${window.configId}` : ''}`;
+
+export const saveFavorite = async (item: PlaylistItem) => {
+  const favorites = await getFavorites();
+  const updatedFavorites = [{ mediaid: item.mediaid }, ...favorites];
+
+  persist.setItem(PERSIST_KEY_FAVORITES, updatedFavorites);
+
+  return updatedFavorites;
+};
+
+export const removeFavorite = async (item: PlaylistItem) => {
+  const favorites = await getFavorites();
+  const updatedFavorites = favorites.filter(({ mediaid }) => mediaid !== item.mediaid);
+
+  persist.setItem(PERSIST_KEY_FAVORITES, updatedFavorites);
+
+  return updatedFavorites;
+};
+
+export const clearFavorites = async () => {
+  persist.setItem(PERSIST_KEY_FAVORITES, []);
+};
+
+export const getFavorites = async () => {
+  const favorites = persist.getItem<SerializedFavorite[]>(PERSIST_KEY_FAVORITES) || [];
+
+  return favorites || [];
+};

--- a/src/services/watchHistory.service.ts
+++ b/src/services/watchHistory.service.ts
@@ -1,0 +1,33 @@
+import * as persist from '#src/utils/persist';
+import type { PlaylistItem } from '#types/playlist';
+import type { SerializedWatchHistoryItem } from '#types/watchHistory';
+
+const PERSIST_KEY_WATCH_HISTORY = `watchhistory${window.configId ? `-${window.configId}` : ''}`;
+
+export const saveWatchHistory = async (item: PlaylistItem, progress: number) => {
+  const watchHistory = await getWatchHistory();
+  const updatedWatchHistory = [{ mediaid: item.mediaid, progress }, ...watchHistory];
+
+  persist.setItem(PERSIST_KEY_WATCH_HISTORY, updatedWatchHistory);
+
+  return updatedWatchHistory;
+};
+
+export const removeWatchHistory = async (item: PlaylistItem) => {
+  const watchHistory = await getWatchHistory();
+  const updatedWatchHistory = watchHistory.filter(({ mediaid }) => mediaid !== item.mediaid);
+
+  persist.setItem(PERSIST_KEY_WATCH_HISTORY, updatedWatchHistory);
+
+  return updatedWatchHistory;
+};
+
+export const clearWatchHistory = async () => {
+  persist.setItem(PERSIST_KEY_WATCH_HISTORY, []);
+};
+
+export const getWatchHistory = async () => {
+  const watchHistory = persist.getItem<SerializedWatchHistoryItem[]>(PERSIST_KEY_WATCH_HISTORY) || [];
+
+  return watchHistory || [];
+};

--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -1,4 +1,5 @@
 import i18next from 'i18next';
+
 import type {
   AuthData,
   Capture,
@@ -33,8 +34,6 @@ export const initializeAccount = async () => {
   if (integration) {
     const features = await integration.getFeatures();
     const account = await integration.initialize();
-
-    console.log(account)
 
     useAccountStore.setState({
       user: account,

--- a/src/stores/AccountStore.ts
+++ b/src/stores/AccountStore.ts
@@ -1,11 +1,11 @@
 import type { PaymentDetail, Subscription, Transaction } from '#types/subscription';
-import type { AuthData, Consent, Customer, CustomerConsent } from '#types/account';
+import type { Consent, CustomerConsent } from '#types/account';
 import { createStore } from '#src/stores/utils';
+import type { AccountDetails } from '#types/app';
 
 type AccountStore = {
   loading: boolean;
-  auth: AuthData | null;
-  user: Customer | null;
+  user: AccountDetails | null;
   subscription: Subscription | null;
   transactions: Transaction[] | null;
   activePayment: PaymentDetail | null;

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,5 +1,7 @@
 import { overrideIPCookieKey } from '#test/constants';
 
+export const isString = (input: unknown) : input is string => typeof input === 'string';
+
 export function debounce<T extends (...args: any[]) => void>(callback: T, wait = 200) {
   let timeout: NodeJS.Timeout | null;
   return (...args: unknown[]) => {

--- a/types/app.d.ts
+++ b/types/app.d.ts
@@ -1,0 +1,9 @@
+export type AccountDetails = {
+  id: string;
+  email: string;
+
+  profile: {
+    firstName: string | undefined;
+    lastName: string | undefined;
+  }
+};

--- a/types/cleeng.d.ts
+++ b/types/cleeng.d.ts
@@ -1,8 +1,68 @@
-interface ApiResponse {
-  errors: string[];
-}
-type CleengResponse<R> = { responseData: R } & ApiResponse;
-type CleengEmptyRequest<R> = (sandbox: boolean) => Promise<CleengResponse<R>>;
-type CleengEmptyAuthRequest<R> = (sandbox: boolean, jwt: string) => Promise<CleengResponse<R>>;
-type CleengRequest<P, R> = (payload: P, sandbox: boolean) => Promise<CleengResponse<R>>;
-type CleengAuthRequest<P, R> = (payload: P, sandbox: boolean, jwt: string) => Promise<CleengResponse<R>>;
+import type { ExternalData } from '#types/account';
+
+type CleengResponse<R> = { responseData: R, errors: [] };
+
+type CleengDirectResponse<R> = R;
+
+type CleengParams = { publisherId?: string; sandbox: boolean; jwt?: string; };
+type WithCleengParams<R> = R & CleengParams;
+
+export type AuthData = {
+  jwt: string;
+  customerToken: string;
+  refreshToken: string;
+};
+
+export type JwtDetails = {
+  customerId: string;
+  exp: number;
+  publisherId: number;
+};
+
+export type PayloadWithIPOverride = {
+  customerIP?: string;
+};
+
+export type LoginPayload = PayloadWithIPOverride & {
+  email: string;
+  password: string;
+  offerId?: string;
+  publisherId?: string;
+};
+
+export type RegisterPayload = PayloadWithIPOverride & {
+  email: string;
+  password: string;
+  offerId?: string;
+  publisherId?: string;
+  locale: string;
+  country: string;
+  currency: string;
+  firstName?: string;
+  lastName?: string;
+  externalId?: string;
+  externalData?: string;
+};
+
+export type Customer = {
+  id: string;
+  email: string;
+  country: string;
+  regDate: string;
+  lastLoginDate?: string;
+  lastUserIp: string;
+  firstName?: string;
+  metadata?: Record<string, unknown>;
+  lastName?: string;
+  fullName?: string;
+  uuid?: string;
+  externalId?: string;
+  externalData?: ExternalData;
+};
+
+export type LocalesData = {
+  country: string;
+  currency: string;
+  locale: string;
+  ipAddress: string;
+};

--- a/types/cleeng.d.ts
+++ b/types/cleeng.d.ts
@@ -1,10 +1,10 @@
 import type { ExternalData } from '#types/account';
 
-type CleengResponse<R> = { responseData: R, errors: [] };
+type CleengResponse<R> = { responseData: R, errors: string[] };
 
 type CleengDirectResponse<R> = R;
 
-type CleengParams = { publisherId?: string; sandbox: boolean; jwt?: string; };
+type CleengParams = { publisherId?: string; };
 type WithCleengParams<R> = R & CleengParams;
 
 export type AuthData = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,7 +2714,7 @@ axios@^0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^1.3.3:
+axios@^1.3.3, axios@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
   integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==


### PR DESCRIPTION
## Description

We discussed the current implementation of the Cleeng and JWP clients earlier, and I had some ideas on how to improve this. 

**The current issues**

- Type inconsistencies in services
- Mixture of Cleeng/JWP data and typing in UI and Controllers
- JWP data is transformed to conform to Cleeng API responses

**What I propose**

- Add an abstract class, "Integration", which defines the abstract methods that each integration should expose
  - Interface could also work, but this doesn't work with constructor params and static members
- Add a JWP and Cleeng integration
  - The app will define common types for the data used in the views. This should not be the Cleeng or JWP types.
  - All integrations transform the data to conform to the app types. E.g. `Customer` -> `AccountDetails`
  - Only the integration knows about the client (Cleeng: client.ts, JWP: InPlayer import)
  - Integration exposes all supported features which the UI can use to hide/show certain elements

With this proposal, the UI and controllers/state know nothing about Cleeng or JWP implementations. This will make it much easier to develop custom features for a specific integration not supported by the others. 

This PR is unfinished, but I'm curious about your thoughts before I continue refactoring everything.

(PS This is not made in the current sprint)
