### PR TITLE
Fix / choose offer modal without prices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,7 +95,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.jsx', '*.tsx'],
+      files: ['*.jsx', '*.tsx', 'src/hooks/*.ts'],
       plugins: [
         // Enable linting React code
         'react',

--- a/public/locales/en/account.json
+++ b/public/locales/en/account.json
@@ -62,6 +62,7 @@
     "field_required": "This field is required",
     "monthly": "Monthly",
     "monthly_subscription": "Monthly subscription",
+    "no_pricing_available": "There are no pricing options available at the moment.",
     "offer_not_found": "Offer not found, please try reloading the page",
     "one_time_only": "This video",
     "subscription": "Subscription",

--- a/public/locales/en/video.json
+++ b/public/locales/en/video.json
@@ -8,7 +8,6 @@
   "current_episode": "Current episode",
   "current_video": "Current video",
   "episode": "episode",
-  "episode_not_found": "Episode not found",
   "episodes": "Episodes",
   "favorite": "Favorite",
   "favorites_warning": "Maximum amount of favorite videos exceeded. You can only add up to {{maxCount}} favorite videos. Please delete one and repeat the operation.",

--- a/public/locales/es/account.json
+++ b/public/locales/es/account.json
@@ -67,6 +67,7 @@
     "field_required": "Este campo es obligatorio",
     "monthly": "Mensual",
     "monthly_subscription": "Suscripción mensual",
+    "no_pricing_available": "No hay opciones de precios disponibles en este momento.",
     "offer_not_found": "Oferta no encontrada, por favor intenta volver a cargar la página",
     "one_time_only": "Este video",
     "subscription": "Suscripción",

--- a/public/locales/es/video.json
+++ b/public/locales/es/video.json
@@ -8,7 +8,6 @@
   "current_episode": "Episodio actual",
   "current_video": "Video actual",
   "episode": "episodio",
-  "episode_not_found": "Episodio no encontrado",
   "episodes": "Episodios",
   "favorite": "Favorito",
   "favorites_warning": "Se ha alcanzado el máximo de videos favoritos. Solo puedes agregar hasta {{maxCount}} videos favoritos. Por favor, elimina uno y repite la operación.",

--- a/src/components/ChooseOfferForm/ChooseOfferForm.tsx
+++ b/src/components/ChooseOfferForm/ChooseOfferForm.tsx
@@ -172,9 +172,9 @@ const ChooseOfferForm: React.FC<Props> = ({
           </label>
         </div>
       )}
-      <div className={styles.offers}>{offers.map(renderOfferBox)}</div>
+      {<div className={styles.offers}>{!offers.length ? <p>{t('choose_offer.no_pricing_available')}</p> : offers.map(renderOfferBox)}</div>}
       {submitting && <LoadingOverlay transparentBackground inline />}
-      <Button label={t('choose_offer.continue')} disabled={submitting} variant="contained" color="primary" type="submit" fullWidth />
+      <Button label={t('choose_offer.continue')} disabled={submitting || !offers.length} variant="contained" color="primary" type="submit" fullWidth />
     </form>
   );
 };

--- a/src/containers/AccountModal/forms/ChooseOffer.tsx
+++ b/src/containers/AccountModal/forms/ChooseOffer.tsx
@@ -5,7 +5,7 @@ import { useLocation, useNavigate } from 'react-router';
 import shallow from 'zustand/shallow';
 
 import useOffers from '#src/hooks/useOffers';
-import { addQueryParam, removeQueryParam } from '#src/utils/location';
+import { addQueryParam } from '#src/utils/location';
 import { useCheckoutStore } from '#src/stores/CheckoutStore';
 import LoadingOverlay from '#components/LoadingOverlay/LoadingOverlay';
 import ChooseOfferForm from '#components/ChooseOfferForm/ChooseOfferForm';
