### PR TITLE
fix: faulty useConfigStore on updateCardDetails

### DIFF
--- a/src/stores/AccountController.ts
+++ b/src/stores/AccountController.ts
@@ -412,7 +412,7 @@ export default class AccountController {
     expYear: number;
     currency: string;
   }) => {
-    const { isSandbox } = useConfigStore();
+    const { isSandbox } = useConfigStore.getState();
     const { getAccountInfo } = useAccountStore.getState();
 
     const { customerId } = getAccountInfo();


### PR DESCRIPTION
## Description

There was a  forgotten getState which was causing updateCardDetails to not work.

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
