### PR TITLE
Fix / ensure modals overlap underlying elements

### DIFF
--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -3,6 +3,7 @@
 
 .layout {
   position: relative;
+  z-index: 0;
 }
 
 .buttonContainer {


### PR DESCRIPTION
## Description

- This PR enhances the modal overlay functionality by explicitly setting `z-index: 0` on the `.layout` class, ensuring a consistent stacking order. Previously, the `z-index` defaulted to `auto`, certain elements beneath an opened modal (e.g., the sign up modal or Player) remained visible. This adjustment establishes a clear stacking context, effectively positioning `.layout` below other elements and resolving the issue of elements showing through the modal overlay.

**Example of initial bug**

<img src="https://github.com/jwplayer/ott-web-app/assets/48496458/aab50078-1eda-442c-9eea-7bf813184d99" width="200"  />