### PR TITLE
Fix / missing feedback when submitting coupon

### DIFF
--- a/packages/common/src/services/integrations/cleeng/CleengService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengService.ts
@@ -193,7 +193,7 @@ export default class CleengService {
       return await resp.json();
     } catch (error: unknown) {
       return {
-        errors: Array.of(error as string),
+        errors: Array.of(error instanceof Error ? error.message : String(error)),
       };
     }
   };

--- a/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
@@ -72,6 +72,7 @@ export default class JWPCheckoutService extends CheckoutService {
       totalPrice: payload.offer.customerPriceInclTax,
       priceBreakdown: {
         offerPrice: payload.offer.customerPriceInclTax,
+        // @TODO is this correct?
         discountAmount: payload.offer.customerPriceInclTax,
         discountedPrice: payload.offer.customerPriceInclTax,
         paymentMethodFee: 0,
@@ -181,14 +182,14 @@ export default class JWPCheckoutService extends CheckoutService {
         accessFeeId: order.id,
       });
 
-      const discountedAmount = order.totalPrice - response.data.amount;
-      const updatedOrder = {
+      const discountAmount = order.totalPrice - response.data.amount;
+      const updatedOrder: Order = {
         ...order,
         totalPrice: response.data.amount,
         priceBreakdown: {
           ...order.priceBreakdown,
-          discountedAmount,
-          discountedPrice: discountedAmount,
+          discountAmount,
+          discountedPrice: discountAmount,
         },
         discount: {
           applied: true,

--- a/packages/ui-react/src/components/CheckoutForm/CheckoutForm.tsx
+++ b/packages/ui-react/src/components/CheckoutForm/CheckoutForm.tsx
@@ -25,6 +25,7 @@ type Props = {
   onCouponInputChange: React.ChangeEventHandler<HTMLInputElement>;
   onRedeemCouponButtonClick: () => void;
   onCloseCouponFormClick: () => void;
+  error?: string;
   couponFormOpen: boolean;
   couponFormError?: string;
   couponFormApplied?: boolean;
@@ -45,6 +46,7 @@ const CheckoutForm: React.FC<Props> = ({
   offerType,
   onBackButtonClick,
   onPaymentMethodChange,
+  error,
   couponFormOpen,
   couponInputValue,
   couponFormError,
@@ -89,6 +91,7 @@ const CheckoutForm: React.FC<Props> = ({
   const orderTitle = offerType === 'svod' ? (offer.period === 'month' ? t('checkout.monthly') : t('checkout.yearly')) : offer.offerTitle;
   return (
     <div>
+      {error ? <FormFeedback variant="error">{error}</FormFeedback> : null}
       <h1 className={styles.title}>{t('checkout.payment_method')}</h1>
       <div className={styles.order}>
         <div className={styles.orderInfo}>

--- a/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
@@ -53,10 +53,10 @@ const Checkout = () => {
     handleSubmit,
   } = useForm({
     initialValues: { couponCode: '', paymentMethodId: paymentMethods?.[0]?.id?.toString() || '' },
-    onSubmit: async ({ couponCode, paymentMethodId }) => {
+    onSubmit: ({ couponCode, paymentMethodId }) => {
       setShowCouponCodeSuccess(false);
 
-      return await updateOrder.mutateAsync({ couponCode, paymentMethodId: parseInt(paymentMethodId) });
+      return updateOrder.mutateAsync({ couponCode, paymentMethodId: parseInt(paymentMethodId) });
     },
     onSubmitSuccess: ({ couponCode }): void => setShowCouponCodeSuccess(!!couponCode),
     onSubmitError: ({ error }) => {
@@ -117,6 +117,7 @@ const Checkout = () => {
       order={order}
       offer={selectedOffer}
       offerType={offerType}
+      error={errors.form}
       onBackButtonClick={backButtonClickHandler}
       paymentMethods={paymentMethods}
       paymentMethodId={paymentMethodId}


### PR DESCRIPTION
## Description

This PR addresses an issue we found during testing. For some reason, there was no feedback when submitting a coupon code. I tried to reproduce this, but the only way I could was to make the `updateOrder` fetch fail. For example, Google Chrome can be put in "Offline" mode using the network tab.

Because there was no feedback, I traced the code and remembered (and spotted some TOODs :-)) that the `updateOrder` method was a bit funky.

This PR addresses some problems and solves the TODOs:

1. Prevent `responseData.errors` to contain Error objects (only strings are expected)
2. Handle errors in try/catch only in the CheckoutController
3. Throw errors with "fixed" messages in integrations
4. Add a generic form error when the request fails due to (service outage/network problems)
5. Prevent mutating the order in the JWP updateOrder method

Although the generic error shows "Unknown error", we know the reason. But we should solve this problem structurally, not just for the `updateOrder` method.

CC: @langemike 