### PR TITLE
Fix / checkout issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,7 +95,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.jsx', '*.tsx'],
+      files: ['*.jsx', '*.tsx', 'src/hooks/*.ts'],
       plugins: [
         // Enable linting React code
         'react',

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -12,6 +12,7 @@ type intervalCheckAccessPayload = {
   iterations?: number;
   offerId?: string;
 };
+
 const useCheckAccess = () => {
   const intervalRef = useRef<number>();
   const navigate = useNavigate();
@@ -25,6 +26,7 @@ const useCheckAccess = () => {
       if (!offerId && clientOffers?.[0]) {
         offerId = clientOffers[0];
       }
+
       intervalRef.current = window.setInterval(async () => {
         const hasAccess = await checkEntitlements(offerId);
 
@@ -37,7 +39,7 @@ const useCheckAccess = () => {
         }
       }, interval);
     },
-    [intervalRef.current, errorMessage],
+    [clientOffers, navigate, location, t],
   );
 
   useEffect(() => {

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -18,10 +18,10 @@ const useCheckAccess = () => {
   const location = useLocation();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { t } = useTranslation('user');
+  const { clientOffers } = useClientIntegration();
 
   const intervalCheckAccess = useCallback(
     ({ interval = 3000, iterations = 5, offerId }: intervalCheckAccessPayload) => {
-      const { clientOffers } = useClientIntegration();
       if (!offerId && clientOffers?.[0]) {
         offerId = clientOffers[0];
       }

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -18,7 +18,7 @@ const useCountdown = (durationSeconds: number, intervalSeconds: number = 1, comp
     return () => {
       window.clearTimeout(timerRef.current);
     };
-  }, [countdown]);
+  }, [completeHandler, countdown, intervalSeconds]);
 
   return countdown;
 };

--- a/src/hooks/useLiveChannels.ts
+++ b/src/hooks/useLiveChannels.ts
@@ -67,6 +67,7 @@ const useLiveChannels = (playlist: PlaylistItem[], initialChannelId: string | un
       setChannel(updatedChannel);
       setProgram(updatedProgram);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channels]);
 
   // update the selected channel and optionally the program

--- a/src/hooks/useLiveProgram.ts
+++ b/src/hooks/useLiveProgram.ts
@@ -27,7 +27,7 @@ const useLiveProgram = (program: EpgProgram | undefined, catchupHours: number | 
     calculateStatus();
 
     return () => clearInterval(intervalId);
-  }, [program]);
+  }, [catchupHours, program]);
 
   return {
     isLive,

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -51,7 +51,7 @@ const useOffers = () => {
       offers,
       offersDict,
     };
-  }, [requestedMediaOffers, allOffers, offerType]);
+  }, [allOffers, isLoading, hasPremierOffer, offerType]);
 };
 
 export default useOffers;

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -28,16 +28,15 @@ const useOffers = () => {
     return [...(requestedMediaOffers || []).map(({ offerId }) => offerId), ...clientOffers].filter(Boolean);
   }, [requestedMediaOffers, clientOffers]);
 
-  const { data: allOffers = [], isLoading } = useQuery(['offers', offerIds.join('-')], () => checkoutService.getOffers({ offerIds }, sandbox));
+  const { data: allOffers, isLoading } = useQuery(['offers', offerIds.join('-')], () => checkoutService.getOffers({ offerIds }, sandbox));
 
   // The `offerQueries` variable mutates on each render which prevents the useMemo to work properly.
   return useMemo(() => {
-    const offers = allOffers.filter((offer: Offer) => (offerType === 'tvod' ? !isSVODOffer(offer) : isSVODOffer(offer)));
-
-    const hasMultipleOfferTypes = allOffers.some((offer: Offer) => (offerType === 'tvod' ? isSVODOffer(offer) : !isSVODOffer(offer)));
+    const offers = (allOffers || []).filter((offer: Offer) => (offerType === 'tvod' ? !isSVODOffer(offer) : isSVODOffer(offer)));
+    const hasMultipleOfferTypes = (allOffers || []).some((offer: Offer) => (offerType === 'tvod' ? isSVODOffer(offer) : !isSVODOffer(offer)));
 
     const offersDict = (!isLoading && Object.fromEntries(offers.map((offer: Offer) => [offer.offerId, offer]))) || {};
-    // we need to get the offerIds from the offer responses since it contains different offerIds based on the customers
+    // we need to get the offerIds from the offer responses since it contains different offerIds based on the customers'
     // location. E.g. if an offer is configured as `S12345678` it becomes `S12345678_US` in the US.
     const defaultOfferId = (!isLoading && offers[offers.length - 1]?.offerId) || '';
 

--- a/src/hooks/useOttAnalytics.ts
+++ b/src/hooks/useOttAnalytics.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { PlaylistItem } from '#types/playlist';
 import { useConfigStore } from '#src/stores/ConfigStore';
@@ -9,44 +9,45 @@ const useOttAnalytics = (item?: PlaylistItem, feedId: string = '') => {
   const user = useAccountStore((state) => state.user);
 
   // ott app user id (oaid)
-  const oaid: number | undefined = user?.id ? Number(user?.id) : undefined;
+  const oaid: number | undefined = user?.id ? Number(user.id) : undefined;
 
   const [player, setPlayer] = useState<jwplayer.JWPlayer | null>(null);
-
-  const timeHandler = useCallback(({ position, duration }: jwplayer.TimeParam) => {
-    window.jwpltx.time(position, duration);
-  }, []);
-
-  const seekHandler = useCallback(({ offset, duration }) => {
-    window.jwpltx.seek(offset, duration);
-  }, []);
-
-  const seekedHandler = useCallback(() => {
-    window.jwpltx.seeked();
-  }, []);
-
-  const playlistItemHandler = useCallback(() => {
-    if (!analyticsToken) return;
-
-    if (!item) {
-      return;
-    }
-
-    window.jwpltx.ready(analyticsToken, window.location.hostname, feedId, item.mediaid, item.title, oaid);
-  }, [item]);
-
-  const completeHandler = useCallback(() => {
-    window.jwpltx.complete();
-  }, []);
-
-  const adImpressionHandler = useCallback(() => {
-    window.jwpltx.adImpression();
-  }, []);
 
   useEffect(() => {
     if (!window.jwpltx || !analyticsToken || !player || !item) {
       return;
     }
+
+    const timeHandler = ({ position, duration }: jwplayer.TimeParam) => {
+      window.jwpltx.time(position, duration);
+    };
+
+    const seekHandler = ({ offset }: jwplayer.SeekParam) => {
+      // TODO: according JWPlayer typings, the seek params doesn't contain a `duration` property, but it actually does
+      window.jwpltx.seek(offset, player.getDuration());
+    };
+
+    const seekedHandler = () => {
+      window.jwpltx.seeked();
+    };
+
+    const playlistItemHandler = () => {
+      if (!analyticsToken) return;
+
+      if (!item) {
+        return;
+      }
+
+      window.jwpltx.ready(analyticsToken, window.location.hostname, feedId, item.mediaid, item.title, oaid);
+    };
+
+    const completeHandler = () => {
+      window.jwpltx.complete();
+    };
+
+    const adImpressionHandler = () => {
+      window.jwpltx.adImpression();
+    };
 
     player.on('playlistItem', playlistItemHandler);
     player.on('complete', completeHandler);
@@ -65,7 +66,7 @@ const useOttAnalytics = (item?: PlaylistItem, feedId: string = '') => {
       player.off('seeked', seekedHandler);
       player.off('adImpression', adImpressionHandler);
     };
-  }, [player, item]);
+  }, [player, item, analyticsToken, feedId, oaid]);
 
   return setPlayer;
 };

