### PR TITLE
Feat / translation improvements and documentation

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -28,6 +28,7 @@ module.exports = {
         'config',
         'epg',
         'tests',
+        'i18n',
       ],
     ],
   },

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The JW OTT Webapp is an open-source, dynamically generated video website built a
 ## Documentation
 
 - [Configure JW OTT Webapp](./docs/configuration.md)
+- [Configure Translations](./docs/translations.md)
 - [Contributing Guidelines](CONTRIBUTING.md)
-- [Frameworks, SDK's and Libraries](./docs/frameworks.md)
+- [Frameworks, SDKs and Libraries](./docs/frameworks.md)
 - [Backend Services](./docs/backend-services.md)
 - [Developer Guidelines](./docs/developer-guidelines.md)
 
@@ -70,4 +71,4 @@ To report bugs and feature requests, or request help using JW OTT Webapp, use th
 
 ## Software License
 
-This project is licensed under under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE.txt](LICENSE.txt) for more details.
+This project is licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0). See [LICENSE.txt](LICENSE.txt) for more details.

--- a/docs/developer-guidelines.md
+++ b/docs/developer-guidelines.md
@@ -6,11 +6,12 @@
 - Run the e2e tests through `yarn codecept:mobile` and `yarn codecept:desktop`
 - Format the code through `yarn format` (or automatically do it via git hooks)
 - Lint through `yarn lint` (eslint, prettier, stylelint and tsc checks)
+- Run `yarn i18next` to extract all translations keys from source-code
 - The JW organization requires personal access tokens for all of their repositories. In order to create a branch or pull request you'll need to [Generate a Personal Access Token](https://github.com/settings/tokens) and then [store it in your git config](https://stackoverflow.com/questions/46645843/where-to-store-my-git-personal-access-token/67360592). (For token permissions, `repo` should be sufficient).
 
 ## Versioning and Changelog
 
