### PR TITLE
Fix / TVOD infinite loop and render optimizations

### DIFF
--- a/src/containers/AccountModal/AccountModal.tsx
+++ b/src/containers/AccountModal/AccountModal.tsx
@@ -24,6 +24,7 @@ import { addQueryParam, removeQueryParam } from '#src/utils/location';
 import FinalizePayment from '#components/FinalizePayment/FinalizePayment';
 import WaitingForPayment from '#components/WaitingForPayment/WaitingForPayment';
 import UpdatePaymentMethod from '#src/containers/UpdatePaymentMethod/UpdatePaymentMethod';
+import useEventCallback from '#src/hooks/useEventCallback';
 
 const PUBLIC_VIEWS = ['login', 'create-account', 'forgot-password', 'reset-password', 'send-confirmation', 'edit-password'];
 
@@ -41,6 +42,14 @@ const AccountModal = () => {
   } = config;
   const isPublicView = viewParam && PUBLIC_VIEWS.includes(viewParam);
 
+  const toLogin = useEventCallback(() => {
+    navigate(addQueryParam(location, 'u', 'login'));
+  });
+
+  const closeHandler = useEventCallback(() => {
+    navigate(removeQueryParam(location, 'u'));
+  });
+
   useEffect(() => {
     // make sure the last view is rendered even when the modal gets closed
     if (viewParam) setView(viewParam);
@@ -48,13 +57,9 @@ const AccountModal = () => {
 
   useEffect(() => {
     if (!!viewParam && !loading && !user && !isPublicView) {
-      navigate(addQueryParam(location, 'u', 'login'));
+      toLogin();
     }
-  }, [viewParam, navigate, location, loading, user, isPublicView]);
-
-  const closeHandler = () => {
-    navigate(removeQueryParam(location, 'u'));
-  };
+  }, [viewParam, loading, user, isPublicView, toLogin]);
 
   const renderForm = () => {
     if (!user && loading && !isPublicView) {

--- a/src/hooks/useClientIntegration.ts
+++ b/src/hooks/useClientIntegration.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { useConfigStore } from '#src/stores/ConfigStore';
 
 export enum ClientIntegrations {
@@ -11,10 +13,24 @@ const useClientIntegration = () => {
   } = useConfigStore.getState();
 
   const isJWP = !!integrations.jwp?.clientId;
+  const isCleeng = !!integrations.cleeng?.id;
   const sandbox = isJWP ? integrations.jwp?.useSandbox : integrations.cleeng?.useSandbox;
   const client = isJWP ? ClientIntegrations.JWP : ClientIntegrations.CLEENG;
   const clientId = isJWP ? integrations.jwp?.clientId : integrations.cleeng?.id;
-  const clientOffers = isJWP ? [`${integrations.jwp?.assetId}`] : [`${integrations.cleeng?.monthlyOffer}`, `${integrations.cleeng?.yearlyOffer}`];
+
+  // prevent infinite updates when `clientOffers` is used in as dependency
+  const clientOffers = useMemo(() => {
+    if (isJWP && !!integrations.jwp?.assetId) {
+      return [`${integrations.jwp.assetId}`];
+    }
+
+    if (isCleeng && integrations.cleeng?.monthlyOffer && integrations.cleeng?.yearlyOffer) {
+      return [`${integrations.cleeng.monthlyOffer}`, `${integrations.cleeng.yearlyOffer}`];
+    }
+
+    // No offers or JWP/Cleeng TVOD
+    return [];
+  }, [isJWP, isCleeng, integrations.jwp, integrations.cleeng]);
 
   return {
     sandbox: sandbox ?? true,

--- a/src/hooks/useEntitlement.ts
+++ b/src/hooks/useEntitlement.ts
@@ -23,6 +23,8 @@ type QueryResult = {
   responseData?: GetEntitlementsResponse;
 };
 
+const notifyOnChangeProps = ['data' as const, 'isLoading' as const];
+
 /**
  * useEntitlement()
  *
@@ -55,6 +57,7 @@ const useEntitlement: UseEntitlement = (playlistItem) => {
       queryFn: () => checkoutService?.getEntitlements({ offerId }, sandbox),
       enabled: !!playlistItem && !!user && !!offerId && !isPreEntitled,
       refetchOnMount: 'always' as const,
+      notifyOnChangeProps,
     })),
   );
 


### PR DESCRIPTION
## Description

This PR fixes an infinite render loop when opening the Choose Offer modal for a JWP TVOD platform. This was caused by the `clientOffers` being constructed each render while being a dependency in the `useOffers` hook.

Besides that, for a TVOD platform, the `clientOffer` resulted in `['null']` when not set. This causes the `useOffers` hook to request non-existing offers for JWP and Cleeng.

The other commit fixes some unnecessary renders in the Choose Offer form caused by depending on the `location` or `navigate` (which also depends on `location`) reactive variables. 
