### PR TITLE
Chore / format package files

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -1,37 +1,87 @@
 {
   "$schema": "https://unpkg.com/syncpack@11.2.1/dist/schema.json",
+  "sortFirst": [
+    "name",
+    "description",
+    "version",
+    "private",
+    "license",
+    "repository",
+    "author",
+    "main",
+    "exports",
+    "engines",
+    "workspaces",
+    "scripts"
+  ],
   "semverGroups": [
     {
-      "dependencies": ["codeceptjs", "codeceptjs**", "react-router", "react-router-dom"],
-      "packages": ["**"],
+      "dependencies": [
+        "codeceptjs",
+        "codeceptjs**",
+        "react-router",
+        "react-router-dom"
+      ],
+      "packages": [
+        "**"
+      ],
       "isIgnored": true
     },
     {
       "range": "^",
-      "dependencies": ["**"],
-      "packages": ["**"],
-      "dependencyTypes": ["prod", "dev", "peer", "resolutions"]
+      "dependencies": [
+        "**"
+      ],
+      "packages": [
+        "**"
+      ],
+      "dependencyTypes": [
+        "prod",
+        "dev",
+        "peer"
+      ]
     }
   ],
   "versionGroups": [
     {
       "label": "Ensure semver ranges for locally developed packages satisfy the local version",
-      "dependencies": ["@jwp/**", "**-config-jwp"],
-      "dependencyTypes": ["peer"],
-      "packages": ["**"],
+      "dependencies": [
+        "@jwp/**",
+        "**-config-jwp"
+      ],
+      "dependencyTypes": [
+        "peer"
+      ],
+      "packages": [
+        "**"
+      ],
       "pinVersion": "*"
     },
     {
       "label": "Ensure local packages are installed as peerDependency",
-      "dependencies": ["@jwp/**", "**-config-jwp"],
-      "dependencyTypes": ["dev", "prod"],
-      "packages": ["**"],
+      "dependencies": [
+        "@jwp/**",
+        "**-config-jwp"
+      ],
+      "dependencyTypes": [
+        "dev",
+        "prod"
+      ],
+      "packages": [
+        "**"
+      ],
       "isBanned": true
     },
     {
-      "dependencies": ["@types/**"],
-      "dependencyTypes": ["!dev"],
-      "packages": ["**"],
+      "dependencies": [
+        "@types/**"
+      ],
+      "dependencyTypes": [
+        "!dev"
+      ],
+      "packages": [
+        "**"
+      ],
       "isBanned": true,
       "label": "@types packages should only be under devDependencies"
     }

--- a/configs/postcss-config-jwp/package.json
+++ b/configs/postcss-config-jwp/package.json
@@ -8,10 +8,10 @@
     "test": "exit 0"
   },
   "devDependencies": {
-    "stylelint": "^15.11.0",
     "postcss": "^8.4.31",
     "postcss-import": "^14.0.2",
-    "postcss-scss": "^4.0.4"
+    "postcss-scss": "^4.0.4",
+    "stylelint": "^15.11.0"
   },
   "peerDependencies": {
     "stylelint-config-jwp": "*"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@jwp/ott",
   "version": "5.1.1",
+  "private": true,
   "license": "Apache-2.0",
-  "main": "index.js",
   "repository": "https://github.com/jwplayer/ott-web-app.git",
   "author": "JW Player",
-  "private": true,
+  "main": "index.js",
   "engines": {
     "node": ">=18.13.0"
   },
@@ -21,16 +21,16 @@
     "format:eslint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\" --fix",
     "format:prettier": "prettier --write \"{**/*,*}.{js,ts,jsx,tsx}\"",
     "format:stylelint": "stylelint --fix '**/*.{css,scss}'",
-    "pre-commit": "yarn depcheck && lint-staged",
-    "prepare": "husky install",
-    "lint": "run-p -c lint:*",
-    "lint:eslint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\"",
-    "lint:prettier": "prettier --check \"{**/*,*}.{js,ts,jsx,tsx}\"",
-    "lint:ts": "tsc --pretty --noEmit -p ./scripts && yarn workspaces run lint:ts",
-    "lint:stylelint": "stylelint '**/*.{css,scss}'",
     "i18next": "i18next 'platforms/*/src/**/*.{ts,tsx}' 'packages/*/src/**/*.{ts,tsx}' && node ./scripts/i18next/generate.js",
     "i18next-diff": "npx ts-node ./scripts/i18next/diff-translations",
     "i18next-update": "npx ts-node ./scripts/i18next/update-translations.ts && yarn i18next",
+    "lint": "run-p -c lint:*",
+    "lint:eslint": "eslint \"{**/*,*}.{js,ts,jsx,tsx}\"",
+    "lint:prettier": "prettier --check \"{**/*,*}.{js,ts,jsx,tsx}\"",
+    "lint:stylelint": "stylelint '**/*.{css,scss}'",
+    "lint:ts": "tsc --pretty --noEmit -p ./scripts && yarn workspaces run lint:ts",
+    "pre-commit": "yarn depcheck && lint-staged",
+    "prepare": "husky install",
     "test": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run",
     "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest"
   },
@@ -55,10 +55,10 @@
     "eslint-config-jwp": "*"
   },
   "resolutions": {
-    "glob-parent": "^5.1.2",
     "codeceptjs/**/ansi-regex": "^4.1.1",
     "codeceptjs/**/minimatch": "^3.0.5",
     "flat": "^5.0.1",
+    "glob-parent": "^5.1.2",
     "json5": "^2.2.2",
     "vite": "^4.4.8"
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jwp/ott-common",
   "version": "4.30.0",
-  "main": "./src",
   "private": true,
+  "main": "./src",
   "scripts": {
     "lint:ts": "tsc --pretty --noEmit -p ./",
     "test": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run",
-    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest",
-    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update"
+    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update",
+    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest"
   },
   "dependencies": {
     "@inplayer-org/inplayer.js": "^3.13.24",

--- a/packages/hooks-react/package.json
+++ b/packages/hooks-react/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "lint:ts": "tsc --pretty --noEmit -p ./",
     "test": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run",
-    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest",
-    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update"
+    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update",
+    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest"
   },
   "dependencies": {
     "@inplayer-org/inplayer.js": "^3.13.24",

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@jwp/ott-ui-react",
   "version": "4.30.0",
-  "main": "./src",
   "private": true,
+  "main": "./src",
   "scripts": {
     "lint:ts": "tsc --pretty --noEmit -p ./",
     "test": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run",
-    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest",
-    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update"
+    "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update",
+    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest"
   },
   "dependencies": {
     "@adyen/adyen-web": "^5.42.1",
@@ -44,7 +44,7 @@
     "sass": "^1.49.10",
     "typescript-plugin-css-modules": "^5.0.2",
     "vi-fetch": "^0.8.0",
-    "vite-plugin-svgr": "4.2.0",
+    "vite-plugin-svgr": "^4.2.0",
     "vitest": "^0.34.6"
   },
   "peerDependencies": {

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -1,29 +1,29 @@
 {
   "name": "@jwp/ott-web",
   "version": "4.30.0",
-  "main": "index.js",
-  "author": "JW Player",
   "private": true,
+  "author": "JW Player",
+  "main": "index.js",
   "engines": {
     "node": ">=18.13.0"
   },
   "scripts": {
+    "build": "vite build --mode ${MODE:=prod} && sh scripts/compressIni.sh build/public/.webapp.ini",
+    "codecept-serve:desktop": "yarn codecept:desktop ; yarn serve-report:desktop",
+    "codecept-serve:mobile": "yarn codecept:mobile ; yarn serve-report:mobile",
+    "codecept:desktop": "cd test-e2e && rm -rf \"./output/desktop\" && codeceptjs run-workers --suites ${WORKER_COUNT:=8} --config ./codecept.desktop.js",
+    "codecept:mobile": "cd test-e2e && rm -rf \"./output/mobile\" && codeceptjs run-workers --suites ${WORKER_COUNT:=8} --config ./codecept.mobile.js",
+    "generate-pwa-assets": "pwa-assets-generator",
+    "lint:ts": "tsc --pretty --noEmit -p ./ && tsc --pretty --noEmit -p ./test-e2e",
+    "load-content-types": "npx ts-node ./scripts/content-types/load-content-types",
+    "serve-report:desktop": "cd test-e2e && allure serve \"./output/desktop\"",
+    "serve-report:mobile": "cd test-e2e && allure serve \"./output/mobile\"",
     "start": "vite",
     "start:test": "vite build --mode test && vite preview --port 8080",
-    "build": "vite build --mode ${MODE:=prod} && sh scripts/compressIni.sh build/public/.webapp.ini",
-    "lint:ts": "tsc --pretty --noEmit -p ./ && tsc --pretty --noEmit -p ./test-e2e",
     "test": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run",
-    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest",
     "test-coverage": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --coverage",
     "test-update": "TZ=UTC LC_ALL=en_US.UTF-8 vitest run --update",
-    "codecept:mobile": "cd test-e2e && rm -rf \"./output/mobile\" && codeceptjs run-workers --suites ${WORKER_COUNT:=8} --config ./codecept.mobile.js",
-    "codecept:desktop": "cd test-e2e && rm -rf \"./output/desktop\" && codeceptjs run-workers --suites ${WORKER_COUNT:=8} --config ./codecept.desktop.js",
-    "serve-report:mobile": "cd test-e2e && allure serve \"./output/mobile\"",
-    "serve-report:desktop": "cd test-e2e && allure serve \"./output/desktop\"",
-    "codecept-serve:mobile": "yarn codecept:mobile ; yarn serve-report:mobile",
-    "codecept-serve:desktop": "yarn codecept:desktop ; yarn serve-report:desktop",
-    "load-content-types": "npx ts-node ./scripts/content-types/load-content-types",
-    "generate-pwa-assets": "pwa-assets-generator"
+    "test-watch": "TZ=UTC LC_ALL=en_US.UTF-8 vitest"
   },
   "dependencies": {
     "@codeceptjs/allure-legacy": "^1.0.2",
@@ -76,10 +76,15 @@
     "vite-plugin-pwa": "^0.14.0",
     "vite-plugin-static-copy": "^0.17.0",
     "vite-plugin-stylelint": "^4.3.0",
-    "vite-plugin-svgr": "4.2.0",
+    "vite-plugin-svgr": "^4.2.0",
     "vitest": "^0.34.6",
     "workbox-build": "^6.5.4",
     "workbox-window": "^6.5.4"
+  },
+  "optionalDependencies": {
+    "gh-pages": "^3.2.3",
+    "lighthouse": "^9.6.7",
+    "sharp": "^0.33.2"
   },
   "peerDependencies": {
     "@jwp/ott-common": "*",
@@ -89,10 +94,5 @@
     "@jwp/ott-ui-react": "*",
     "eslint-config-jwp": "*",
     "postcss-config-jwp": "*"
-  },
-  "optionalDependencies": {
-    "gh-pages": "^3.2.3",
-    "lighthouse": "^9.6.7",
-    "sharp": "^0.33.2"
   }
 }


### PR DESCRIPTION
## Description

I performed a `$ npx syncpack format` and `npx syncpack fix-mismatches` to align the package JSON files. 

I also wanted to add a script that syncs the versions of all workspace packages. But this requires using `yarn version`, which is not used when you make a release, right?
