### PR TITLE
fix: Replace `Profile info` with `Account info`

### DIFF
--- a/platforms/web/public/locales/en/user.json
+++ b/platforms/web/public/locales/en/user.json
@@ -1,6 +1,6 @@
 {
   "account": {
-    "about_you": "Profile info",
+    "about_you": "Account info",
     "add_password": "Add password",
     "add_password_error": "Failed to proceed to the Add Password screen. Please try again.",
     "add_password_modal_text": "We sent instructions to {{email}} on how to add a password. If you don’t receive the email within a few minutes, check your spam folder or",

--- a/platforms/web/test-e2e/tests/account_test.ts
+++ b/platforms/web/test-e2e/tests/account_test.ts
@@ -52,7 +52,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string, res
     I.see('Password');
     I.see('Edit password');
 
-    I.see('Profile info');
+    I.see('Account info');
     I.see('First name');
     I.seeInField('input[name="firstName"][readonly]', firstName);
     I.see('Last name');
@@ -253,7 +253,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string, res
 
   Scenario(`I can update my consents - ${providerName}`, async ({ I }) => {
     I.amOnPage(constants.accountsUrl);
-    I.waitForText('Profile info', longTimeout);
+    I.waitForText('Account info', longTimeout);
     I.scrollTo('//*[text() = "Legal & Marketing"]', undefined, -100);
 
     I.dontSeeCheckboxIsChecked(consentCheckbox);


### PR DESCRIPTION
## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR solves #OWA-69.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
