### PR TITLE
Feat / checkout and payment improvements

### DIFF
--- a/src/components/CheckoutForm/CheckoutForm.module.scss
+++ b/src/components/CheckoutForm/CheckoutForm.module.scss
@@ -115,7 +115,7 @@
   }
 
   tfoot {
-    tr:first-child {
+    tr:first-of-type {
       td {
         padding-top: 8px;
         font-weight: var(--body-font-weight-bold);
@@ -123,14 +123,13 @@
       }
     }
 
-    tr:last-child {
+    tr:not(:first-of-type) {
       td {
         font-size: 14px;
       }
     }
   }
-}
-
+  }
 .divider {
   border: none;
   border-top: 1px solid rgba(variables.$white, 0.34);

--- a/src/components/CheckoutForm/CheckoutForm.tsx
+++ b/src/components/CheckoutForm/CheckoutForm.tsx
@@ -151,20 +151,24 @@ const CheckoutForm: React.FC<Props> = ({
                 <td>{formatPrice(-offer.customerPriceInclTax, order.currency, offer.customerCountry)}</td>
               </tr>
             ) : null}
-            <tr>
-              <td>{t('checkout.payment_method_fee')}</td>
-              <td>{formatPrice(order.priceBreakdown.paymentMethodFee, order.currency, offer.customerCountry)}</td>
-            </tr>
+            {order.priceBreakdown.paymentMethodFee > 0 && (
+              <tr>
+                <td>{t('checkout.payment_method_fee')}</td>
+                <td>{formatPrice(order.priceBreakdown.paymentMethodFee, order.currency, offer.customerCountry)}</td>
+              </tr>
+            )}
           </tbody>
           <tfoot>
             <tr>
               <td>{t('checkout.total_price')}</td>
               <td>{formatPrice(order.totalPrice, order.currency, offer.customerCountry)}</td>
             </tr>
-            <tr>
-              <td>{t('checkout.applicable_tax', { taxRate: Math.round(order.taxRate * 100) })}</td>
-              <td>{formatPrice(order.priceBreakdown.taxValue, order.currency, offer.customerCountry)}</td>
-            </tr>
+            {order.priceBreakdown.taxValue > 0 && (
+              <tr>
+                <td>{t('checkout.applicable_tax', { taxRate: Math.round(order.taxRate * 100) })}</td>
+                <td>{formatPrice(order.priceBreakdown.taxValue, order.currency, offer.customerCountry)}</td>
+              </tr>
+            )}
           </tfoot>
         </table>
       </div>

--- a/src/components/CheckoutForm/__snapshots__/CheckoutForm.test.tsx.snap
+++ b/src/components/CheckoutForm/__snapshots__/CheckoutForm.test.tsx.snap
@@ -67,16 +67,7 @@ exports[`<CheckoutForm> > renders and matches snapshot 1`] = `
       <table
         class="_orderTotals_abc9bc"
       >
-        <tbody>
-          <tr>
-            <td>
-              checkout.payment_method_fee
-            </td>
-            <td>
-              € 0,00
-            </td>
-          </tr>
-        </tbody>
+        <tbody />
         <tfoot>
           <tr>
             <td>

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -50,6 +50,7 @@ const Payment = ({
   const hasMoreTransactions = hiddenTransactionsCount > 0;
   const navigate = useNavigate();
   const location = useLocation();
+  const isGrantedSubscription = activeSubscription?.period === 'granted';
 
   function onCompleteSubscriptionClick() {
     navigate(addQueryParam(location, 'u', 'choose-offer'));
@@ -92,16 +93,18 @@ const Payment = ({
               <div className={styles.infoBox} key={activeSubscription.subscriptionId}>
                 <p>
                   <strong>{getTitle(activeSubscription.period)}</strong> <br />
-                  {activeSubscription.status === 'active' && activeSubscription.period !== 'granted'
+                  {activeSubscription.status === 'active' && !isGrantedSubscription
                     ? t('user:payment.next_billing_date_on', { date: formatDate(activeSubscription.expiresAt) })
                     : t('user:payment.subscription_expires_on', { date: formatDate(activeSubscription.expiresAt) })}
                 </p>
-                <p className={styles.price}>
-                  <strong>{formatPrice(activeSubscription.nextPaymentPrice, activeSubscription.nextPaymentCurrency, customer.country)}</strong>
-                  <small>/{t(`account:periods.${activeSubscription.period}`)}</small>
-                </p>
+                {!isGrantedSubscription && (
+                  <p className={styles.price}>
+                    <strong>{formatPrice(activeSubscription.nextPaymentPrice, activeSubscription.nextPaymentCurrency, customer.country)}</strong>
+                    <small>/{t(`account:periods.${activeSubscription.period}`)}</small>
+                  </p>
+                )}
               </div>
-              {activeSubscription.status === 'active' && activeSubscription.period !== 'granted' ? (
+              {activeSubscription.status === 'active' && !isGrantedSubscription ? (
                 <Button label={t('user:payment.cancel_subscription')} onClick={onCancelSubscriptionClick} />
               ) : canRenewSubscription ? (
                 <Button label={t('user:payment.renew_subscription')} onClick={onRenewSubscriptionClick} />
@@ -156,10 +159,11 @@ const Payment = ({
               <div className={styles.infoBox} key={transaction.transactionId}>
                 <p className="transactionItem">
                   <strong>{transaction.offerTitle}</strong> <br />
-                  {t('user:payment.price_payed_with', {
-                    price: formatPrice(parseFloat(transaction.transactionPriceInclTax), transaction.transactionCurrency, transaction.customerCountry),
-                    method: transaction.paymentMethod,
-                  })}
+                  {!isGrantedSubscription &&
+                    t('user:payment.price_payed_with', {
+                      price: formatPrice(parseFloat(transaction.transactionPriceInclTax), transaction.transactionCurrency, transaction.customerCountry),
+                      method: transaction.paymentMethod,
+                    })}
                 </p>
                 <p>
                   {transaction.transactionId}

--- a/test-e2e/tests/payments/coupons_test.ts
+++ b/test-e2e/tests/payments/coupons_test.ts
@@ -66,7 +66,9 @@ function runTestSuite(props: ProviderProps, providerName: string) {
 
     I.see(formatPrice(-37.5, 'EUR', props.locale));
     I.see(formatPrice(12.5, 'EUR', props.locale));
-    I.see(formatPrice(props.applicableTax, 'EUR', props.locale));
+    if (props.applicableTax !== 0) {
+      I.see(formatPrice(props.applicableTax, 'EUR', props.locale));
+    }
 
     I.fillField('couponCode', 'test100');
     I.click('Apply');

--- a/test-e2e/tests/payments/subscription_test.ts
+++ b/test-e2e/tests/payments/subscription_test.ts
@@ -111,8 +111,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
 
     I.see('Redeem coupon');
     I.see(props.yearlyOffer.price);
-    I.see('Payment method fee');
-    I.see(props.yearlyOffer.paymentFee);
+    I.dontSee('Payment method fee');
+    I.dontSee(props.yearlyOffer.paymentFee);
     I.see('Total');
     if (props.applicableTax !== 0) {
       I.see('Applicable tax (21%)');


### PR DESCRIPTION
## Description

This PR addresses two bugs:

- Remove pricing on payment page for granted subscriptions
   - With `activeSubscription.period` it's determined whether or not to show the pricing. This was necessary because the data is mocked for a "granted" subscription (see `formatGrantedSubscription`), which caused a wrong currency symbol to appear for countries that don't use 'EUR'.
- Hide tax and payment provider fees when not applicable
   - If there is no tax and/or no payment provider fee, they're now hidden during the checkout process
