### PR TITLE
Feat / disable deprecated receipts cleeng

### DIFF
--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -68,7 +68,7 @@ export default class CleengAccountService extends AccountService {
       canExportAccountData: false,
       canDeleteAccount: false,
       canUpdatePaymentMethod: true,
-      canShowReceipts: true,
+      canShowReceipts: false,
       hasSocialURLs: false,
       hasNotifications: false,
     });


### PR DESCRIPTION
## Description

This PR disables the receipt external link for Cleeng, as the endpoint [has been deprecated](https://developers.cleeng.com/reference/fetch-transaction-receipt). Following their release notes of [Feb 01](https://publisher.support.cleeng.com/hc/en-us/articles/12436507653532-Release-Notes-2024-02-01) and [Feb 26](https://publisher.support.cleeng.com/hc/en-us/articles/12855939759132-Release-Notes-2024-02-29), there is no alternative endpoint and publishers and users should rely on [transactional email](https://publisher.support.cleeng.com/hc/en-us/articles/10043396751772-How-to-set-up-transactional-emails). 

### Steps completed:

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