--- a/src/hooks/usePlanByEpg.ts
+++ b/src/hooks/usePlanByEpg.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useEpg } from 'planby';
-import { startOfToday, startOfTomorrow } from 'date-fns';
+import { startOfDay, startOfToday, startOfTomorrow } from 'date-fns';
 
 import type { EpgChannel } from '#src/services/epg.service';
 import { is12HourClock } from '#src/utils/datetime';
@@ -44,7 +44,7 @@ const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: 
   //       in the Planby component. E.g. `[subHours(new Date(), 12), addHours(new Date(), 12)]`. The `date` dependency
   //       must also be changed to update every hour instead of daily.
   const date = startOfToday().toJSON();
-  const [startDate, endDate] = useMemo(() => [startOfToday(), startOfTomorrow()], [date]);
+  const [startDate, endDate] = useMemo(() => [startOfDay(new Date(date)), startOfTomorrow()], [date]);
 
   return useEpg({
     channels: epgChannels,

--- a/src/hooks/useSearchQueryUpdater.ts
+++ b/src/hooks/useSearchQueryUpdater.ts
@@ -10,12 +10,15 @@ const useSearchQueryUpdater = () => {
   const updateSearchPath = useDebounce((query: string) => {
     navigate(`/q/${encodeURIComponent(query)}`);
   }, 350);
-  const updateSearchQuery = useCallback((query: string) => {
-    useUIStore.setState({
-      searchQuery: query,
-    });
-    updateSearchPath(query);
-  }, []);
+  const updateSearchQuery = useCallback(
+    (query: string) => {
+      useUIStore.setState({
+        searchQuery: query,
+      });
+      updateSearchPath(query);
+    },
+    [updateSearchPath],
+  );
   const resetSearchQuery = useCallback(() => {
     const returnPage = useUIStore.getState().preSearchPage;
 

--- a/src/hooks/useWatchHistoryListener.ts
+++ b/src/hooks/useWatchHistoryListener.ts
@@ -1,15 +1,19 @@
 import { useEffect } from 'react';
 
+import useEventCallback from '#src/hooks/useEventCallback';
+
 export const useWatchHistoryListener = (saveItem: () => void): void => {
+  const saveItemEvent = useEventCallback(saveItem);
+
   useEffect(() => {
-    const visibilityListener = () => document.visibilityState === 'hidden' && saveItem();
-    window.addEventListener('beforeunload', saveItem);
+    const visibilityListener = () => document.visibilityState === 'hidden' && saveItemEvent();
+    window.addEventListener('beforeunload', saveItemEvent);
     window.addEventListener('visibilitychange', visibilityListener);
 
     return () => {
-      saveItem();
-      window.removeEventListener('beforeunload', saveItem);
+      saveItemEvent();
+      window.removeEventListener('beforeunload', saveItemEvent);
       window.removeEventListener('visibilitychange', visibilityListener);
     };
-  }, []);
+  }, [saveItemEvent]);
 };


### PR DESCRIPTION
## Description

This PR fixes two problems. The first problem was an infinite render loop when opening the choose offers modal. This was caused by using a default value as react-query data. This becomes an issue when the same variable becomes a dependency in a useEffect/useMemo.

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/17c9c35f-aa69-4e73-8a9e-5ce974c0b046)

The second change fixes a React hook violation. This probably wasn't an issue before because it didn't use any hooks internally, but we've added a `useMemo` hook to ... ironically ... also prevent infinite render loops.

<img width="1154" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/db8b2847-4e5b-40a4-94db-52df1b9f79ef">

