### PR TITLE
Feat / reload site on update

### DIFF
--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -36,4 +36,7 @@ if (rootElement) {
   console.info('Application - rootElement not found');
 }
 
-registerSW();
+const refresh = registerSW({
+  immediate: true,
+  onNeedRefresh: () => refresh(true),
+});

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -59,6 +59,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
       StylelintPlugin(),
       svgr(),
       VitePWA({
+        registerType: 'autoUpdate',
         manifestFilename: 'manifest.json',
         manifest: {
           name: app.name,


### PR DESCRIPTION
## Description

This small configuration change will ensure users will always use the latest version of the web app. Before, you need to visit the site, close it or clear the cache to ensure the latest version is used.

This is because the PWA will wait until a suitable moment to activate the "waiting" next version of the deployment. On many occasions, publishers (and we) want to be able to deploy fixes immediately.

Read more about this here:

https://vite-pwa-org.netlify.app/guide/auto-update.html

 CC: @langemike 