-We use the [TriPSs/conventional-changelog-action](https://github.com/TriPSs/conventional-changelog-action) github [action](https://github.com/jwplayer/ott-web-app/actions/workflows/bump-version.yml) to do an automated version increment for any commit to the develop branch. The type of version increment will be determined by the commit message(s) in the code being added as follows (see [Convential Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more details):
+We use the [TriPSs/conventional-changelog-action](https://github.com/TriPSs/conventional-changelog-action) GitHub [action](https://github.com/jwplayer/ott-web-app/actions/workflows/bump-version.yml) to do an automated version increment for any commit to the develop branch. The type of version increment will be determined by the commit message(s) in the code being added as follows (see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more details):
 
 - `fix:` - perform a patch bump
 - `feat:` - perform a minor bump
@@ -20,7 +21,7 @@ We use the [TriPSs/conventional-changelog-action](https://github.com/TriPSs/conv
 
 In case there are multiple commits being merged, the biggest type of bump will be performed.
 
-The github action will update the project package.json, create a release tag in github, and update the changelog based on the commit messages in the code being merged.
+The GitHub action will update the project package.json, create a release tag in GitHub, and update the changelog based on the commit messages in the code being merged.
 
 **Note**: In order to access the repository and bypass the protected branch requirements, the action relies on a personal access token, which must belong to an admin of the repo, and which is stored as `ACTION_TOKEN` in the [repository secrets](https://github.com/jwplayer/ott-web-app/settings/secrets/actions). If this token needs to be updated, please generate a [Personal Access Token](https://github.com/settings/tokens) with the `public_repo` scope.
 

--- a/docs/initialization-file.md
+++ b/docs/initialization-file.md
@@ -45,7 +45,7 @@ Keep in mind, if the playerLicenseKey ini setting is provided, it will be used e
 
 ### additionalAllowedConfigSources[]
 
-An array of of 8-character IDs (entered 1 per line) for app configs in your JWP account (or url paths) that can be used with the [`app-config=<config source>` query param](configuration.md#switching-between-app-configs).
+An array of 8-character IDs (entered 1 per line) for app configs in your JWP account (or url paths) that can be used with the [`app-config=<config source>` query param](configuration.md#switching-between-app-configs).
 This may be useful for example if you have a staging or experimental config that you want to be able to test on your site using the [`app-config` query parameter](configuration.md#switching-between-app-configs) without changing the default config that the application loads with for all of your users.
 See [.webapp.test.ini](/ini/templates/.webapp.test.ini) for an example.
 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -4,6 +4,17 @@ The OTT Web App has multilingual support and is enabled by default. The default 
 
 Before changing or adding languages, read the sections below to understand the moving parts better.
 
+## Translation status
+
+Here is a list of all supported translations included in the OTT Web App. The status indicates if the translations are 
+generated using Google Translate/ChatGTP or validated by a person.
+
+| Language | Code | Status    | Validated by             |
+|----------|------|-----------|--------------------------|
+| English  | en   | Validated | Dev team                 |
+| Spanish  | es   | Validated | Jose Alfredo Lopez Urrea |
+| ...      |      |           |                          |
+
 ## Translation files
 
 The web app uses the [react-i18next](https://react.i18next.com/) library for displaying translated strings. Translation 

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,93 @@
+# Translate OTT Web App
+
+The OTT Web App has multilingual support and is enabled by default. The default languages are English and Spanish.
+
+Before changing or adding languages, read the sections below to understand the moving parts better.
+
+## Translation files
+
+The web app uses the [react-i18next](https://react.i18next.com/) library for displaying translated strings. Translation 
+files are defined in JSON format and can be found in the `./public/locales` directory. Translation files are separated 
+by namespace.
+
+The structure of all translation files is generated automatically using the `yarn i18next` command. This script 
+extracts all namespaces and translation keys from the source code. Refrain from editing the structure (e.g., adding or 
+removing keys) of translation files manually because this is prone to mistakes.
+
+To add a new language, create a new subdirectory in the `./public/locales` directory using the language code or 
+LCID string if the language is region specific. For example, using the `fr` language code will be available for all 
+French-speaking regions (e.g., Belgium, Canada, France, Luxembourg, etc.). But if you have different translations for 
+one or more French-speaking regions, use the LCID string (e.g., `fr-be`, `fr-ca`, `fr-lu`, or `fr-fr`) instead of the 
+language code. The downside of this, when having multiple French-speaking regions, a lot of translations will be 
+duplicate.
+
+After adding the subdirectory, run the `yarn i18next` command to generate all the added 
+language(s) translation files. You can now translate each key for the added language(s). 
+
+## Defined languages
+
+When a language is added to the `./public/locales` folder, the OTT Web App doesn't automatically recognize this. 
+Instead, the language must first be added to the "defined languages" list. This is for two reasons:
+
+- As OTT Web App we want to be able to include many languages without enabling them all by default
+- For each language, the display name must be defined, which is shown in the language selection menu
+
+Navigate to the `./src/i18n/config.ts` file and find the `DEFINED_LANGUAGES` constant. Each entry specifies the 
+language code (or LCID string) and display name. 
+
+> If you have added multiple languages using the LCID string identifier, each much be added to the list of defined 
+> languages and ensure to include the region in the `displayName`. For example: `Français Canadien`
+
+The `displayName` is always translated for the language it is written for. This ensures that when the current language is 
+wrong for the current user, he/her will still be able to recognize the language.
+
+```ts
+export const DEFINED_LANGUAGES: LanguageDefinition[] = [
+  {
+    code: 'en',
+    displayName: 'English',
+  },
+  {
+    code: 'fr',
+    displayName: 'Français',
+  },
+];
+```
+
+> You won't have to delete entries with languages that are not supported for your OTT Web App. Instead, don't enable 
+> the language in the app (see the next step). 
+
+## Enabled languages
+
+Languages can be enabled or disabled by updating the `APP_ENABLED_LANGUAGES` environment variable. This can be changed 
+in the `.env` file or by adding the environment variable to the start/build commands.
+
+This disables the multilingual feature by only supporting the English language. The language selection icon will be 
+hidden in the header.
+
+```shell
+$ APP_ENABLED_LANGUAGES=en yarn build 
+```
+
+This builds an OTT Web App supporting the English and French languages. The language selection icon will be shown in 
+the header. 
+
+```shell
+$ APP_ENABLED_LANGUAGES=en,fr yarn build 
+```
+
+## Default language
+
+OTT Web App will try to predict the user language by looking at the Browser language. When the language can't be 
+predicted, or there is no support for the Browser language, the default language will be used. By default, this is set 
+to `en`.
+
+The default language can be changed in the `.env` file as well or by adding the `APP_DEFAULT_LANGUAGE` environment 
+variable to the start/build commands.
+
+Build an OTT Web App with English and French translations, but default to French when the language couldn't be 
+predicted.
+
+```shell
+$ APP_ENABLED_LANGUAGES=en,fr APP_DEFAULT_LANGUAGE=fr yarn build 
+```

--- a/public/locales/es/account.json
+++ b/public/locales/es/account.json
@@ -23,7 +23,7 @@
     "discount_period_other": "Durante los primeros {{count}} {{period}}",
     "free_trial_discount": "Prueba gratuita",
     "go_back_to_checkout": "Volver a la caja",
-    "invalid_card_expiry": "Fecha de vencimiento de la tarjeta inválida",
+    "invalid_card_expiry": "Fecha de vencimiento Invalido para la tarjeta",
     "invalid_card_number": "Número de tarjeta inválido",
     "invalid_cvc_number": "Número de CVC inválido",
     "monthly": "Suscripción mensual",

--- a/src/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/components/LanguageMenu/LanguageMenu.tsx
@@ -15,8 +15,6 @@ type Props = {
 const LanguageMenu = ({ onClick, languages, currentLanguage }: Props) => {
   return (
     <ul className={styles.menuItems}>
-      {/* no need to translate */}
-      <li className={styles.header}>Choose language</li>
       {languages.map(({ code, displayName }) => (
         <li key={code} className={classNames(styles.menuItem, { [styles.menuItemActive]: currentLanguage?.code === code })}>
           <Link onClick={() => onClick?.(code)}>{displayName}</Link>

--- a/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
+++ b/src/components/LanguageMenu/__snapshots__/LanguageMenu.test.tsx.snap
@@ -6,11 +6,6 @@ exports[`<LanguageMenu> > renders and matches snapshot 1`] = `
     class="_menuItems_0acc33"
   >
     <li
-      class="_header_0acc33"
-    >
-      Choose language
-    </li>
-    <li
       class="_menuItem_0acc33"
     >
       <a

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -12,7 +12,7 @@ import TextField from '#components/TextField/TextField';
 import LoadingOverlay from '#components/LoadingOverlay/LoadingOverlay';
 import Button from '#components/Button/Button';
 import type { Customer } from '#types/account';
-import { formatDate, formatPrice } from '#src/utils/formatting';
+import { formatLocalizedDate, formatPrice } from '#src/utils/formatting';
 import { addQueryParam } from '#src/utils/location';
 import type { PaymentDetail, Subscription, Transaction } from '#types/subscription';
 import type { AccessModel } from '#types/Config';
@@ -57,7 +57,7 @@ const Payment = ({
   onUpgradeSubscriptionClick,
   offerSwitchesAvailable,
 }: Props): JSX.Element => {
-  const { t } = useTranslation(['user', 'account']);
+  const { t, i18n } = useTranslation(['user', 'account']);
   const hiddenTransactionsCount = transactions ? transactions?.length - VISIBLE_TRANSACTIONS : 0;
   const hasMoreTransactions = hiddenTransactionsCount > 0;
   const navigate = useNavigate();
@@ -108,8 +108,8 @@ const Payment = ({
                 <p>
                   <strong>{getTitle(activeSubscription.period)}</strong> <br />
                   {activeSubscription.status === 'active' && !isGrantedSubscription
-                    ? t('user:payment.next_billing_date_on', { date: formatDate(activeSubscription.expiresAt) })
-                    : t('user:payment.subscription_expires_on', { date: formatDate(activeSubscription.expiresAt) })}
+                    ? t('user:payment.next_billing_date_on', { date: formatLocalizedDate(new Date(activeSubscription.expiresAt * 1000), i18n.language) })
+                    : t('user:payment.subscription_expires_on', { date: formatLocalizedDate(new Date(activeSubscription.expiresAt), i18n.language) })}
                 </p>
                 {!isGrantedSubscription && (
                   <p className={styles.price}>
@@ -193,7 +193,7 @@ const Payment = ({
                   <p>
                     {transaction.transactionId}
                     <br />
-                    {formatDate(transaction.transactionDate)}
+                    {formatLocalizedDate(new Date(transaction.transactionDate * 1000), i18n.language)}
                   </p>
                   {canShowReceipts && (
                     <IconButton aria-label={t('user:payment.show_receipt')} onClick={() => !isLoading && onShowReceiptClick(transaction.transactionId)}>

--- a/src/components/Payment/Payment.tsx
+++ b/src/components/Payment/Payment.tsx
@@ -109,7 +109,7 @@ const Payment = ({
                   <strong>{getTitle(activeSubscription.period)}</strong> <br />
                   {activeSubscription.status === 'active' && !isGrantedSubscription
                     ? t('user:payment.next_billing_date_on', { date: formatLocalizedDate(new Date(activeSubscription.expiresAt * 1000), i18n.language) })
-                    : t('user:payment.subscription_expires_on', { date: formatLocalizedDate(new Date(activeSubscription.expiresAt), i18n.language) })}
+                    : t('user:payment.subscription_expires_on', { date: formatLocalizedDate(new Date(activeSubscription.expiresAt * 1000), i18n.language) })}
                 </p>
                 {!isGrantedSubscription && (
                   <p className={styles.price}>

--- a/src/components/Payment/__snapshots__/Payment.test.tsx.snap
+++ b/src/components/Payment/__snapshots__/Payment.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         <p>
           T712014024
           <br />
-          5/5/2021
+          May 5, 2021
         </p>
       </div>
     </div>
@@ -102,7 +102,7 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         <p>
           T177974068
           <br />
-          5/5/2021
+          May 5, 2021
         </p>
       </div>
     </div>
@@ -125,7 +125,7 @@ exports[`<Payment> > renders and matches snapshot 1`] = `
         <p>
           T996601696
           <br />
-          5/5/2021
+          May 5, 2021
         </p>
       </div>
     </div>

--- a/src/components/RenewSubscriptionForm/RenewSubscriptionForm.tsx
+++ b/src/components/RenewSubscriptionForm/RenewSubscriptionForm.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styles from './RenewSubscriptionForm.module.scss';
 
 import Button from '#components/Button/Button';
-import { formatDate, formatPrice } from '#src/utils/formatting';
+import { formatLocalizedDate, formatPrice } from '#src/utils/formatting';
 import FormFeedback from '#components/FormFeedback/FormFeedback';
 import type { Customer } from '#types/account';
 import type { Subscription } from '#types/subscription';
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const RenewSubscriptionForm: React.FC<Props> = ({ subscription, customer, error, submitting, onConfirm, onClose }: Props) => {
-  const { t } = useTranslation('account');
+  const { t, i18n } = useTranslation('account');
 
   return (
     <div>
@@ -29,7 +29,7 @@ const RenewSubscriptionForm: React.FC<Props> = ({ subscription, customer, error,
       <div className={styles.infoBox}>
         <p>
           <strong>{subscription.offerTitle}</strong> <br />
-          {t('renew_subscription.next_billing_date_on', { date: formatDate(subscription.expiresAt) })}
+          {t('renew_subscription.next_billing_date_on', { date: formatLocalizedDate(new Date(subscription.expiresAt * 1000), i18n.language) })}
         </p>
         <p className={styles.price}>
           <strong>{formatPrice(subscription.nextPaymentPrice, subscription.nextPaymentCurrency, customer.country)}</strong>

--- a/src/components/SubscriptionRenewed/SubscriptionRenewed.tsx
+++ b/src/components/SubscriptionRenewed/SubscriptionRenewed.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import styles from './SubscriptionRenewed.module.scss';
 
 import Button from '#components/Button/Button';
-import { formatDate, formatPrice } from '#src/utils/formatting';
+import { formatLocalizedDate, formatPrice } from '#src/utils/formatting';
 import type { Subscription } from '#types/subscription';
 import type { Customer } from '#types/account';
 
@@ -15,8 +15,8 @@ type Props = {
 };
 
 const SubscriptionRenewed: React.FC<Props> = ({ onClose, customer, subscription }: Props) => {
-  const { t } = useTranslation('account');
-  const date = formatDate(subscription.expiresAt);
+  const { t, i18n } = useTranslation('account');
+  const date = formatLocalizedDate(new Date(subscription.expiresAt * 1000), i18n.language);
   const price = formatPrice(subscription.nextPaymentPrice, subscription.nextPaymentCurrency, customer.country);
 
   return (

--- a/src/containers/AccountModal/forms/CancelSubscription.tsx
+++ b/src/containers/AccountModal/forms/CancelSubscription.tsx
@@ -6,12 +6,12 @@ import { useAccountStore } from '#src/stores/AccountStore';
 import CancelSubscriptionForm from '#components/CancelSubscriptionForm/CancelSubscriptionForm';
 import LoadingOverlay from '#components/LoadingOverlay/LoadingOverlay';
 import SubscriptionCancelled from '#components/SubscriptionCancelled/SubscriptionCancelled';
-import { formatDate } from '#src/utils/formatting';
+import { formatLocalizedDate } from '#src/utils/formatting';
 import { removeQueryParam } from '#src/utils/location';
 import { updateSubscription } from '#src/stores/AccountController';
 
 const CancelSubscription = () => {
-  const { t } = useTranslation('account');
+  const { t, i18n } = useTranslation('account');
   const navigate = useNavigate();
   const location = useLocation();
   const subscription = useAccountStore((s) => s.subscription);
@@ -42,7 +42,7 @@ const CancelSubscription = () => {
   return (
     <React.Fragment>
       {cancelled ? (
-        <SubscriptionCancelled expiresDate={formatDate(subscription.expiresAt)} onClose={closeHandler} />
+        <SubscriptionCancelled expiresDate={formatLocalizedDate(new Date(subscription.expiresAt * 1000), i18n.language)} onClose={closeHandler} />
       ) : (
         <CancelSubscriptionForm onConfirm={cancelSubscriptionConfirmHandler} onCancel={closeHandler} submitting={submitting} error={error} />
       )}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -54,6 +54,8 @@ const initI18n = async () => {
     .init({
       supportedLngs: supportedLanguages.map(({ code }) => code),
       fallbackLng: defaultLanguage,
+      // this option ensures that empty strings in translations will fall back to the default language
+      returnEmptyString: false,
       ns: NAMESPACES,
       defaultNS: 'common',
       fallbackNS: 'common',

--- a/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -749,7 +749,7 @@ exports[`User Component tests > Payments Page 1`] = `
             <p>
               11232
               <br />
-              7/16/2022
+              July 16, 2022
             </p>
           </div>
         </div>
@@ -772,7 +772,7 @@ exports[`User Component tests > Payments Page 1`] = `
             <p>
               11234
               <br />
-              11/9/2022
+              November 9, 2022
             </p>
           </div>
         </div>

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -78,12 +78,6 @@ export const episodeURL = (episode: PlaylistItem, seriesId?: string, play: boole
     seriesId,
   });
 
-export const formatDate = (dateString: number) => {
-  if (!dateString) return '';
-
-  return new Date(dateString * 1000).toLocaleDateString('en-US');
-};
-
 export const formatPrice = (price: number, currency: string, country: string) => {
   return new Intl.NumberFormat(country || undefined, {
     style: 'currency',
@@ -135,10 +129,14 @@ export const formatVideoSchedule = (locale: string, scheduledStart?: Date, sched
   return `${formatLocalizedDateTime(scheduledStart, locale, ' • ')} - ${formatLocalizedTime(scheduledEnd, locale)}`;
 };
 
-export const formatLocalizedDate = (date: Date, locale: string) =>
-  new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
+export const formatLocalizedDate = (date: Date, locale: string) => {
+  return new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
+};
 
-export const formatLocalizedTime = (date: Date, locale: string) => new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
+export const formatLocalizedTime = (date: Date, locale: string) => {
+  return new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: 'numeric' }).format(date);
+};
 
-export const formatLocalizedDateTime = (date: Date, locale: string, separator = ' ') =>
-  `${formatLocalizedDate(date, locale)}${separator}${formatLocalizedTime(date, locale)}`;
+export const formatLocalizedDateTime = (date: Date, locale: string, separator = ' ') => {
+  return `${formatLocalizedDate(date, locale)}${separator}${formatLocalizedTime(date, locale)}`;
+};

--- a/test-e2e/utils/payments.ts
+++ b/test-e2e/utils/payments.ts
@@ -32,7 +32,7 @@ export function addYear(date: Date) {
 }
 
 export function formatDate(date: Date) {
-  return date.toLocaleDateString('en-US', { day: 'numeric', month: 'long', hour: 'numeric' });
+  return new Intl.DateTimeFormat('en-US', { day: 'numeric', month: 'long', year: 'numeric' }).format(date);
 }
 
 export async function finishAndCheckSubscription(I: CodeceptJS.I, billingDate: Date, today: Date, yearlyPrice: string) {

--- a/test-e2e/utils/payments.ts
+++ b/test-e2e/utils/payments.ts
@@ -32,7 +32,7 @@ export function addYear(date: Date) {
 }
 
 export function formatDate(date: Date) {
-  return date.toLocaleDateString();
+  return date.toLocaleDateString('en-US', { day: 'numeric', month: 'long', hour: 'numeric' });
 }
 
 export async function finishAndCheckSubscription(I: CodeceptJS.I, billingDate: Date, today: Date, yearlyPrice: string) {


### PR DESCRIPTION
## Description

This PR addresses two fixes made regarding the new translations feature.

- Empty (un)translated strings will now fall back to the default language (English by default)
- All dates shown in the app are now localized using the current language.

Also, I've created a quick documentation of how the translations work and can be configured. Let me know if parts need to be added or if something needs more clarification in the documentation.

**New additions**

- Spanish translation fix after validation by Jose Alfredo Lopez Urrea
- Add translations status table in the translations document
