### PR TITLE
Fix / Cleeng PayPal payments not working

### DIFF
--- a/packages/common/src/controllers/CheckoutController.ts
+++ b/packages/common/src/controllers/CheckoutController.ts
@@ -205,13 +205,11 @@ export default class CheckoutController {
 
   paypalPayment = async ({
     successUrl,
-    waitingUrl,
     cancelUrl,
     errorUrl,
     couponCode = '',
   }: {
     successUrl: string;
-    waitingUrl: string;
     cancelUrl: string;
     errorUrl: string;
     couponCode: string;
@@ -223,7 +221,6 @@ export default class CheckoutController {
     const response = await this.checkoutService.paymentWithPayPal({
       order: order,
       successUrl,
-      waitingUrl,
       cancelUrl,
       errorUrl,
       couponCode,
@@ -291,21 +288,13 @@ export default class CheckoutController {
     return responseData;
   };
 
-  updatePayPalPaymentMethod = async (
-    successUrl: string,
-    waitingUrl: string,
-    cancelUrl: string,
-    errorUrl: string,
-    paymentMethodId: number,
-    currentPaymentId?: number,
-  ) => {
+  updatePayPalPaymentMethod = async (successUrl: string, cancelUrl: string, errorUrl: string, paymentMethodId: number, currentPaymentId?: number) => {
     assertModuleMethod(this.checkoutService.updatePaymentMethodWithPayPal, 'updatePaymentMethodWithPayPal is not available in checkout service');
     assertModuleMethod(this.checkoutService.deletePaymentMethod, 'deletePaymentMethod is not available in checkout service');
 
     const response = await this.checkoutService.updatePaymentMethodWithPayPal({
       paymentMethodId,
       successUrl,
-      waitingUrl,
       cancelUrl,
       errorUrl,
     });

--- a/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
@@ -136,7 +136,7 @@ export default class JWPCheckoutService extends CheckoutService {
   paymentWithPayPal: PaymentWithPayPal = async (payload) => {
     try {
       const response = await InPlayer.Payment.getPayPalParams({
-        origin: payload.waitingUrl,
+        origin: payload.successUrl,
         accessFeeId: payload.order.id,
         paymentMethod: 2,
         voucherCode: payload.couponCode,

--- a/packages/common/types/checkout.ts
+++ b/packages/common/types/checkout.ts
@@ -263,7 +263,6 @@ export type PaymentWithPayPalPayload = {
   successUrl: string;
   cancelUrl: string;
   errorUrl: string;
-  waitingUrl: string;
   couponCode?: string;
 };
 

--- a/packages/hooks-react/src/useCheckAccess.ts
+++ b/packages/hooks-react/src/useCheckAccess.ts
@@ -8,7 +8,7 @@ type IntervalCheckAccessPayload = {
   interval?: number;
   iterations?: number;
   offerId?: string;
-  callback?: (hasAccess: boolean) => void;
+  callback?: (hasAccess: boolean, offerId: string | undefined) => void;
 };
 
 const useCheckAccess = () => {
@@ -32,11 +32,11 @@ const useCheckAccess = () => {
 
         if (hasAccess) {
           await accountController.reloadSubscriptions({ delay: 2000 }); // Delay needed for backend processing (Cleeng API returns empty subscription, even after accessGranted from entitlements call
-          callback?.(true);
+          callback?.(true, offerId);
         } else if (--iterations === 0) {
           window.clearInterval(intervalRef.current);
           setErrorMessage(t('payment.longer_than_usual'));
-          callback?.(false);
+          callback?.(false, offerId);
         }
       }, interval);
     },

--- a/packages/hooks-react/src/useCheckout.ts
+++ b/packages/hooks-react/src/useCheckout.ts
@@ -52,11 +52,7 @@ const useCheckout = ({ onUpdateOrderSuccess, onSubmitPaymentWithoutDetailsSucces
     },
   });
 
-  const submitPaymentPaypal = useMutation<
-    { redirectUrl: string },
-    Error,
-    { successUrl: string; waitingUrl: string; cancelUrl: string; errorUrl: string; couponCode: string }
-  >({
+  const submitPaymentPaypal = useMutation<{ redirectUrl: string }, Error, { successUrl: string; cancelUrl: string; errorUrl: string; couponCode: string }>({
     mutationKey: ['submitPaymentPaypal'],
     mutationFn: checkoutController.paypalPayment,
     onSuccess: onSubmitPaypalPaymentSuccess,

--- a/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
+++ b/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import useCheckAccess from '@jwp/ott-hooks-react/src/useCheckAccess';
 import { modalURLFromLocation } from '@jwp/ott-ui-react/src/utils/location';
+import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 
 import Spinner from '../Spinner/Spinner';
 import { useAriaAnnouncer } from '../../containers/AnnouncementProvider/AnnoucementProvider';
@@ -18,20 +19,26 @@ const WaitingForPayment = () => {
   const announce = useAriaAnnouncer();
   const { intervalCheckAccess, errorMessage } = useCheckAccess();
 
-  useEffect(() => {
+  const startIntervalEvent = useEventCallback(() => {
     intervalCheckAccess({
       interval: 3000,
       iterations: 5,
       offerId,
-      callback: (hasAccess) => {
+      callback: (hasAccess, offerId) => {
         if (!hasAccess) return;
+        const isSubscription = offerId?.startsWith('S');
 
         announce(t('checkout.payment_success'), 'success');
-        navigate(modalURLFromLocation(location, 'welcome'));
+
+        navigate(modalURLFromLocation(location, isSubscription ? 'welcome' : null));
       },
     });
-    //eslint-disable-next-line
-  }, []);
+  });
+
+  useEffect(() => {
+    startIntervalEvent();
+  }, [startIntervalEvent]);
+
   return (
     <div className={styles.center}>
       {errorMessage ? (

--- a/packages/ui-react/src/containers/UpdatePaymentMethod/UpdatePaymentMethod.tsx
+++ b/packages/ui-react/src/containers/UpdatePaymentMethod/UpdatePaymentMethod.tsx
@@ -49,18 +49,10 @@ const UpdatePaymentMethod = ({ onCloseButtonClick }: Props) => {
       setPaymentError(undefined);
 
       const successUrl = modalURLFromWindowLocation('payment-method-success');
-      const waitingUrl = modalURLFromWindowLocation('waiting-for-payment');
       const cancelUrl = modalURLFromWindowLocation('payment-cancelled');
       const errorUrl = modalURLFromWindowLocation('payment-error');
 
-      const response = await checkoutController.updatePayPalPaymentMethod(
-        successUrl,
-        waitingUrl,
-        cancelUrl,
-        errorUrl,
-        paymentMethodId as number,
-        currentPaymentId,
-      );
+      const response = await checkoutController.updatePayPalPaymentMethod(successUrl, cancelUrl, errorUrl, paymentMethodId as number, currentPaymentId);
 
       if (response) {
         window.location.href = response.redirectUrl;

--- a/packages/ui-react/src/utils/location.ts
+++ b/packages/ui-react/src/utils/location.ts
@@ -12,6 +12,6 @@ export const modalURLFromLocation = (location: Location, u: keyof AccountModals 
 };
 
 // Create a full modal url including hostname, mostly for external use (e.g paypal successUrl)
-export const modalURLFromWindowLocation = (u: keyof AccountModals, queryParams?: QueryParamsArg) => {
+export const modalURLFromWindowLocation = (u: keyof AccountModals | null, queryParams?: QueryParamsArg) => {
   return createURL(window.location.href, { u, ...queryParams });
 };

--- a/platforms/web/test-e2e/utils/payments.ts
+++ b/platforms/web/test-e2e/utils/payments.ts
@@ -1,6 +1,6 @@
 import { overrideIPCookieKey } from '../../src/constants';
 
-import constants, { longTimeout } from './constants';
+import constants, { longTimeout, normalTimeout } from './constants';
 
 export async function goToCheckout(I: CodeceptJS.I) {
   await I.openMainMenu();
@@ -31,6 +31,7 @@ export function formatDate(date: Date) {
 
 export async function finishAndCheckSubscription(I: CodeceptJS.I, billingDate: Date, today: Date, yearlyPrice: string, hasInlineOfferSwitch: boolean) {
   I.click('Continue');
+  I.waitForText(`Waiting for payment`, normalTimeout);
   I.waitForText(`Welcome to JW OTT Web App (SVOD)`, longTimeout);
   I.waitForText(`Thank you for subscribing to JW OTT Web App (SVOD). Please enjoy all our content.`);
 


### PR DESCRIPTION
## Description

The Cleeng Paypal flow didn't work anymore because a relative URL was used as `successUrl`. I tried cleaning it up a little because it was a bit difficult to differentiate between absolute and relative URLs (relative URLs are used for routing).

I also fixed a bug that when buying access to a TVOD item, the waiting for payment screen will show a timeout error. This is because the logic doesn't check access for the TVOD offer but uses the SVOD offers instead. We should fix this soon to make the experience better and prevent having no access without refreshing first.

**Edit**

This problem might be bigger than I originally thought. We DO add the `offerId` to the waiting for payment URL, but the offer IDs are not consistent throughout the app. This is because Cleeng works with separate assets, whilst InPlayer uses a single asset with multiple pricing options.

We use the offerId to check the access for SVOD and TVOD purchases, but because the `offerId` is filled only with the pricing option id, the check interval fails. 

In this PR, I attempt to workaround this issue by changing the JWP offerId to `S${assetId}_${optionId}` so it can be parsed later. This might look strange and does make the offerId inconsistent with the SVOD offer ID, which IS the assetId.

Long story short, we have to look at this further and decide how to refactor. 

**Edit2**

Since this PR originally tried to fix the Cleeng PayPal error, I will create a different, more simple PR for that without the refactoring.
