### PR TITLE
fix(project): fix live stream duration check for ott plugin

### DIFF
--- a/platforms/web/public/jwpltx.js
+++ b/platforms/web/public/jwpltx.js
@@ -155,8 +155,9 @@ window.jwpltx = window.jwpltx || {};
       return;
     }
 
-    // 0 or negative vd means live stream
-    if (vd < 1) {
+    // 0 or negative vd - Live Stream with DVR
+    // Infinity -> Live Stream without DVR
+    if (vd < 1 || vd === Infinity) {
       // Initial tick means play() event
       if (!uri.pw) {
         uri.vd = 0;


### PR DESCRIPTION
## Description

- If duration === Infinity, then we have a stream without DVR
- If duration < 1, then DVR for a stream is set

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
