### PR TITLE
Rework / ensure modals overlay underlying elements

### DIFF
--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -3,6 +3,7 @@
 
 .layout {
   position: relative;
+  z-index: 0;
 }
 
 .buttonContainer {


### PR DESCRIPTION
## This PR

- Improves modal overlay functionality by setting `z-index: 0` on the `.layout` class, ensuring proper stacking order. Previously, the `z-index` defaulted to `auto`, but this adjustment establishes a stacking context, effectively positioning `.layout` below other elements. 
   - Solves: [OTT-1119](https://videodock.atlassian.net/browse/OTT-1119)