### PR TITLE
Test / fix e2e overlapping reports

### DIFF
--- a/platforms/web/test-e2e/tests/language_test.ts
+++ b/platforms/web/test-e2e/tests/language_test.ts
@@ -65,7 +65,7 @@ Scenario('Spanish language is selected when the locale is `es-ES`', async ({ I }
   await assertActiveLanguage(I, 'es');
 });
 
-Scenario('Changing the language is persisted in the localStorage`', async ({ I }) => {
+Scenario('Changing the language is persisted in the localStorage', async ({ I }) => {
   I.restartBrowser({ locale: 'en-US' });
   I.useConfig(testConfigs.basicNoAuth);
 
@@ -80,7 +80,7 @@ Scenario('Changing the language is persisted in the localStorage`', async ({ I }
   assert.strictEqual(persistedLanguage, 'es');
 });
 
-Scenario('The language is restored from localStorage`', async ({ I }) => {
+Scenario('The language is restored from localStorage', async ({ I }) => {
   I.restartBrowser({
     storageState: {
       origins: [

--- a/platforms/web/test-e2e/tests/login/account_test.ts
+++ b/platforms/web/test-e2e/tests/login/account_test.ts
@@ -2,28 +2,30 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 
 import constants, { normalTimeout } from '#utils/constants';
 import passwordUtils from '#utils/password_utils';
-import { tryToSubmitForm, fillAndCheckField, checkField } from '#utils/login';
+import { checkField, fillAndCheckField, tryToSubmitForm } from '#utils/login';
 
 const fieldRequired = 'This field is required';
 const invalidEmail = 'Please re-enter your email details and try again.';
 const incorrectLogin = 'Incorrect email/password combination';
-const formFeedback = 'div[class*=formFeedback]';
+
+Feature('login - account').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 runTestSuite(testConfigs.jwpAuth, 'JW Player');
 runTestSuite(testConfigs.cleengAuthvod, 'Cleeng');
 
 function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
-  Feature(`login - account - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(async ({ I }) => {
+  async function beforeScenario(I: CodeceptJS.I) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     I.useConfig(config);
 
     await I.openSignInModal();
 
     I.waitForElement(constants.loginFormSelector, normalTimeout);
-  });
+  }
 
   Scenario(`I can close the modal - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
+
     I.clickCloseButton();
     I.dontSee('Email');
     I.dontSee('Password');
@@ -31,6 +33,8 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can close the modal by clicking outside - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
+
     I.forceClick('div[data-testid="backdrop"]');
 
     I.dontSee('Email');
@@ -39,10 +43,12 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can toggle to view password - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     await passwordUtils.testPasswordToggling(I);
   });
 
   Scenario(`I get a warning when the form is incompletely filled in - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     tryToSubmitForm(I);
 
     checkField(I, 'email', fieldRequired);
@@ -50,6 +56,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I see email warnings - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('email', 'danny@email.com');
     I.fillField('password', 'Password');
 
@@ -81,6 +88,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I see empty password warnings - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('email', 'danny@email.com');
     I.fillField('password', 'Password');
 
@@ -105,6 +113,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I see a login error message - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('email', 'danny@email.com');
     I.fillField('password', 'Password');
 

--- a/platforms/web/test-e2e/tests/login/home_test.ts
+++ b/platforms/web/test-e2e/tests/login/home_test.ts
@@ -3,19 +3,16 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 import constants, { longTimeout } from '#utils/constants';
 import { LoginContext } from '#utils/password_utils';
 
+Feature(`login - home`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
 runTestSuite(testConfigs.jwpAuth, 'JW Player');
 runTestSuite(testConfigs.cleengAuthvod, 'Cleeng');
 
 function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   let loginContext: LoginContext;
 
-  Feature(`login - home - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(({ I }) => {
-    I.useConfig(config);
-  });
-
   Scenario(`Sign-in buttons show for accounts config - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openSignInMenu();
 
     I.see('Sign in');
@@ -23,6 +20,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`Sign-in buttons don't show for config without accounts - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openSignInMenu();
 
     I.see('Sign in');
@@ -37,6 +35,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can open the log in modal - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openSignInModal();
     I.waitForElement(constants.loginFormSelector, longTimeout);
 
@@ -51,6 +50,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can login - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     loginContext = await I.registerOrLogin(loginContext);
 
     await I.openMainMenu();
@@ -64,6 +64,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can log out - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     loginContext = await I.registerOrLogin(loginContext);
 
     await I.openMainMenu();

--- a/platforms/web/test-e2e/tests/payments/coupons_test.ts
+++ b/platforms/web/test-e2e/tests/payments/coupons_test.ts
@@ -2,7 +2,7 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 
 import { LoginContext } from '#utils/password_utils';
 import constants from '#utils/constants';
-import { goToCheckout, formatPrice, finishAndCheckSubscription, addYear, cancelPlan, renewPlan, overrideIP } from '#utils/payments';
+import { addYear, cancelPlan, checkSubscription, finishSubscription, formatPrice, goToCheckout, overrideIP, renewPlan } from '#utils/payments';
 import { ProviderProps } from '#test/types';
 
 const jwProps: ProviderProps = {
@@ -87,8 +87,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
         '',
       );
     }
-
-    await finishAndCheckSubscription(I, addYear(today), today, props.yearlyOffer.price, props.hasInlineOfferSwitch);
+    await finishSubscription(I);
+    await checkSubscription(I, addYear(today), today, props.yearlyOffer.price, props.hasInlineOfferSwitch);
   });
 
   Scenario(`I can cancel a free subscription - ${providerName}`, async ({ I }) => {

--- a/platforms/web/test-e2e/tests/payments/payments_test.ts
+++ b/platforms/web/test-e2e/tests/payments/payments_test.ts
@@ -17,6 +17,7 @@ const jwProps: ProviderProps = {
   fieldWrapper: '',
   hasInlineOfferSwitch: true,
 };
+
 const cleengProps: ProviderProps = {
   config: testConfigs.svod,
   monthlyOffer: constants.offers.monthlyOffer.cleeng,
@@ -40,13 +41,111 @@ function runTestSuite(props: ProviderProps, providerName: string) {
 
   const cardInfo = Array.of(['Card number', '•••• •••• •••• 1111'], ['Expiry date', '03/2030'], ['Security code', '******']);
 
-  Feature(`subscription - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+  Feature(`payments - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
   Before(async ({ I }) => {
     // This gets used in checkoutService.getOffer to make sure the offers are geolocated for NL
     overrideIP(I);
-
     I.useConfig(props.config);
+  });
+
+  Scenario(`I can see my payments data - ${providerName}`, async ({ I }) => {
+    paidLoginContext = await I.registerOrLogin(paidLoginContext);
+
+    await I.openMainMenu();
+
+    I.click('Payments');
+    I.see('Subscription details');
+    I.see('You have no subscription. Complete your subscription to start watching all movies and series.');
+    I.see('Complete subscription');
+
+    I.see('Payment method');
+    I.see('No payment methods');
+
+    I.see('Billing history');
+    I.see('No transactions');
+  });
+
+  Scenario(`I can see offered subscriptions - ${providerName}`, async ({ I }) => {
+    paidLoginContext = await I.registerOrLogin(paidLoginContext);
+
+    I.amOnPage(constants.paymentsUrl);
+
+    I.click('Complete subscription');
+    I.see('Choose plan');
+    I.see('Watch this on JW OTT Web App');
+
+    await within(props.monthlyOffer.label, () => {
+      I.see('Monthly');
+      I.see('First month free');
+      I.see('Cancel anytime');
+      I.see('Watch on all devices');
+      I.see(props.monthlyOffer.price);
+      I.see('/month');
+    });
+
+    await within(props.yearlyOffer.label, () => {
+      I.see('Cancel anytime');
+      I.see('Watch on all devices');
+      I.see(props.yearlyOffer.price);
+      I.see('/year');
+    });
+
+    I.see('Continue');
+  });
+
+  Scenario(`I can choose an offer - ${providerName}`, async ({ I }) => {
+    paidLoginContext = await I.registerOrLogin(paidLoginContext);
+
+    I.amOnPage(constants.offersUrl);
+
+    I.click(props.monthlyOffer.label);
+    I.seeCssPropertiesOnElements(props.monthlyOffer.label, { color: '#000000' });
+    I.seeCssPropertiesOnElements(props.yearlyOffer.label, { color: '#ffffff' });
+
+    I.click(props.yearlyOffer.label);
+    I.seeCssPropertiesOnElements(props.monthlyOffer.label, { color: '#ffffff' });
+    I.seeCssPropertiesOnElements(props.yearlyOffer.label, { color: '#000000' });
+
+    I.click('Continue');
+    I.waitForLoaderDone();
+
+    I.see('Yearly subscription');
+    I.see(props.yearlyOffer.price);
+    I.see('/year');
+
+    I.see('Redeem coupon');
+    I.see(props.yearlyOffer.price);
+    I.dontSee('Payment method fee');
+    I.dontSee(props.yearlyOffer.paymentFee);
+    I.see('Total');
+    if (props.applicableTax !== 0) {
+      I.see('Applicable tax (21%)');
+    }
+    I.clickCloseButton();
+  });
+
+  Scenario(`I can see payment types - ${providerName}`, async ({ I }) => {
+    paidLoginContext = await I.registerOrLogin(paidLoginContext);
+
+    await goToCheckout(I);
+
+    I.waitForText('Credit card');
+    I.waitForText('PayPal');
+    I.waitForText(props.paymentFields.creditCardholder);
+    I.waitForText('Card number');
+    I.waitForText('Expiry date');
+    I.waitForText('Security code');
+    I.waitForText('Continue');
+    I.dontSee("Clicking 'continue' will bring you to the PayPal site.");
+
+    I.click('PayPal');
+
+    I.waitForText("Clicking 'continue' will bring you to the PayPal site.");
+    I.dontSee('Card number');
+    I.dontSee('Expiry date');
+    I.dontSee('Security code');
+    I.waitForText('Continue');
   });
 
   Scenario(`I can open the PayPal site - ${providerName}`, async ({ I }) => {

--- a/platforms/web/test-e2e/tests/payments/payments_test.ts
+++ b/platforms/web/test-e2e/tests/payments/payments_test.ts
@@ -1,8 +1,8 @@
 import { testConfigs } from '@jwp/ott-testing/constants';
 
 import { LoginContext } from '#utils/password_utils';
-import constants, { longTimeout } from '#utils/constants';
-import { goToCheckout, finishSubscription, cancelPlan, renewPlan, overrideIP, addYear, formatDate, checkSubscription } from '#utils/payments';
+import constants from '#utils/constants';
+import { goToCheckout, overrideIP } from '#utils/payments';
 import { ProviderProps } from '#test/types';
 
 const jwProps: ProviderProps = {
@@ -31,25 +31,22 @@ const cleengProps: ProviderProps = {
   hasInlineOfferSwitch: false,
 };
 
+Feature('payments').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
+Before(async ({ I }) => {
+  // This gets used in checkoutService.getOffer to make sure the offers are geolocated for NL
+  overrideIP(I);
+});
+
 runTestSuite(jwProps, 'JW Player');
 runTestSuite(cleengProps, 'Cleeng');
 
 function runTestSuite(props: ProviderProps, providerName: string) {
   let paidLoginContext: LoginContext;
 
-  const today = new Date();
-
-  const cardInfo = Array.of(['Card number', '•••• •••• •••• 1111'], ['Expiry date', '03/2030'], ['Security code', '******']);
-
-  Feature(`payments - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(async ({ I }) => {
-    // This gets used in checkoutService.getOffer to make sure the offers are geolocated for NL
-    overrideIP(I);
-    I.useConfig(props.config);
-  });
-
   Scenario(`I can see my payments data - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     await I.openMainMenu();
@@ -67,6 +64,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can see offered subscriptions - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     I.amOnPage(constants.paymentsUrl);
@@ -95,6 +94,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can choose an offer - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     I.amOnPage(constants.offersUrl);
@@ -126,6 +127,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can see payment types - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     await goToCheckout(I);
@@ -146,83 +149,5 @@ function runTestSuite(props: ProviderProps, providerName: string) {
     I.dontSee('Expiry date');
     I.dontSee('Security code');
     I.waitForText('Continue');
-  });
-
-  Scenario(`I can open the PayPal site - ${providerName}`, async ({ I }) => {
-    paidLoginContext = await I.registerOrLogin(paidLoginContext);
-
-    await goToCheckout(I);
-
-    I.click('PayPal');
-    I.click('Continue');
-
-    I.waitInUrl('paypal.com', longTimeout);
-    // I'm sorry, I don't know why, but this test ends in a way that causes the next test to fail
-    I.amOnPage(constants.baseUrl);
-  });
-
-  Scenario(`I can finish my subscription with credit card - ${providerName}`, async ({ I }) => {
-    paidLoginContext = await I.registerOrLogin(paidLoginContext);
-
-    await goToCheckout(I);
-
-    const alreadySubscribed = await tryTo(() => {
-      I.waitForText('Next billing date is on ' + formatDate(today));
-    });
-
-    if (!alreadySubscribed) {
-      await I.payWithCreditCard(
-        props.paymentFields.creditCardholder,
-        props.creditCard,
-        props.paymentFields.cardNumber,
-        props.paymentFields.expiryDate,
-        props.paymentFields.securityCode,
-        props.fieldWrapper,
-      );
-
-      await finishSubscription(I);
-    }
-
-    await checkSubscription(I, addYear(today), today, props.yearlyOffer.price, props.hasInlineOfferSwitch);
-
-    cardInfo.forEach(([label, value]) => I.seeInField(label, value));
-  });
-
-  Scenario(`I can cancel my subscription - ${providerName}`, async ({ I }) => {
-    paidLoginContext = await I.registerOrLogin(paidLoginContext);
-
-    await cancelPlan(I, addYear(today), props.canRenewSubscription, providerName);
-
-    // Still see payment info
-    cardInfo.forEach(([label, value]) => I.seeInField(label, value));
-  });
-
-  Scenario(`I can renew my subscription - ${providerName}`, async ({ I }) => {
-    if (props.canRenewSubscription) {
-      paidLoginContext = await I.registerOrLogin(paidLoginContext);
-      renewPlan(I, addYear(today), props.yearlyOffer.price);
-    }
-  });
-
-  Scenario(`I can view my invoices - ${providerName}`, async ({ I }) => {
-    if (props.canRenewSubscription) {
-      paidLoginContext = await I.registerOrLogin(paidLoginContext);
-      I.amOnPage(constants.paymentsUrl);
-      I.waitForLoaderDone();
-      I.see('Billing history');
-      I.dontSee('No transactions');
-
-      I.scrollPageToBottom();
-
-      if (props.canOpenReceipts) {
-        // Open the invoice which is opened in a new tab
-        I.click('Show receipt');
-        I.switchToNextTab();
-
-        // Assert invoice functionality by validating the presence of the purchase button
-        I.seeElement('.purchase-button');
-        I.closeCurrentTab();
-      }
-    }
   });
 }

--- a/platforms/web/test-e2e/tests/payments/subscription_test.ts
+++ b/platforms/web/test-e2e/tests/payments/subscription_test.ts
@@ -2,7 +2,7 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 
 import { LoginContext } from '#utils/password_utils';
 import constants, { longTimeout } from '#utils/constants';
-import { goToCheckout, finishSubscription, cancelPlan, renewPlan, overrideIP, addYear, formatDate, checkSubscription } from '#utils/payments';
+import { addYear, cancelPlan, checkSubscription, finishSubscription, formatDate, goToCheckout, overrideIP, renewPlan } from '#utils/payments';
 import { ProviderProps } from '#test/types';
 
 const jwProps: ProviderProps = {
@@ -30,6 +30,13 @@ const cleengProps: ProviderProps = {
   hasInlineOfferSwitch: false,
 };
 
+Feature('subscription').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
+Before(async ({ I }) => {
+  // This gets used in checkoutService.getOffer to make sure the offers are geolocated for NL
+  overrideIP(I);
+});
+
 runTestSuite(jwProps, 'JW Player');
 runTestSuite(cleengProps, 'Cleeng');
 
@@ -40,16 +47,9 @@ function runTestSuite(props: ProviderProps, providerName: string) {
 
   const cardInfo = Array.of(['Card number', '•••• •••• •••• 1111'], ['Expiry date', '03/2030'], ['Security code', '******']);
 
-  Feature(`subscription - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(async ({ I }) => {
-    // This gets used in checkoutService.getOffer to make sure the offers are geolocated for NL
-    overrideIP(I);
-
-    I.useConfig(props.config);
-  });
-
   Scenario(`I can open the PayPal site - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     await goToCheckout(I);
@@ -63,6 +63,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can finish my subscription with credit card - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     await goToCheckout(I);
@@ -90,6 +92,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can cancel my subscription - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     await cancelPlan(I, addYear(today), props.canRenewSubscription, providerName);
@@ -99,6 +103,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can renew my subscription - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     if (props.canRenewSubscription) {
       paidLoginContext = await I.registerOrLogin(paidLoginContext);
       renewPlan(I, addYear(today), props.yearlyOffer.price);
@@ -106,6 +112,8 @@ function runTestSuite(props: ProviderProps, providerName: string) {
   });
 
   Scenario(`I can view my invoices - ${providerName}`, async ({ I }) => {
+    I.useConfig(props.config);
+
     if (props.canRenewSubscription) {
       paidLoginContext = await I.registerOrLogin(paidLoginContext);
       I.amOnPage(constants.paymentsUrl);

--- a/platforms/web/test-e2e/tests/register_test.ts
+++ b/platforms/web/test-e2e/tests/register_test.ts
@@ -3,13 +3,14 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 import constants, { longTimeout, normalTimeout } from '#utils/constants';
 import passwordUtils from '#utils/password_utils';
 
+Feature(`register`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
 runTestSuite(testConfigs.jwpAuth, 'JW Player');
 runTestSuite(testConfigs.cleengAuthvod, 'Cleeng');
 
 function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
-  Feature(`register - ${providerName}'`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(async ({ I }) => {
+  async function beforeScenario(I: CodeceptJS.I) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     I.useConfig(config);
 
     if (await I.isMobile()) {
@@ -18,9 +19,10 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
 
     I.click('Sign up');
     I.waitForElement(constants.registrationFormSelector, normalTimeout);
-  });
+  }
 
   Scenario(`I can open the register modal - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     await I.seeQueryParams({ u: 'create-account' });
 
     I.see('Email');
@@ -42,6 +44,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can close the modal - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.waitForElement(constants.registrationFormSelector, normalTimeout);
 
     I.clickCloseButton();
@@ -55,7 +58,8 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     I.see('Sign up');
   });
 
-  Scenario(`I can switch to the Sign In modal - ${providerName}`, ({ I }) => {
+  Scenario(`I can switch to the Sign In modal - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.click('Sign in', constants.registrationFormSelector);
     I.seeElement(constants.loginFormSelector);
     I.see('Forgot password');
@@ -67,6 +71,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`The Sign up modal will invalidate when directly pressing submit - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.click('Continue');
     I.seeElementInDOM('div[class*=formFeedback]'); // This element can be visually hidden through CSS
     I.seeAttributesOnElements('input[name="email"]', { 'aria-invalid': 'true' });
@@ -74,6 +79,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I get warned when filling in incorrect credentials - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('Email', 'test');
     I.pressKey('Tab');
     I.see('Please re-enter your email details');
@@ -95,6 +101,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I get strength feedback when typing in a password - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     const textOptions = ['Weak', 'Fair', 'Strong', 'Very strong'];
 
     function checkFeedback(password, expectedColor, expectedText) {
@@ -114,10 +121,12 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can toggle to view password - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     await passwordUtils.testPasswordToggling(I);
   });
 
   Scenario(`I can't submit without checking required consents - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('Email', 'test@123.org');
     I.fillField('Password', 'pAssword123!');
 
@@ -131,6 +140,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I get warned for duplicate users - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('Email', constants.username);
     I.fillField('Password', 'Password123!');
     await I.fillCustomRegistrationFields();
@@ -140,6 +150,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can register - ${providerName}`, async ({ I }) => {
+    await beforeScenario(I);
     I.fillField('Email', passwordUtils.createRandomEmail());
     I.fillField('Password', passwordUtils.createRandomPassword());
 

--- a/platforms/web/test-e2e/tests/video_detail_test.ts
+++ b/platforms/web/test-e2e/tests/video_detail_test.ts
@@ -5,6 +5,8 @@ import { testConfigs } from '@jwp/ott-testing/constants';
 import constants, { longTimeout, normalTimeout } from '#utils/constants';
 import passwordUtils, { LoginContext } from '#utils/password_utils';
 
+Feature(`video_detail`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
 runTestSuite(testConfigs.cleengAuthvod, 'Cleeng');
 runTestSuite(testConfigs.jwpAuth, 'JW Player');
 
@@ -14,13 +16,8 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     password: passwordUtils.createRandomPassword(),
   };
 
-  Feature(`video_detail - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(({ I }) => {
-    I.useConfig(config);
-  });
-
   Scenario(`Video detail screen loads - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard('Agent 327');
     I.see('Agent 327');
     I.see('2021');
@@ -36,6 +33,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can expand the description (@mobile-only) - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard('Agent 327');
 
     function checkHeight(height) {
@@ -63,9 +61,13 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     checkHeight('60px');
   });
 
-  Scenario(`I can watch a video - ${providerName}`, async ({ I }) => await playBigBuckBunny(I));
+  Scenario(`I can watch a video - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
+    await playBigBuckBunny(I);
+  });
 
   Scenario(`I can return to the video detail screen - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await playBigBuckBunny(I);
 
     I.click('div[aria-label="Back"]');
@@ -84,6 +86,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can play a trailer - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard(constants.elephantsDreamTitle);
 
     I.click('Trailer');
@@ -96,6 +99,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can play a trailer without signing in - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard(constants.elephantsDreamTitle);
 
     I.see(constants.signUpToWatch);
@@ -110,6 +114,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can play a video after signing up - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard(constants.elephantsDreamTitle);
 
     I.see(constants.signUpToWatch);
@@ -132,6 +137,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can play a video after signing in - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.openVideoCard(constants.elephantsDreamTitle);
 
     I.see(constants.signUpToWatch);
@@ -156,6 +162,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can share the media - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await I.enableClipboard();
 
     await I.openVideoCard(constants.elephantsDreamTitle);

--- a/platforms/web/test-e2e/tests/watch_history/logged_in_test.ts
+++ b/platforms/web/test-e2e/tests/watch_history/logged_in_test.ts
@@ -7,19 +7,16 @@ import { LoginContext } from '#utils/password_utils';
 const videoLength = 596;
 const videoTitle = constants.bigBuckBunnyTitle;
 
+Feature('watch_history - logged in').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
+
 runTestSuite(testConfigs.jwpAuth, testConfigs.jwpAuthNoWatchlist, 'JW Player');
 runTestSuite(testConfigs.cleengAuthvod, testConfigs.cleengAuthvodNoWatchlist, 'Cleeng');
 
 function runTestSuite(config: typeof testConfigs.svod, configNoWatchlist: typeof testConfigs.jwpAuthNoWatchlist, providerName: string) {
   let loginContext: LoginContext;
 
-  Feature(`watch_history - logged in - ${providerName}`).retry(Number(process.env.TEST_RETRY_COUNT) || 0);
-
-  Before(({ I }) => {
-    I.useConfig(config);
-  });
-
   Scenario(`I can get my watch history when logged in - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     await registerOrLogin(I);
 
     // New user has no continue watching history shelf
@@ -39,6 +36,7 @@ function runTestSuite(config: typeof testConfigs.svod, configNoWatchlist: typeof
   });
 
   Scenario(`I can get my watch history stored to my account after login - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     I.dontSee(constants.continueWatchingShelfTitle);
 
     await I.openVideoCard(videoTitle);
@@ -61,6 +59,7 @@ function runTestSuite(config: typeof testConfigs.svod, configNoWatchlist: typeof
   });
 
   Scenario(`I can see my watch history on the Home screen when logged in - ${providerName}`, async ({ I }) => {
+    I.useConfig(config);
     I.dontSee(constants.continueWatchingShelfTitle);
 
     await registerOrLogin(I);


### PR DESCRIPTION
## Description

Because we use a function to wrap the JWP and Cleeng scenarios, the CodeceptJS run workers' reporting fails. The reporter instance exists only once for each worker and it creates two Allure runs within the same instance because of the duplicate ``Feature(`subscription - ${providerName}`)`` calls.

I've played with [data-driven tests](https://codecept.io/advanced/#data-driven-tests), but this will run all steps sequentially.

The easiest fix was to either remove the `Feature` and `Before` calls from the `runTestSuite` functions so it only creates 1 test run.

After this change, the Allure reporting will show all the scenarios before this was the last one completed.

<img width="764" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/1e20b515-7083-4c9a-8fc6-331aaae07957">

https://github.com/codeceptjs/allure-legacy/blob/8c31bd2d0736487edaa7d92a813562b2571cef49/index.js#L180-L182

Calls:

```js
Allure.prototype.startSuite = function(suiteName, timestamp) {
    this.suites.unshift(new Suite(suiteName, timestamp));
};
```

```js
Allure.prototype.endSuite = function(timestamp) {
    var suite = this.getCurrentSuite();

    suite.end(timestamp);
    if(suite.hasTests()) {
        writer.writeSuite(this.options.targetDir, suite);
    }
    this.suites.shift();
};
```

The culprit... This function only returns the first suite:

```js
Allure.prototype.getCurrentSuite = function() {
    return this.suites[0];
};
```
