### PR TITLE
fix: update sdk version and payment card types

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@adyen/adyen-web": "^5.42.1",
     "@codeceptjs/allure-legacy": "^1.0.2",
-    "@inplayer-org/inplayer.js": "^3.13.15",
+    "@inplayer-org/inplayer.js": "^3.13.19",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",
     "dompurify": "^2.3.8",

--- a/src/services/inplayer.checkout.service.ts
+++ b/src/services/inplayer.checkout.service.ts
@@ -150,11 +150,11 @@ export const updateOrder: UpdateOrder = async ({ order, couponCode }) => {
 
 export const directPostCardPayment = async (cardPaymentPayload: CardPaymentData, order: Order) => {
   const payload = {
-    number: parseInt(String(cardPaymentPayload.cardNumber).replace(/\s/g, ''), 10),
+    number: cardPaymentPayload.cardNumber.replace(/\s/g, ''),
     cardName: cardPaymentPayload.cardholderName,
     expMonth: cardPaymentPayload.cardExpMonth || '',
     expYear: cardPaymentPayload.cardExpYear || '',
-    cvv: parseInt(cardPaymentPayload.cardCVC),
+    cvv: cardPaymentPayload.cardCVC,
     accessFee: order.id,
     paymentMethod: 1,
     voucherCode: cardPaymentPayload.couponCode,

--- a/types/checkout.d.ts
+++ b/types/checkout.d.ts
@@ -105,7 +105,7 @@ export type PaymentStatus = {
 export type CardPaymentData = {
   couponCode?: string;
   cardholderName: string;
-  cardNumber: string | number;
+  cardNumber: string;
   cardExpiry: string;
   cardExpMonth?: string;
   cardExpYear?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,10 +1480,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@inplayer-org/inplayer.js@^3.13.15":
-  version "3.13.17"
-  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.17.tgz#2312ecdf7761b5634939b1811346dc0fb0c0b00b"
-  integrity sha512-jj6Qcdf1fOX7QBoEnzwfdL7IhYYVKBLpGnYYqwViyp6Jd3Wded5vh6zVzAvGXjJuaNOWd3hG2fTdL6tNaogRrA==
+"@inplayer-org/inplayer.js@^3.13.19":
+  version "3.13.19"
+  resolved "https://registry.yarnpkg.com/@inplayer-org/inplayer.js/-/inplayer.js-3.13.19.tgz#064069a83f6d6241067071e846a7ecf60d9f8135"
+  integrity sha512-KyURtkjOt2cuKzGJfxrc4xMTkvqywWh81u6MpbMmpCOOYnGBsb2z92Uop4M/bVc24gbIGzAqpTttFqruOJLR6w==
   dependencies:
     aws-iot-device-sdk "^2.2.6"
     axios "^0.21.2"


### PR DESCRIPTION
## Description

There was a bug which was causing the payment fail if the leading ccv number is 0.
Updated SDK library to support only string for the ccv and card number and updated the payload as well.

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
