### PR TITLE
fix: null ref in jwpltx crashing e2e tests

### DIFF
--- a/public/jwpltx.js
+++ b/public/jwpltx.js
@@ -41,11 +41,16 @@ window.jwpltx = window.jwpltx || {};
 
   // Sends the last ping when closing the player or window
   function sendRemainingData() {
+    // This is rare, but happens in e2e tests and can occur if the user closes the player really fast before any ticks.
+    // There is no data, so just skip.
+    if (!uri) {
+      return;
+    }
+
     if (uri.pw === -1) {
       clearLiveInterval();
     } else {
-      const pw = getCurrentProgressQuantile(lastVp, uri.vd);
-      uri.pw = pw;
+      uri.pw = getCurrentProgressQuantile(lastVp, uri.vd);
     }
 
     clearSeekingTimeout();


### PR DESCRIPTION
## Description

Fixed a small race condition bug in jwpltx file that only usually happens in e2e tests

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
