### PR TITLE
Fix: redirect when no integration is configured

### DIFF
--- a/packages/common/src/stores/AccountStore.ts
+++ b/packages/common/src/stores/AccountStore.ts
@@ -19,7 +19,7 @@ type AccountStore = {
 };
 
 export const useAccountStore = createStore<AccountStore>('AccountStore', (set, get) => ({
-  loading: true,
+  loading: false,
   user: null,
   subscription: null,
   transactions: null,


### PR DESCRIPTION
## Description

When navigating directly to a user page (`/u/payments`) when no integration is configured, an infinite spinner shows, this is caused by the `AccountStore#loading` state being set to `true` initially, but this is never reset to `false` when no integration is initialized.

CC: @langemike (can't assign as a reviewer)