### PR TITLE
feat: Spanish translation for `other_registration_details`

### DIFF
--- a/public/locales/en/user.json
+++ b/public/locales/en/user.json
@@ -41,6 +41,7 @@
     "lastname": "Last name",
     "password": "Password",
     "save": "Save",
+    "other_registration_details": "Other registration details",
     "security": "Password",
     "terms_and_tracking": "Legal & Marketing",
     "update_consents": "Update consents",

--- a/public/locales/en/user.json
+++ b/public/locales/en/user.json
@@ -41,7 +41,6 @@
     "lastname": "Last name",
     "password": "Password",
     "save": "Save",
-    "other_registration_details": "Other registration details",
     "security": "Password",
     "terms_and_tracking": "Legal & Marketing",
     "update_consents": "Update consents",

--- a/public/locales/es/user.json
+++ b/public/locales/es/user.json
@@ -41,6 +41,7 @@
     "lastname": "Apellido",
     "password": "",
     "save": "Guardar",
+    "other_registration_details": "Otros detalles de registro",
     "security": "Contraseña",
     "terms_and_tracking": "Jurídico y marketing",
     "update_consents": "Actualizar consentimientos",


### PR DESCRIPTION
## Description

There's a new translation text with tag `other_registration_details` and this PR contains the Spanish translation.