@@ -35,7 +35,7 @@ const ChooseOffer = () => {
   const location = useLocation();
   const { t } = useTranslation('account');
   const { setOffer } = useCheckoutStore(({ setOffer }) => ({ setOffer }), shallow);
-  const { isLoading, offerType, setOfferType, offers, offersDict, defaultOfferId, hasMultipleOfferTypes, hasPremierOffer } = useOffers();
+  const { isLoading, offerType, setOfferType, offers, offersDict, defaultOfferId, hasMultipleOfferTypes, hasPremierOffer, isTvodRequested } = useOffers();
   const { subscription } = useAccountStore.getState();
   const [offerSwitches, updateOffer] = useCheckoutStore((state) => [state.offerSwitches, state.updateOffer]);
   const isOfferSwitch = useQueryParam('u') === 'upgrade-subscription';
@@ -49,10 +49,6 @@ const ChooseOffer = () => {
   const initialValues: ChooseOfferFormData = {
     offerId: defaultOfferId,
   };
-
-  const closeModal = useEventCallback((replace = false) => {
-    navigate(removeQueryParam(location, 'u'), { replace });
-  });
 
   const updateAccountModal = useEventCallback((modal: string) => {
     navigate(addQueryParam(location, 'u', modal));
@@ -92,13 +88,6 @@ const ChooseOffer = () => {
   const { handleSubmit, handleChange, setValue, values, errors, submitting } = useForm(initialValues, chooseOfferSubmitHandler, validationSchema);
 
   useEffect(() => {
-    // close auth modal when there are no offers defined in the config
-    if (!isLoading && !offers.length) {
-      closeModal(true);
-    }
-  }, [isLoading, offers, closeModal]);
-
-  useEffect(() => {
     if (!isOfferSwitch) setValue('offerId', defaultOfferId);
 
     // Update offerId if the user is switching offers to ensure the correct offer is checked in the ChooseOfferForm
@@ -110,7 +99,7 @@ const ChooseOffer = () => {
   }, [setValue, defaultOfferId, availableOffers]);
 
   // loading state
-  if (!offers.length || isLoading) {
+  if (isLoading) {
     return (
       <div style={{ height: 300 }}>
         <LoadingOverlay inline />
@@ -127,7 +116,7 @@ const ChooseOffer = () => {
       submitting={submitting}
       offers={availableOffers}
       offerType={offerType}
-      setOfferType={hasMultipleOfferTypes && !hasPremierOffer ? setOfferType : undefined}
+      setOfferType={isTvodRequested || (hasMultipleOfferTypes && !hasPremierOffer) ? setOfferType : undefined}
     />
   );
 };

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -12,6 +12,7 @@ type intervalCheckAccessPayload = {
   iterations?: number;
   offerId?: string;
 };
+
 const useCheckAccess = () => {
   const intervalRef = useRef<number>();
   const navigate = useNavigate();
@@ -25,6 +26,7 @@ const useCheckAccess = () => {
       if (!offerId && clientOffers?.[0]) {
         offerId = clientOffers[0];
       }
+
       intervalRef.current = window.setInterval(async () => {
         const hasAccess = await checkEntitlements(offerId);
 
@@ -37,7 +39,7 @@ const useCheckAccess = () => {
         }
       }, interval);
     },
-    [intervalRef.current, errorMessage],
+    [clientOffers, navigate, location, t],
   );
 
   useEffect(() => {

--- a/src/hooks/useCheckAccess.ts
+++ b/src/hooks/useCheckAccess.ts
@@ -18,10 +18,10 @@ const useCheckAccess = () => {
   const location = useLocation();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { t } = useTranslation('user');
+  const { clientOffers } = useClientIntegration();
 
   const intervalCheckAccess = useCallback(
     ({ interval = 3000, iterations = 5, offerId }: intervalCheckAccessPayload) => {
-      const { clientOffers } = useClientIntegration();
       if (!offerId && clientOffers?.[0]) {
         offerId = clientOffers[0];
       }

--- a/src/hooks/useCountdown.ts
+++ b/src/hooks/useCountdown.ts
@@ -18,7 +18,7 @@ const useCountdown = (durationSeconds: number, intervalSeconds: number = 1, comp
     return () => {
       window.clearTimeout(timerRef.current);
     };
-  }, [countdown]);
+  }, [completeHandler, countdown, intervalSeconds]);
 
   return countdown;
 };

--- a/src/hooks/useLiveChannels.ts
+++ b/src/hooks/useLiveChannels.ts
@@ -67,6 +67,7 @@ const useLiveChannels = (playlist: PlaylistItem[], initialChannelId: string | un
       setChannel(updatedChannel);
       setProgram(updatedProgram);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channels]);
 
   // update the selected channel and optionally the program

--- a/src/hooks/useLiveProgram.ts
+++ b/src/hooks/useLiveProgram.ts
@@ -27,7 +27,7 @@ const useLiveProgram = (program: EpgProgram | undefined, catchupHours: number | 
     calculateStatus();
 
     return () => clearInterval(intervalId);
-  }, [program]);
+  }, [catchupHours, program]);
 
   return {
     isLive,

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -50,8 +50,9 @@ const useOffers = () => {
       setOfferType,
       offers,
       offersDict,
+      isTvodRequested: hasTvodOffer,
     };
-  }, [allOffers, isLoading, hasPremierOffer, offerType]);
+  }, [allOffers, isLoading, hasPremierOffer, offerType, hasTvodOffer]);
 };
 
 export default useOffers;

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -51,7 +51,7 @@ const useOffers = () => {
       offers,
       offersDict,
     };
-  }, [requestedMediaOffers, allOffers, offerType]);
+  }, [allOffers, isLoading, hasPremierOffer, offerType]);
 };
 
 export default useOffers;

