### PR TITLE
Feat / BCL live events

### DIFF
--- a/src/components/Card/Card.module.scss
+++ b/src/components/Card/Card.module.scss
@@ -210,6 +210,12 @@ $aspects: ((1, 1), (2, 1), (2, 3), (4, 3), (5, 3), (16, 9), (9, 16), (9, 13));
   background-color: variables.$red;
 }
 
+svg.scheduled {
+  width: 18px;
+  height: 18px;
+  margin-right: 4px;
+}
+
 .progressContainer {
   position: absolute;
   right: 0;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import { formatDurationTag, formatSeriesMetaString } from '#src/utils/formatting
 import Lock from '#src/icons/Lock';
 import Image from '#components/Image/Image';
 import type { ImageData } from '#types/playlist';
+import Today from '#src/icons/Today';
 
 export const cardAspectRatios = ['2:1', '16:9', '5:3', '4:3', '1:1', '9:13', '2:3', '9:16'] as const;
 
@@ -30,6 +31,8 @@ type CardProps = {
   isCurrent?: boolean;
   isLocked?: boolean;
   currentLabel?: string;
+  isLive?: boolean;
+  isScheduled?: boolean;
 };
 
 function Card({
@@ -49,8 +52,10 @@ function Card({
   isCurrent = false,
   isLocked = true,
   currentLabel,
+  isLive = false,
+  isScheduled = false,
 }: CardProps): JSX.Element {
-  const { t } = useTranslation('common');
+  const { t } = useTranslation(['common', 'video']);
   const [imageLoaded, setImageLoaded] = useState(false);
   const cardClassName = classNames(styles.card, {
     [styles.featured]: featured,
@@ -72,8 +77,15 @@ function Card({
       return <div className={styles.tag}>{formatSeriesMetaString(seasonNumber, episodeNumber)}</div>;
     } else if (duration) {
       return <div className={styles.tag}>{formatDurationTag(duration)}</div>;
-    } else if (duration === 0) {
+    } else if (isLive) {
       return <div className={classNames(styles.tag, styles.live)}>{t('live')}</div>;
+    } else if (isScheduled) {
+      return (
+        <div className={styles.tag}>
+          <Today className={styles.scheduled} />
+          {t('scheduled')}
+        </div>
+      );
     }
   };
 

--- a/src/components/Shelf/Shelf.tsx
+++ b/src/components/Shelf/Shelf.tsx
@@ -12,6 +12,8 @@ import { isLocked } from '#src/utils/entitlements';
 import TileDock from '#components/TileDock/TileDock';
 import Card, { type PosterAspectRatio } from '#components/Card/Card';
 import type { Playlist, PlaylistItem } from '#types/playlist';
+import { isLiveChannel } from '#src/utils/media';
+import { MediaStatus } from '#src/utils/liveEvent';
 
 export const tileBreakpoints: Breakpoints = {
   [Breakpoint.xs]: 1,
@@ -87,6 +89,8 @@ const Shelf = ({
         loading={loading}
         isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, item)}
         posterAspect={posterAspect}
+        isLive={item.mediaStatus === MediaStatus.LIVE || isLiveChannel(item)}
+        isScheduled={item.mediaStatus === MediaStatus.SCHEDULED}
       />
     ),
     [watchHistory, onCardHover, featured, loading, accessModel, isLoggedIn, hasSubscription, posterAspect, onCardClick, playlist.feedid, type],

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+
+import Tag from '#components/Tag/Tag';
+import Today from '#src/icons/Today';
+import { MediaStatus } from '#src/utils/liveEvent';
+
+type Props = {
+  mediaStatus?: MediaStatus;
+};
+
+export default function StatusIcon({ mediaStatus }: Props) {
+  const { t } = useTranslation('video');
+
+  if (mediaStatus === MediaStatus.SCHEDULED) {
+    return <Today />;
+  } else if (mediaStatus === MediaStatus.LIVE) {
+    return <Tag isLive>{t('live')}</Tag>;
+  }
+
+  return null;
+}

--- a/src/components/VideoDetails/VideoDetails.module.scss
+++ b/src/components/VideoDetails/VideoDetails.module.scss
@@ -68,10 +68,16 @@
 }
 
 .primaryMetadata {
+  display: flex;
+  align-items: center;
   margin-bottom: 8px;
   font-size: 16px;
   line-height: 18px;
   letter-spacing: 0.15px;
+  
+  > :first-child {
+    margin-right: 8px;
+  }
 
   @include responsive.mobile-only() {
     order: 2;

--- a/src/components/VideoDetailsInline/VideoDetailsInline.module.scss
+++ b/src/components/VideoDetailsInline/VideoDetailsInline.module.scss
@@ -69,15 +69,17 @@ div.title {
 }
 
 .primaryMetadata {
+  display: flex;
   flex: 1;
   flex-basis: 100%;
+  align-items: center;
   margin-right: auto;
   margin-bottom: 0;
   font-size: 16px;
   line-height: 18px;
   letter-spacing: 0.15px;
 
-  > div.live {
+  > :first-child {
     display: inline-block;
     margin-right: 8px;
 

--- a/src/components/VideoDetailsInline/VideoDetailsInline.tsx
+++ b/src/components/VideoDetailsInline/VideoDetailsInline.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import styles from './VideoDetailsInline.module.scss';
 
-import Tag from '#components/Tag/Tag';
 import CollapsibleText from '#components/CollapsibleText/CollapsibleText';
 import useBreakpoint, { Breakpoint } from '#src/hooks/useBreakpoint';
 import { testId } from '#src/utils/common';
@@ -18,8 +16,7 @@ type Props = {
   live?: boolean;
 };
 
-const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetadata, shareButton, favoriteButton, trailerButton, live }) => {
-  const { t } = useTranslation('common');
+const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetadata, shareButton, favoriteButton, trailerButton }) => {
   const breakpoint: Breakpoint = useBreakpoint();
   const isMobile = breakpoint === Breakpoint.xs;
 
@@ -29,14 +26,7 @@ const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetada
     <div className={styles.details} data-testid={testId('video-details-inline')}>
       <TitleComponent className={styles.title}>{title}</TitleComponent>
       <div className={styles.inlinePlayerMetadata}>
-        <div className={styles.primaryMetadata}>
-          {live && (
-            <Tag className={styles.live} isLive>
-              {t('live')}
-            </Tag>
-          )}
-          {primaryMetadata}
-        </div>
+        <div className={styles.primaryMetadata}>{primaryMetadata}</div>
         {trailerButton}
         {favoriteButton}
         {shareButton}

--- a/src/components/VideoList/VideoList.tsx
+++ b/src/components/VideoList/VideoList.tsx
@@ -8,6 +8,8 @@ import { isLocked } from '#src/utils/entitlements';
 import { testId } from '#src/utils/common';
 import type { AccessModel } from '#types/Config';
 import type { Playlist, PlaylistItem } from '#types/playlist';
+import { isLiveChannel } from '#src/utils/media';
+import { MediaStatus } from '#src/utils/liveEvent';
 
 type Props = {
   playlist?: Playlist;
@@ -43,7 +45,7 @@ function VideoList({
       {!!header && header}
       {playlist &&
         playlist.playlist.map((playlistItem: PlaylistItem) => {
-          const { mediaid, title, duration, seriesId, episodeNumber, seasonNumber, shelfImage } = playlistItem;
+          const { mediaid, title, duration, seriesId, episodeNumber, seasonNumber, shelfImage, mediaStatus } = playlistItem;
 
           return (
             <VideoListItem
@@ -61,6 +63,8 @@ function VideoList({
               isActive={activeMediaId === mediaid}
               activeLabel={activeLabel}
               isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
+              isLive={mediaStatus === MediaStatus.LIVE || isLiveChannel(playlistItem)}
+              isScheduled={mediaStatus === MediaStatus.SCHEDULED}
             />
           );
         })}

--- a/src/components/VideoListItem/VideoListItem.module.scss
+++ b/src/components/VideoListItem/VideoListItem.module.scss
@@ -106,6 +106,12 @@ svg.lock {
   border-radius: 4px;
 }
 
+svg.scheduled {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+}
+
 .tag {
   margin-left: 4px;
   padding: 2px 6px;
@@ -115,6 +121,8 @@ svg.lock {
 .live {
   background-color: variables.$red;
 }
+
+
 
 .progressContainer {
   position: absolute;

--- a/src/components/VideoListItem/VideoListItem.tsx
+++ b/src/components/VideoListItem/VideoListItem.tsx
@@ -9,6 +9,7 @@ import Image from '#components/Image/Image';
 import Lock from '#src/icons/Lock';
 import Tag from '#components/Tag/Tag';
 import { formatDurationTag, formatSeriesMetaString } from '#src/utils/formatting';
+import Today from '#src/icons/Today';
 
 type VideoListItemProps = {
   onClick?: () => void;
@@ -24,6 +25,8 @@ type VideoListItemProps = {
   isActive?: boolean;
   activeLabel?: string;
   isLocked?: boolean;
+  isLive?: boolean;
+  isScheduled?: boolean;
 };
 
 function VideoListItem({
@@ -40,6 +43,8 @@ function VideoListItem({
   activeLabel,
   isLocked = true,
   image,
+  isLive = false,
+  isScheduled = false,
 }: VideoListItemProps): JSX.Element {
   const { t } = useTranslation('common');
   const [imageLoaded, setImageLoaded] = useState(false);
@@ -56,8 +61,15 @@ function VideoListItem({
       return formatSeriesMetaString(seasonNumber, episodeNumber);
     } else if (duration) {
       return formatDurationTag(duration);
-    } else if (duration === 0) {
+    } else if (isLive) {
       return t('live');
+    } else if (isScheduled) {
+      return (
+        <>
+          <Today className={styles.scheduled} />
+          {t('scheduled')}
+        </>
+      );
     }
   };
 
@@ -78,7 +90,7 @@ function VideoListItem({
         {isActive && <div className={styles.activeLabel}>{activeLabel}</div>}
         <div className={styles.tags}>
           {isLocked && <Lock className={styles.lock} />}
-          <Tag className={classNames(styles.tag, { [styles.live]: duration === 0 })}>{renderTagLabel()}</Tag>
+          <Tag className={classNames(styles.tag, { [styles.live]: isLive })}>{renderTagLabel()}</Tag>
         </div>
 
         {progress ? (

--- a/src/containers/InlinePlayer/InlinePlayer.tsx
+++ b/src/containers/InlinePlayer/InlinePlayer.tsx
@@ -25,6 +25,7 @@ type Props = {
   startWatchingButton: React.ReactNode;
   isLoggedIn: boolean;
   paywall: boolean;
+  playable?: boolean;
   autostart?: boolean;
 };
 
@@ -41,6 +42,7 @@ const InlinePlayer: React.FC<Props> = ({
   isLoggedIn,
   paywall,
   autostart,
+  playable = true,
 }: Props) => {
   const siteName = useConfigStore((s) => s.config.siteName);
   const { t } = useTranslation();
@@ -53,17 +55,21 @@ const InlinePlayer: React.FC<Props> = ({
 
   return (
     <div className={styles.inlinePlayer}>
-      <Fade open={paywall}>
+      <Fade open={!playable || paywall}>
         <div className={styles.paywall}>
           <Image className={styles.poster} image={item.backgroundImage} alt={item.title} width={1280} />
-          <Lock className={styles.lock} />
-          <h2 className={styles.title}>{t('video:sign_up_to_start_watching')}</h2>
-          <span className={styles.text}>{t('account:choose_offer.watch_this_on_platform', { siteName })}</span>
-          {startWatchingButton}
-          {!isLoggedIn && <Button onClick={loginButtonClickHandler} label={t('common:sign_in')} />}
+          {paywall && (
+            <>
+              <Lock className={styles.lock} />
+              <h2 className={styles.title}>{t('video:sign_up_to_start_watching')}</h2>
+              <span className={styles.text}>{t('account:choose_offer.watch_this_on_platform', { siteName })}</span>
+              {startWatchingButton}
+              {!isLoggedIn && <Button onClick={loginButtonClickHandler} label={t('common:sign_in')} />}
+            </>
+          )}
         </div>
       </Fade>
-      {!paywall && (
+      {!paywall && playable && (
         <PlayerContainer
           item={item}
           feedId={feedId}

--- a/src/hooks/useLiveEvent.ts
+++ b/src/hooks/useLiveEvent.ts
@@ -1,10 +1,9 @@
 import type { PlaylistItem } from '../../types/playlist';
-import { getMediaStatusFromEventState, isLiveEvent, isPlayable } from '../utils/liveEvent';
+import { isLiveEvent, isPlayable } from '../utils/liveEvent';
 
 export function useLiveEvent(media: PlaylistItem) {
   return {
     isLiveEvent: isLiveEvent(media),
-    mediaStatus: getMediaStatusFromEventState(media),
     isPlayable: isPlayable(media),
   };
 }

--- a/src/hooks/useLiveEvent.ts
+++ b/src/hooks/useLiveEvent.ts
@@ -1,0 +1,10 @@
+import type { PlaylistItem } from '../../types/playlist';
+import { getMediaStatusFromEventState, isLiveEvent, isPlayable } from '../utils/liveEvent';
+
+export function useLiveEvent(media: PlaylistItem) {
+  return {
+    isLiveEvent: isLiveEvent(media),
+    mediaStatus: getMediaStatusFromEventState(media),
+    isPlayable: isPlayable(media),
+  };
+}

--- a/src/icons/Today.tsx
+++ b/src/icons/Today.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import createIcon from './Icon';
+
+export default createIcon(
+  '0 0 24 24',
+  <g>
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z" />
+  </g>,
+);

--- a/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -30,7 +30,7 @@ import InlinePlayer from '#src/containers/InlinePlayer/InlinePlayer';
 import StatusIcon from '#components/StatusIcon/StatusIcon';
 
 const MediaEvent: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
-  const { t } = useTranslation('video');
+  const { t, i18n } = useTranslation('video');
 
   const [playTrailer, setPlayTrailer] = useState<boolean>(false);
   const breakpoint = useBreakpoint();
@@ -89,8 +89,8 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
 
   const primaryMetadata = (
     <>
-      <StatusIcon mediaStatus={liveEvent.mediaStatus} />
-      {formatLiveEventMetaString(data)}
+      <StatusIcon mediaStatus={data.mediaStatus} />
+      {formatLiveEventMetaString(data, i18n.language)}
     </>
   );
 

--- a/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { Helmet } from 'react-helmet';
+import { useTranslation } from 'react-i18next';
+import shallow from 'zustand/shallow';
+
+import { useLiveEvent } from '#src/hooks/useLiveEvent';
+import { MediaStatus } from '#src/utils/liveEvent';
+import type { ScreenComponent } from '#types/screens';
+import VideoLayout from '#components/VideoLayout/VideoLayout';
+import { isLocked } from '#src/utils/entitlements';
+import { formatLiveEventMetaString, mediaURL } from '#src/utils/formatting';
+import type { PlaylistItem } from '#types/playlist';
+import useMedia from '#src/hooks/useMedia';
+import { generateMovieJSONLD } from '#src/utils/structuredData';
+import { useConfigStore } from '#src/stores/ConfigStore';
+import { useAccountStore } from '#src/stores/AccountStore';
+import usePlaylist from '#src/hooks/usePlaylist';
+import useEntitlement from '#src/hooks/useEntitlement';
+import StartWatchingButton from '#src/containers/StartWatchingButton/StartWatchingButton';
+import Cinema from '#src/containers/Cinema/Cinema';
+import useBreakpoint, { Breakpoint } from '#src/hooks/useBreakpoint';
+import TrailerModal from '#src/containers/TrailerModal/TrailerModal';
+import ShareButton from '#components/ShareButton/ShareButton';
+import FavoriteButton from '#src/containers/FavoriteButton/FavoriteButton';
+import PlayTrailer from '#src/icons/PlayTrailer';
+import Button from '#components/Button/Button';
+import useQueryParam from '#src/hooks/useQueryParam';
+import InlinePlayer from '#src/containers/InlinePlayer/InlinePlayer';
+import StatusIcon from '#components/StatusIcon/StatusIcon';
+
+const MediaEvent: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
+  const { t } = useTranslation('video');
+
+  const [playTrailer, setPlayTrailer] = useState<boolean>(false);
+  const breakpoint = useBreakpoint();
+
+  // Routing
+  const navigate = useNavigate();
+
+  const params = useParams();
+  const id = params.id || '';
+  const play = useQueryParam('play') === '1';
+  const feedId = useQueryParam('r');
+
+  // Config
+  const { config, accessModel } = useConfigStore(({ config, accessModel }) => ({ config, accessModel }), shallow);
+  const { siteName, features, custom } = config;
+
+  const isFavoritesEnabled: boolean = Boolean(features?.favoritesList);
+  const inlineLayout = Boolean(custom?.inlinePlayer);
+
+  // Media
+  const { isLoading: isTrailerLoading, data: trailerItem } = useMedia(data?.trailerId || '');
+  const { isLoading: isPlaylistLoading, data: playlist } = usePlaylist(feedId || '');
+
+  // Event
+  const liveEvent = useLiveEvent(data);
+
+  // User, entitlement
+  const { user, subscription } = useAccountStore(({ user, subscription }) => ({ user, subscription }), shallow);
+  const { isEntitled } = useEntitlement(data);
+
+  // Handlers
+  const goBack = () => data && navigate(mediaURL(data, feedId, false));
+  const onCardClick = (item: PlaylistItem) => navigate(mediaURL(item, feedId));
+
+  const handleComplete = useCallback(() => {
+    if (!id || !playlist) return;
+
+    const index = playlist.playlist.findIndex(({ mediaid }) => mediaid === id);
+    const nextItem = playlist.playlist[index + 1];
+
+    if (nextItem.mediaStatus === MediaStatus.SCHEDULED) {
+      return;
+    }
+
+    return nextItem && navigate(mediaURL(nextItem, feedId, true));
+  }, [id, playlist, navigate, feedId]);
+
+  // Effects
+  useEffect(() => {
+    (document.scrollingElement || document.body).scroll({ top: 0 });
+  }, [id]);
+
+  // UI
+  const pageTitle = `${data.title} - ${siteName}`;
+  const canonicalUrl = data ? `${window.location.origin}${mediaURL(data)}` : window.location.href;
+
+  const primaryMetadata = (
+    <>
+      <StatusIcon mediaStatus={liveEvent.mediaStatus} />
+      {formatLiveEventMetaString(data)}
+    </>
+  );
+
+  const shareButton = <ShareButton title={data.title} description={data.description} url={canonicalUrl} />;
+  const startWatchingButton = <StartWatchingButton item={data} playUrl={mediaURL(data, feedId, true)} disabled={!liveEvent.isPlayable} />;
+
+  const favoriteButton = isFavoritesEnabled && <FavoriteButton item={data} />;
+  const trailerButton = (!!trailerItem || isTrailerLoading) && (
+    <Button
+      label={t('video:trailer')}
+      aria-label={t('video:watch_trailer')}
+      startIcon={<PlayTrailer />}
+      onClick={() => setPlayTrailer(true)}
+      active={playTrailer}
+      fullWidth={breakpoint < Breakpoint.md}
+      disabled={!trailerItem}
+    />
+  );
+
+  const isLoggedIn = !!user;
+  const hasSubscription = !!subscription;
+
+  return (
+    <React.Fragment>
+      <Helmet>
+        <title>{pageTitle}</title>
+        <link rel="canonical" href={canonicalUrl} />
+        <meta name="description" content={data.description} />
+        <meta property="og:description" content={data.description} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:type" content="video.other" />
+        {data.image && <meta property="og:image" content={data.image?.replace(/^https:/, 'http:')} />}
+        {data.image && <meta property="og:image:secure_url" content={data.image?.replace(/^http:/, 'https:')} />}
+        <meta property="og:image:width" content={data.image ? '720' : ''} />
+        <meta property="og:image:height" content={data.image ? '406' : ''} />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={data.description} />
+        <meta name="twitter:image" content={data.image} />
+        <meta property="og:video" content={canonicalUrl.replace(/^https:/, 'http:')} />
+        <meta property="og:video:secure_url" content={canonicalUrl.replace(/^http:/, 'https:')} />
+        <meta property="og:video:type" content="text/html" />
+        <meta property="og:video:width" content="1280" />
+        <meta property="og:video:height" content="720" />
+        {data.tags?.split(',').map((tag) => (
+          <meta property="og:video:tag" content={tag} key={tag} />
+        ))}
+        {data ? <script type="application/ld+json">{generateMovieJSONLD(data)}</script> : null}
+      </Helmet>
+      <VideoLayout
+        item={data}
+        inlineLayout={inlineLayout}
+        isLoading={isLoading || isPlaylistLoading}
+        accessModel={accessModel}
+        isLoggedIn={isLoggedIn}
+        hasSubscription={hasSubscription}
+        title={data.title}
+        description={data.description}
+        image={data.backgroundImage}
+        primaryMetadata={primaryMetadata}
+        shareButton={shareButton}
+        favoriteButton={favoriteButton}
+        trailerButton={trailerButton}
+        startWatchingButton={startWatchingButton}
+        playlist={playlist}
+        relatedTitle={playlist?.title}
+        onItemClick={onCardClick}
+        activeLabel={t('current_video')}
+        player={
+          inlineLayout ? (
+            <InlinePlayer
+              isLoggedIn={isLoggedIn}
+              item={data}
+              onComplete={handleComplete}
+              feedId={feedId ?? undefined}
+              startWatchingButton={startWatchingButton}
+              paywall={isLocked(accessModel, isLoggedIn, hasSubscription, data)}
+              autostart={liveEvent.isPlayable && (play || undefined)}
+              playable={liveEvent.isPlayable}
+            />
+          ) : (
+            <Cinema
+              open={play && isEntitled}
+              onClose={goBack}
+              item={data}
+              title={data.title}
+              primaryMetadata={primaryMetadata}
+              onComplete={handleComplete}
+              feedId={feedId ?? undefined}
+              onNext={handleComplete}
+            />
+          )
+        }
+      />
+      <TrailerModal item={trailerItem} title={`${data.title} - Trailer`} open={playTrailer} onClose={() => setPlayTrailer(false)} />
+    </React.Fragment>
+  );
+};
+
+export default MediaEvent;

--- a/src/screenMapping.ts
+++ b/src/screenMapping.ts
@@ -1,3 +1,6 @@
+import MediaEvent from './pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent';
+import { isLiveEvent } from './utils/liveEvent';
+
 import { mediaScreenMap } from '#src/pages/ScreenRouting/MediaScreenRouter';
 import MediaHub from '#src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub';
 
@@ -40,4 +43,7 @@ import MediaHub from '#src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub';
 export default function registerCustomScreens() {
   // Hub is an example screen for the media router
   mediaScreenMap.registerByContentType(MediaHub, 'hub');
+
+  // todo: remove the isLiveEvent function when the media item's contain the correct contentType(without the VCH prefix)
+  mediaScreenMap.register(MediaEvent, isLiveEvent);
 }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -1,3 +1,7 @@
+import { parseISO } from 'date-fns';
+
+import { getMediaStatusFromEventState } from '../utils/liveEvent';
+
 import { addQueryParams } from '#src/utils/formatting';
 import { getDataOrThrow } from '#src/utils/api';
 import { filterMediaOffers } from '#src/utils/entitlements';
@@ -29,6 +33,9 @@ export const transformMediaItem = (item: PlaylistItem, playlist?: Playlist) => {
     backgroundImage: generateImageData(config, ImageProperty.BACKGROUND, item),
     channelLogoImage: generateImageData(config, ImageProperty.CHANNEL_LOGO, item),
     mediaOffers: item.productIds ? filterMediaOffers(offerKeys, item.productIds) : undefined,
+    scheduledStart: item['VCH.ScheduledStart'] ? parseISO(item['VCH.ScheduledStart'] as string) : undefined,
+    scheduledEnd: item['VCH.ScheduledEnd'] ? parseISO(item['VCH.ScheduledEnd'] as string) : undefined,
+    mediaStatus: getMediaStatusFromEventState(item),
   };
 };
 

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -27,7 +27,7 @@ export const transformMediaItem = (item: PlaylistItem, playlist?: Playlist) => {
 
   const offerKeys = Object.keys(config?.integrations)[0];
 
-  return {
+  const transformedMediaItem = {
     ...item,
     shelfImage: generateImageData(config, ImageProperty.SHELF, item, playlist),
     backgroundImage: generateImageData(config, ImageProperty.BACKGROUND, item),
@@ -35,8 +35,12 @@ export const transformMediaItem = (item: PlaylistItem, playlist?: Playlist) => {
     mediaOffers: item.productIds ? filterMediaOffers(offerKeys, item.productIds) : undefined,
     scheduledStart: item['VCH.ScheduledStart'] ? parseISO(item['VCH.ScheduledStart'] as string) : undefined,
     scheduledEnd: item['VCH.ScheduledEnd'] ? parseISO(item['VCH.ScheduledEnd'] as string) : undefined,
-    mediaStatus: getMediaStatusFromEventState(item),
   };
+
+  // add the media status to the media item after the transformation because the live media status depends on the scheduledStart and scheduledEnd
+  transformedMediaItem.mediaStatus = getMediaStatusFromEventState(transformedMediaItem);
+
+  return transformedMediaItem;
 };
 
 /**

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -129,10 +129,10 @@ export const formatVideoSchedule = (locale: string, scheduledStart?: Date, sched
   }
 
   if (!scheduledEnd) {
-    return formatLocalizedDateTime(scheduledStart, locale, '•');
+    return formatLocalizedDateTime(scheduledStart, locale, ' • ');
   }
 
-  return `${formatLocalizedDateTime(scheduledStart, locale, '•')} - ${formatLocalizedTime(scheduledEnd, 'locale')}`;
+  return `${formatLocalizedDateTime(scheduledStart, locale, ' • ')} - ${formatLocalizedTime(scheduledEnd, 'locale')}`;
 };
 
 const formatLocalizedDate = (date: Date, locale: string) => new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
@@ -140,4 +140,4 @@ const formatLocalizedDate = (date: Date, locale: string) => new Intl.DateTimeFor
 const formatLocalizedTime = (date: Date, locale: string) => new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
 
 const formatLocalizedDateTime = (date: Date, locale: string, separator = ' ') =>
-  `${formatLocalizedDate(date, locale)} ${separator} ${formatLocalizedTime(date, locale)}`;
+  `${formatLocalizedDate(date, locale)}${separator}${formatLocalizedTime(date, locale)}`;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 import type { PlaylistItem } from '#types/playlist';
 
 export const formatDurationTag = (seconds: number): string | null => {
@@ -109,4 +111,28 @@ export const formatSeriesMetaString = (seasonNumber?: string, episodeNumber?: st
   }
 
   return seasonNumber && seasonNumber !== '0' ? `S${seasonNumber}:E${episodeNumber}` : `E${episodeNumber}`;
+};
+
+export const formatLiveEventMetaString = (media: PlaylistItem) => {
+  const metaData = [];
+  const scheduled = formatVideoSchedule(media.scheduledStart, media.scheduledEnd);
+
+  if (scheduled) metaData.push(scheduled);
+  if (media.duration) metaData.push(formatDuration(media.duration));
+  if (media.genre) metaData.push(media.genre);
+  if (media.rating) metaData.push(media.rating);
+
+  return metaData.join(' • ');
+};
+
+export const formatVideoSchedule = (scheduledStart?: Date, scheduledEnd?: Date) => {
+  if (!scheduledStart) {
+    return '';
+  }
+
+  if (!scheduledEnd) {
+    return format(scheduledStart, 'PPP • p');
+  }
+
+  return `${format(scheduledStart, 'PPP • p')} - ${format(scheduledEnd, 'p')}`;
 };

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,5 +1,3 @@
-import { format } from 'date-fns';
-
 import type { PlaylistItem } from '#types/playlist';
 
 export const formatDurationTag = (seconds: number): string | null => {
@@ -113,9 +111,9 @@ export const formatSeriesMetaString = (seasonNumber?: string, episodeNumber?: st
   return seasonNumber && seasonNumber !== '0' ? `S${seasonNumber}:E${episodeNumber}` : `E${episodeNumber}`;
 };
 
-export const formatLiveEventMetaString = (media: PlaylistItem) => {
+export const formatLiveEventMetaString = (media: PlaylistItem, locale: string) => {
   const metaData = [];
-  const scheduled = formatVideoSchedule(media.scheduledStart, media.scheduledEnd);
+  const scheduled = formatVideoSchedule(locale, media.scheduledStart, media.scheduledEnd);
 
   if (scheduled) metaData.push(scheduled);
   if (media.duration) metaData.push(formatDuration(media.duration));
@@ -125,14 +123,21 @@ export const formatLiveEventMetaString = (media: PlaylistItem) => {
   return metaData.join(' • ');
 };
 
-export const formatVideoSchedule = (scheduledStart?: Date, scheduledEnd?: Date) => {
+export const formatVideoSchedule = (locale: string, scheduledStart?: Date, scheduledEnd?: Date) => {
   if (!scheduledStart) {
     return '';
   }
 
   if (!scheduledEnd) {
-    return format(scheduledStart, 'PPP • p');
+    return formatLocalizedDateTime(scheduledStart, locale, '•');
   }
 
-  return `${format(scheduledStart, 'PPP • p')} - ${format(scheduledEnd, 'p')}`;
+  return `${formatLocalizedDateTime(scheduledStart, locale, '•')} - ${formatLocalizedTime(scheduledEnd, 'locale')}`;
 };
+
+const formatLocalizedDate = (date: Date, locale: string) => new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
+
+const formatLocalizedTime = (date: Date, locale: string) => new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
+
+const formatLocalizedDateTime = (date: Date, locale: string, separator = ' ') =>
+  `${formatLocalizedDate(date, locale)} ${separator} ${formatLocalizedTime(date, locale)}`;

--- a/src/utils/liveEvent.ts
+++ b/src/utils/liveEvent.ts
@@ -1,0 +1,55 @@
+import type { PlaylistItem } from '#types/playlist';
+
+export enum EventState {
+  PRE_LIVE = 'PRE_LIVE',
+  LIVE_UNPUBLISHED = 'LIVE_UNPUBLISHED',
+  LIVE_PUBLISHED = 'LIVE_PUBLISHED',
+  INSTANT_VOD = 'INSTANT_VOD',
+  VOD_PUBLIC = 'VOD_PUBLIC',
+}
+
+export const enum MediaStatus {
+  LIVE = 'LIVE',
+  VOD = 'VOD',
+  SCHEDULED = 'SCHEDULED',
+}
+
+export const isLiveEvent = (playlistItem?: PlaylistItem) => {
+  return !!playlistItem && !!playlistItem['VCH.EventState'] && !!playlistItem['VCH.ScheduledStart'];
+};
+
+export const isScheduledOrLiveMedia = (playlistItem: PlaylistItem) => {
+  return playlistItem.mediaStatus === MediaStatus.SCHEDULED || playlistItem.mediaStatus === MediaStatus.LIVE;
+};
+
+export const getMediaStatusFromEventState = (playlistItem: PlaylistItem) => {
+  const eventState = playlistItem['VCH.EventState'];
+  const { scheduledStart, scheduledEnd } = playlistItem;
+
+  const now = new Date();
+  const started = eventState === EventState.LIVE_PUBLISHED || (scheduledStart && scheduledStart < now);
+  const live = started && scheduledEnd && scheduledEnd > now;
+
+  if (live) {
+    return MediaStatus.LIVE;
+  }
+
+  if (!eventState) {
+    return MediaStatus.VOD;
+  }
+
+  switch (eventState) {
+    case EventState.PRE_LIVE:
+    case EventState.LIVE_UNPUBLISHED:
+      return MediaStatus.SCHEDULED;
+    case EventState.LIVE_PUBLISHED:
+      return MediaStatus.LIVE;
+    case EventState.INSTANT_VOD:
+    case EventState.VOD_PUBLIC:
+      return MediaStatus.VOD;
+  }
+};
+
+export const isPlayable = (playlistItem: PlaylistItem) => {
+  return playlistItem.mediaStatus === MediaStatus.LIVE || playlistItem.mediaStatus === MediaStatus.VOD;
+};

--- a/test-e2e/tests/home_test.ts
+++ b/test-e2e/tests/home_test.ts
@@ -51,7 +51,7 @@ Scenario('I can slide within the featured shelf', async ({ I }) => {
 
   await within(makeShelfXpath(ShelfId.featured), async () => {
     I.see('Blender Channel');
-    I.see('LIVE');
+
     I.dontSee('Spring');
     I.dontSee('8 min');
 

--- a/test-e2e/tests/live_channel_test.ts
+++ b/test-e2e/tests/live_channel_test.ts
@@ -29,7 +29,7 @@ Before(async ({ I }) => {
   const isSummer = today.offset !== winterDay.offset;
   const isGMT = winterDay.offset === 0 && summerDay.offset === 0;
 
-  // Time is mocked in GMT, so to maintan the same local time we need 1 hour later in GMT in winter
+  // Time is mocked in GMT, so to maintain the same local time we need 1 hour later in GMT in winter
   // Example, during summer time in Amsterdam (GMT+2) 8:00 AM GMT = 10:00 AM CEST
   // In winter time in Amsterdam (GMT+1) 9:00 AM GMT = 10:00 AM CET
   await I.mockTimeGMT(isSummer || isGMT ? 8 : 9, 0, 0);
@@ -65,7 +65,8 @@ Scenario('I can navigate to live channels from the live channels shelf', async (
   I.click('Play Channel 1');
 
   waitForEpgAnimation(I);
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can navigate to live channels from the header', ({ I }) => {
@@ -73,14 +74,16 @@ Scenario('I can navigate to live channels from the header', ({ I }) => {
   I.click('Live');
 
   waitForEpgAnimation(I);
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can watch the current live program on the live channel screen', async ({ I }) => {
   await I.openVideoCard('Channel 1');
 
   I.see('The Daily Show with Trevor Noah: Ears Edition', locate('h2').inside(videoDetailsLocator));
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
   I.see('Start watching');
   I.see('Watch from start');
 
@@ -100,7 +103,8 @@ Scenario('I see the epg on the live channel screen', async ({ I }) => {
   I.see('The Daily Show with Trevor Noah: Ears Edition');
   I.see('Live');
 
-  I.see('LIVEOn Channel 1');
+  I.see('LIVE');
+  I.see('On Channel 1');
   I.see('Start watching');
 
   I.seeElement(channel1LiveProgramLocator);
@@ -134,7 +138,8 @@ Scenario('I can select an upcoming program on the same channel', async ({ I }) =
 
   I.see('The Flash', locate('div').inside(videoDetailsLocator));
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.dontSee('LIVE', locate('div').inside(videoDetailsLocator));
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 
   I.seeElement(locate('button[disabled]').withText('Start watching'));
 
@@ -157,7 +162,8 @@ Scenario('I can select a previous program on the same channel and watch the vide
   I.scrollTo(channel1PreviousProgramLocator);
   await isSelectedProgram(I, channel1PreviousProgramLocator, 'channel 1');
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.dontSee('LIVE', locate('div').inside(videoDetailsLocator));
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 
   I.seeElement(channel1LiveProgramLocator);
   await isLiveProgram(I, channel1LiveProgramLocator, 'channel 1');
@@ -174,10 +180,11 @@ Scenario('I can select a program on another channel', async ({ I }) => {
 
   waitForEpgAnimation(I);
 
-  I.dontSee('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.dontSee('On Channel 1', locate('div').inside(videoDetailsLocator));
 
   I.see('The Flash', locate('h2').inside(videoDetailsLocator));
-  I.see('LIVEOn Channel 2', locate('div').inside(videoDetailsLocator));
+  I.see('On Channel 2', locate('div').inside(videoDetailsLocator));
 
   I.scrollTo(channel2LiveProgramLocator);
   I.seeElement(channel2LiveProgramLocator);
@@ -185,8 +192,10 @@ Scenario('I can select a program on another channel', async ({ I }) => {
 
   I.click(channel1Locator);
   waitForEpgAnimation(I);
-  I.dontSee('LIVEOn Channel 2', locate('div').inside(videoDetailsLocator));
-  I.see('LIVEOn Channel 1', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.dontSee('On Channel 2', locate('div').inside(videoDetailsLocator));
+  I.see('LIVE');
+  I.see('On Channel 1', locate('div').inside(videoDetailsLocator));
 });
 
 Scenario('I can navigate through the epg', async ({ I }) => {

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -58,6 +58,9 @@ export type PlaylistItem = {
   scheduleDataFormat?: string;
   scheduleDemo?: string;
   catchupHours?: string;
+  mediaStatus?: MediaStatus;
+  scheduledStart?: Date;
+  scheduledEnd?: Date;
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
## Description

This PR adds BCL live events to the ott webapp.

- adds Media event screen
- adds useLiveEvent hook
- adds Media event metadata to videodetail
- remove the live tag from media items that are not currently "live"


**Summary of how the media events work**
Suppose a playlist contains a scheduled or live media item the playlist will be refetched every 30 seconds. For playlists that only have live items the custom property refect can be added to the playlist in the dashboard. A media item that contains the VCH.EvenState and VCH.ScheduledStart will be handled as a live event. The media event screen will refetch the media item in intervals of 30 seconds if it’s either a live event or a scheduled event.

A media item will be considered LIVE and playable if either VCH.EventState = LIVE_PUBLISHED  or VCH.ScheduledStart > now. A media item will be considered VOD and playable if  VCH.EventState = INSTANT_VOD || VOD_PUBLIC or VCH.ScheduledEnd < now. A media item will be considered SCHEDULED and not playable if VCH.EventState = PRE_LIVE || LIVE_UNPUBLISHED
