### PR TITLE
Fix / lose focus after activating share button

### DIFF
--- a/packages/ui-react/src/utils/clipboard.test.ts
+++ b/packages/ui-react/src/utils/clipboard.test.ts
@@ -1,0 +1,28 @@
+import { copyToClipboard } from './clipboard';
+
+document.execCommand = vi.fn();
+const execCommandMocked = vi.mocked(document.execCommand);
+
+describe('clipboard', () => {
+  test('copies text to clipboard', () => {
+    copyToClipboard('text to copy');
+
+    expect(execCommandMocked).toHaveBeenCalledWith('copy');
+  });
+
+  test('restores focus to the last active element', () => {
+    // create a test button
+    const button = document.createElement('button');
+    button.textContent = 'share';
+
+    document.body.appendChild(button);
+
+    button.focus();
+
+    // document.activeElement = '';
+    copyToClipboard('text to copy');
+
+    expect(document.activeElement).toEqual(button);
+    document.body.removeChild(button);
+  });
+});

--- a/packages/ui-react/src/utils/clipboard.ts
+++ b/packages/ui-react/src/utils/clipboard.ts
@@ -1,4 +1,5 @@
 export const copyToClipboard = (value: string): void => {
+  const focusedElement = document.activeElement as HTMLElement;
   const inputElement = document.createElement('input');
   inputElement.style.zIndex = '-10';
   inputElement.style.position = 'absolute';
@@ -9,4 +10,5 @@ export const copyToClipboard = (value: string): void => {
   document.execCommand('copy');
   inputElement.blur();
   document.body.removeChild(inputElement);
+  focusedElement?.focus();
 };


### PR DESCRIPTION
## Description

When activating the share button, the focus is lost because of the select and copy action. This change stores the document activeElement and restoring focus after the copy command.

> Should we be using Clipboard APIs? 🤔 

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [x] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