--- a/src/hooks/useOffers.ts
+++ b/src/hooks/useOffers.ts
@@ -28,16 +28,15 @@ const useOffers = () => {
     return [...(requestedMediaOffers || []).map(({ offerId }) => offerId), ...clientOffers].filter(Boolean);
   }, [requestedMediaOffers, clientOffers]);
 
-  const { data: allOffers = [], isLoading } = useQuery(['offers', offerIds.join('-')], () => checkoutService.getOffers({ offerIds }, sandbox));
+  const { data: allOffers, isLoading } = useQuery(['offers', offerIds.join('-')], () => checkoutService.getOffers({ offerIds }, sandbox));
 
   // The `offerQueries` variable mutates on each render which prevents the useMemo to work properly.
   return useMemo(() => {
-    const offers = allOffers.filter((offer: Offer) => (offerType === 'tvod' ? !isSVODOffer(offer) : isSVODOffer(offer)));
-
-    const hasMultipleOfferTypes = allOffers.some((offer: Offer) => (offerType === 'tvod' ? isSVODOffer(offer) : !isSVODOffer(offer)));
+    const offers = (allOffers || []).filter((offer: Offer) => (offerType === 'tvod' ? !isSVODOffer(offer) : isSVODOffer(offer)));
+    const hasMultipleOfferTypes = (allOffers || []).some((offer: Offer) => (offerType === 'tvod' ? isSVODOffer(offer) : !isSVODOffer(offer)));
 
     const offersDict = (!isLoading && Object.fromEntries(offers.map((offer: Offer) => [offer.offerId, offer]))) || {};
-    // we need to get the offerIds from the offer responses since it contains different offerIds based on the customers
+    // we need to get the offerIds from the offer responses since it contains different offerIds based on the customers'
     // location. E.g. if an offer is configured as `S12345678` it becomes `S12345678_US` in the US.
     const defaultOfferId = (!isLoading && offers[offers.length - 1]?.offerId) || '';
 

--- a/src/hooks/useOttAnalytics.ts
+++ b/src/hooks/useOttAnalytics.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { PlaylistItem } from '#types/playlist';
 import { useConfigStore } from '#src/stores/ConfigStore';
@@ -9,44 +9,45 @@ const useOttAnalytics = (item?: PlaylistItem, feedId: string = '') => {
   const user = useAccountStore((state) => state.user);
 
   // ott app user id (oaid)
-  const oaid: number | undefined = user?.id ? Number(user?.id) : undefined;
+  const oaid: number | undefined = user?.id ? Number(user.id) : undefined;
 
   const [player, setPlayer] = useState<jwplayer.JWPlayer | null>(null);
-
-  const timeHandler = useCallback(({ position, duration }: jwplayer.TimeParam) => {
-    window.jwpltx.time(position, duration);
-  }, []);
-
-  const seekHandler = useCallback(({ offset, duration }) => {
-    window.jwpltx.seek(offset, duration);
-  }, []);
-
-  const seekedHandler = useCallback(() => {
-    window.jwpltx.seeked();
-  }, []);
-
-  const playlistItemHandler = useCallback(() => {
-    if (!analyticsToken) return;
-
-    if (!item) {
-      return;
-    }
-
-    window.jwpltx.ready(analyticsToken, window.location.hostname, feedId, item.mediaid, item.title, oaid);
-  }, [item]);
-
-  const completeHandler = useCallback(() => {
-    window.jwpltx.complete();
-  }, []);
-
-  const adImpressionHandler = useCallback(() => {
-    window.jwpltx.adImpression();
-  }, []);
 
   useEffect(() => {
     if (!window.jwpltx || !analyticsToken || !player || !item) {
       return;
     }
+
+    const timeHandler = ({ position, duration }: jwplayer.TimeParam) => {
+      window.jwpltx.time(position, duration);
+    };
+
+    const seekHandler = ({ offset }: jwplayer.SeekParam) => {
+      // TODO: according JWPlayer typings, the seek params doesn't contain a `duration` property, but it actually does
+      window.jwpltx.seek(offset, player.getDuration());
+    };
+
+    const seekedHandler = () => {
+      window.jwpltx.seeked();
+    };
+
+    const playlistItemHandler = () => {
+      if (!analyticsToken) return;
+
+      if (!item) {
+        return;
+      }
+
+      window.jwpltx.ready(analyticsToken, window.location.hostname, feedId, item.mediaid, item.title, oaid);
+    };
+
+    const completeHandler = () => {
+      window.jwpltx.complete();
+    };
+
+    const adImpressionHandler = () => {
+      window.jwpltx.adImpression();
+    };
 
     player.on('playlistItem', playlistItemHandler);
     player.on('complete', completeHandler);
@@ -65,7 +66,7 @@ const useOttAnalytics = (item?: PlaylistItem, feedId: string = '') => {
       player.off('seeked', seekedHandler);
       player.off('adImpression', adImpressionHandler);
     };
-  }, [player, item]);
+  }, [player, item, analyticsToken, feedId, oaid]);
 
   return setPlayer;
 };

