### PR TITLE
Fix / catch Cleeng invalid coupon for offer

### DIFF
--- a/packages/common/src/controllers/CheckoutController.ts
+++ b/packages/common/src/controllers/CheckoutController.ts
@@ -103,6 +103,8 @@ export default class CheckoutController {
           useCheckoutStore.getState().setOrder(null);
         } else if (error.message === 'Invalid coupon code') {
           throw new FormValidationError({ couponCode: [i18next.t('account:checkout.coupon_not_valid')] });
+        } else if (error.message === 'Invalid coupon code for this offer') {
+          throw new FormValidationError({ couponCode: [i18next.t('account:checkout.coupon_not_valid_for_offer')] });
         }
       }
 

--- a/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
@@ -97,6 +97,10 @@ export default class CleengCheckoutService extends CheckoutService {
       if (response.errors[0].includes(`Coupon ${payload.couponCode} not found`)) {
         throw new Error('Invalid coupon code');
       }
+
+      if (response.errors[0].includes(`Coupon ${payload.couponCode} cannot be applied on this offer`)) {
+        throw new Error('Invalid coupon code for this offer');
+      }
     }
 
     return response;

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -15,6 +15,7 @@
     "coupon_applied": "Your coupon code has been applied",
     "coupon_discount": "Coupon discount",
     "coupon_not_valid": "Coupon code is not valid",
+    "coupon_not_valid_for_offer": "Coupon code is not valid for this offer",
     "credit_card": "Credit card",
     "credit_card_name": "Credit card name",
     "days_trial_one": "You will be charged tomorrow.",

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -15,6 +15,7 @@
     "coupon_applied": "Se ha aplicado tu código de cupón",
     "coupon_discount": "Descuento de cupón",
     "coupon_not_valid": "El código de cupón no es válido",
+    "coupon_not_valid_for_offer": "El código de cupón no es válido para esta oferta",
     "credit_card": "Tarjeta de crédito",
     "credit_card_name": "Nombre de la tarjeta de crédito",
     "days_trial_one": "Se te cobrará mañana.",


### PR DESCRIPTION
## Description

Cleeng responds with a specific error when a coupon code can't be applied to a specific offer. This resulted in an "Unknown error".

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/48c66a95-78ca-4b9a-a098-39e7d41ba860)

This PR adds the error check and shows a translated message in the UI.