--- a/src/hooks/usePlanByEpg.ts
+++ b/src/hooks/usePlanByEpg.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useEpg } from 'planby';
-import { startOfToday, startOfTomorrow } from 'date-fns';
+import { startOfDay, startOfToday, startOfTomorrow } from 'date-fns';
 
 import type { EpgChannel } from '#src/services/epg.service';
 import { is12HourClock } from '#src/utils/datetime';
@@ -44,7 +44,7 @@ const usePlanByEpg = (channels: EpgChannel[], sidebarWidth: number, itemHeight: 
   //       in the Planby component. E.g. `[subHours(new Date(), 12), addHours(new Date(), 12)]`. The `date` dependency
   //       must also be changed to update every hour instead of daily.
   const date = startOfToday().toJSON();
-  const [startDate, endDate] = useMemo(() => [startOfToday(), startOfTomorrow()], [date]);
+  const [startDate, endDate] = useMemo(() => [startOfDay(new Date(date)), startOfTomorrow()], [date]);
 
   return useEpg({
     channels: epgChannels,

--- a/src/hooks/useSearchQueryUpdater.ts
+++ b/src/hooks/useSearchQueryUpdater.ts
@@ -10,12 +10,15 @@ const useSearchQueryUpdater = () => {
   const updateSearchPath = useDebounce((query: string) => {
     navigate(`/q/${encodeURIComponent(query)}`);
   }, 350);
-  const updateSearchQuery = useCallback((query: string) => {
-    useUIStore.setState({
-      searchQuery: query,
-    });
-    updateSearchPath(query);
-  }, []);
+  const updateSearchQuery = useCallback(
+    (query: string) => {
+      useUIStore.setState({
+        searchQuery: query,
+      });
+      updateSearchPath(query);
+    },
+    [updateSearchPath],
+  );
   const resetSearchQuery = useCallback(() => {
     const returnPage = useUIStore.getState().preSearchPage;
 

--- a/src/hooks/useWatchHistoryListener.ts
+++ b/src/hooks/useWatchHistoryListener.ts
@@ -1,15 +1,19 @@
 import { useEffect } from 'react';
 
+import useEventCallback from '#src/hooks/useEventCallback';
+
 export const useWatchHistoryListener = (saveItem: () => void): void => {
+  const saveItemEvent = useEventCallback(saveItem);
+
   useEffect(() => {
-    const visibilityListener = () => document.visibilityState === 'hidden' && saveItem();
-    window.addEventListener('beforeunload', saveItem);
+    const visibilityListener = () => document.visibilityState === 'hidden' && saveItemEvent();
+    window.addEventListener('beforeunload', saveItemEvent);
     window.addEventListener('visibilitychange', visibilityListener);
 
     return () => {
-      saveItem();
-      window.removeEventListener('beforeunload', saveItem);
+      saveItemEvent();
+      window.removeEventListener('beforeunload', saveItemEvent);
       window.removeEventListener('visibilitychange', visibilityListener);
     };
-  }, []);
+  }, [saveItemEvent]);
 };


### PR DESCRIPTION
## Description

Choose offer modal improvements so that when someone tries to pay a tvod item and therefore the item doesn't have prices set up, we show them message that there are no prices instead of not doing anything despite clicking the buy button.
<img width="988" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/37805865/c8e0a2c9-4a47-4ff8-8542-6a773fd72e4d">
Here is an example how it looks now and you can navigate to the subscription prices and back, but you will not be able to continue with the flow for the TVOD item since it doesn't have prices the button for continue is disabled.

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
