### PR TITLE
Refactor / replace modal with HTML Dialog

### DIFF
--- a/packages/hooks-react/src/useOffers.ts
+++ b/packages/hooks-react/src/useOffers.ts
@@ -1,5 +1,4 @@
-import { useMutation } from 'react-query';
-import { useEffect } from 'react';
+import { useMutation, useQuery } from 'react-query';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
 import { getModule } from '@jwp/ott-common/src/modules/container';
 import { useCheckoutStore } from '@jwp/ott-common/src/stores/CheckoutStore';
@@ -21,9 +20,9 @@ const useOffers = () => {
     shallow,
   );
 
-  const { mutate: initialise, isLoading: isInitialisationLoading } = useMutation<void>({
-    mutationKey: ['initialiseOffers', requestedMediaOffers],
-    mutationFn: checkoutController.initialiseOffers,
+  const { isLoading: isInitialisationLoading } = useQuery<void>({
+    queryKey: ['initialiseOffers', requestedMediaOffers],
+    queryFn: checkoutController.initialiseOffers,
   });
 
   const chooseOffer = useMutation({
@@ -36,10 +35,6 @@ const useOffers = () => {
     mutationFn: checkoutController.switchSubscription,
     onSuccess: () => accountController.reloadSubscriptions({ delay: 7500 }), // @todo: Is there a better way to wait?
   });
-
-  useEffect(() => {
-    initialise();
-  }, [requestedMediaOffers, initialise]);
 
   const hasMediaOffers = mediaOffers.length > 0;
   const hasSubscriptionOffers = subscriptionOffers.length > 0;

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -45,7 +45,8 @@
     "typescript-plugin-css-modules": "^5.0.2",
     "vi-fetch": "^0.8.0",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^1.3.1"
+    "vitest": "^1.3.1",
+    "wicg-inert": "^3.1.2"
   },
   "peerDependencies": {
     "@jwp/ott-common": "*",

--- a/packages/ui-react/src/components/Alert/Alert.test.tsx
+++ b/packages/ui-react/src/components/Alert/Alert.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Alert from './Alert';
 
 describe('<Alert>', () => {
   test('renders and matches snapshot', () => {
-    const { container } = render(<Alert message="Body" open={true} onClose={vi.fn()} />);
+    const { container } = renderWithRouter(<Alert message="Body" open={true} onClose={vi.fn()} />);
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.test.tsx
+++ b/packages/ui-react/src/components/ChooseOfferForm/ChooseOfferForm.test.tsx
@@ -107,7 +107,7 @@ describe('<OffersForm>', () => {
 
     fireEvent.click(getByTestId('S345569153_NL'));
 
-    expect(onChange).toBeCalled();
+    expect(onChange).toHaveBeenCalled();
   });
 
   test('calls the onSubmit callback when submitting the form', () => {

--- a/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/packages/ui-react/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import ConfirmationDialog from './ConfirmationDialog';
 
 describe('<ConfirmationDialog>', () => {
   test('renders and matches snapshot', () => {
-    const { container } = render(<ConfirmationDialog body="Body" title="Title" open={true} onConfirm={vi.fn()} onClose={vi.fn()} />);
+    const { container } = renderWithRouter(<ConfirmationDialog body="Body" title="Title" open={true} onConfirm={vi.fn()} onClose={vi.fn()} />);
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/ui-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.test.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Dialog from './Dialog';
 
 describe('<Dialog>', () => {
   test('renders and matches snapshot', () => {
-    const { baseElement } = render(
+    const { baseElement } = renderWithRouter(
       <>
         <span>Some content</span>
-        <Dialog onClose={vi.fn()} open={true} role="dialog">
+        <Dialog onClose={vi.fn()} open={true}>
           Dialog contents
         </Dialog>
         <span>Some other content</span>
@@ -16,22 +17,5 @@ describe('<Dialog>', () => {
     );
 
     expect(baseElement).toMatchSnapshot();
-  });
-
-  test('Should ensure Dialog is properly marked as a modal and has role "dialog"', () => {
-    const { getByTestId } = render(
-      <>
-        <span>Some content</span>
-        <Dialog onClose={vi.fn()} open={true} role="dialog" data-testid="dialog">
-          Dialog contents
-        </Dialog>
-        <span>Some other content</span>
-      </>,
-    );
-
-    const dialogElement = getByTestId('dialog');
-
-    expect(dialogElement).toHaveAttribute('aria-modal', 'true');
-    expect(dialogElement).toHaveAttribute('role', 'dialog');
   });
 });

--- a/packages/ui-react/src/components/Dialog/Dialog.tsx
+++ b/packages/ui-react/src/components/Dialog/Dialog.tsx
@@ -13,13 +13,13 @@ type Props = {
   onClose: () => void;
   size?: 'small' | 'large';
   children: React.ReactNode;
-  role: React.AriaRole;
+  role?: React.AriaRole;
 } & React.AriaAttributes;
 
-const Dialog: React.FC<Props> = ({ open, onClose, children, size = 'small', role = 'dialog', ...ariaAttributes }: Props) => {
+const Dialog: React.FC<Props> = ({ open, onClose, children, size = 'small', role, ...ariaAttributes }: Props) => {
   return (
-    <Modal open={open} onClose={onClose} AnimationComponent={Slide}>
-      <div className={classNames(styles.dialog, styles[size])} aria-modal="true" role={role} data-testid={testId('dialog')} {...ariaAttributes}>
+    <Modal open={open} onClose={onClose} AnimationComponent={Slide} role={role} centered>
+      <div className={classNames(styles.dialog, styles[size])} data-testid={testId('dialog')} {...ariaAttributes}>
         {children}
         <ModalCloseButton onClick={onClose} />
       </div>

--- a/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/ui-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -12,53 +12,40 @@ exports[`<Dialog> > renders and matches snapshot 1`] = `
       Some other content
     </span>
   </div>
-  <div
-    style="transition: opacity 0.3s ease-in-out; opacity: 0; will-change: opacity;"
+  <dialog
+    class="_centered_6c6c55"
+    open=""
   >
     <div
-      class="_modal_6c6c55"
+      style="transition: transform 0.3s ease, opacity 0.3s ease; transform: translate(0, -15px); opacity: 0; z-index: 15;"
     >
       <div
-        class="_backdrop_6c6c55"
-        data-testid="backdrop"
-      />
-      <div
-        class="_container_6c6c55"
+        class="_dialog_00d559 _small_00d559"
+        data-testid="dialog"
       >
-        <div
-          style="transition: transform 0.2s ease, opacity 0.2s ease; transform: translate(0, -15px); opacity: 0; z-index: 15;"
+        Dialog contents
+        <button
+          aria-label="close_modal"
+          class="_iconButton_0fef65 _modalCloseButton_b92d69"
+          type="button"
         >
-          <div
-            aria-modal="true"
-            class="_dialog_00d559 _small_00d559"
-            data-testid="dialog"
-            role="dialog"
+          <svg
+            aria-hidden="true"
+            class="_icon_585b29"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Dialog contents
-            <button
-              aria-label="close_modal"
-              class="_iconButton_0fef65 _modalCloseButton_b92d69"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="_icon_585b29"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                />
-                <path
-                  d="M0 0h24v24H0z"
-                  fill="none"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
+            <path
+              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </button>
       </div>
     </div>
-  </div>
+  </dialog>
 </body>
 `;

--- a/packages/ui-react/src/components/Modal/Modal.module.scss
+++ b/packages/ui-react/src/components/Modal/Modal.module.scss
@@ -2,27 +2,64 @@
 @use '@jwp/ott-ui-react/src/styles/theme';
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 
-.modal {
-  position: fixed;
+$animation-duration: 0.3s;
+
+dialog {
   top: 0;
   left: 0;
-  z-index: variables.$modals-z-index;
   width: 100vw;
-  height: 100dvh;
+  max-width: 100vw;
+  height: 100%;
+  max-height: 100vh;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  color: var(--body-color);
+  background: transparent;
+  border: none;
+
+  &.centered[open] {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+  }
+
+  &.close[open] {
+    animation: fade-out $animation-duration forwards;
+
+    &::backdrop {
+      animation: fade-out $animation-duration forwards;
+    }
+  }
+
+  &[open] {
+    animation: fade-in $animation-duration forwards;
+
+    &::backdrop {
+      animation: fade-in $animation-duration forwards;
+    }
+  }
 }
 
-.backdrop {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+dialog::backdrop {
   background-color: theme.$modal-backdrop-bg;
 }
 
-.container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }

--- a/packages/ui-react/src/components/Modal/Modal.test.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.test.tsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act } from '@testing-library/react';
+
+import { renderWithRouter } from '../../../test/utils';
 
 import Modal from './Modal';
 
 describe('<Modal>', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   test('renders and matches snapshot', () => {
-    const { container } = render(
+    const { container } = renderWithRouter(
       <Modal open={true} onClose={vi.fn()}>
         <p>Test modal</p>
       </Modal>,
@@ -14,42 +24,19 @@ describe('<Modal>', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('calls the onClose function when clicking the backdrop', () => {
+  test('add overflowY hidden on the body element when open', async () => {
     const onClose = vi.fn();
-    const { getByTestId } = render(<Modal open={true} onClose={onClose} />);
-
-    fireEvent.click(getByTestId('backdrop'));
-
-    expect(onClose).toBeCalledTimes(1);
-  });
-
-  test('Should add inert attribute on the root div when open', () => {
-    const onClose = vi.fn();
-    const { getByTestId, rerender } = render(
-      <div id="root" data-testid="root">
-        <Modal open={true} onClose={onClose} />
-      </div>,
-    );
-
-    expect(getByTestId('root')).toHaveProperty('inert', true);
-
-    rerender(
-      <div id="root" data-testid="root">
-        <Modal open={false} onClose={onClose} />
-      </div>,
-    );
-
-    expect(getByTestId('root')).toHaveProperty('inert', false);
-  });
-
-  test('should add overflowY hidden on the body element when open', () => {
-    const onClose = vi.fn();
-    const { container, rerender } = render(<Modal open={true} onClose={onClose} />);
+    const { container, rerender } = await act(() => renderWithRouter(<Modal open={true} onClose={onClose} />));
 
     expect(container.parentNode).toHaveStyle({ overflowY: 'hidden' });
 
-    rerender(<Modal open={false} onClose={onClose} />);
+    act(() => {
+      rerender(<Modal open={false} onClose={onClose} />);
+    });
 
+    await act(() => vi.runAllTimers()); // wait for close animation
+
+    expect(onClose).toHaveBeenCalled();
     expect(container.parentNode).not.toHaveStyle({ overflowY: 'hidden' });
   });
 });

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -1,95 +1,102 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { type HTMLAttributes, type KeyboardEventHandler, type ReactEventHandler, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import { testId } from '@jwp/ott-common/src/utils/common';
+import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
+import classNames from 'classnames';
 
-import Fade from '../Animation/Fade/Fade';
 import Grow from '../Animation/Grow/Grow';
-import scrollbarSize from '../../utils/dom';
+import { useModal } from '../../hooks/useModal';
 
 import styles from './Modal.module.scss';
 
+export type AnimationProps = {
+  open?: boolean;
+  duration?: number;
+  delay?: number;
+  children: React.ReactNode;
+  className?: string;
+  onCloseAnimationEnd?: () => void;
+};
+
 type Props = {
   children?: React.ReactNode;
-  AnimationComponent?: React.JSXElementConstructor<{ open?: boolean; duration?: number; delay?: number; children: React.ReactNode; className?: string }>;
+  className?: string;
+  centered?: boolean;
+  AnimationComponent?: React.ElementType<AnimationProps>;
   open: boolean;
   onClose?: () => void;
   animationContainerClassName?: string;
+  role?: HTMLAttributes<HTMLElement>['role'];
 } & React.AriaAttributes;
 
-const Modal: React.FC<Props> = ({ open, onClose, children, AnimationComponent = Grow, animationContainerClassName, ...ariaAtributes }: Props) => {
-  const [visible, setVisible] = useState(open);
-  const lastFocus = useRef<HTMLElement>() as React.MutableRefObject<HTMLElement>;
-  const modalRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
+const Modal: React.FC<Props> = ({
+  open,
+  onClose,
+  children,
+  className,
+  centered,
+  role,
+  AnimationComponent = Grow,
+  animationContainerClassName,
+  ...ariaAttributes
+}: Props) => {
+  const modalRef = useRef<HTMLDialogElement>() as React.MutableRefObject<HTMLDialogElement>;
 
-  const keyDownEventHandler = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape' && onClose) {
-      onClose();
+  const { handleOpen, handleClose } = useModal();
+
+  const closeModalEvent = useEventCallback(() => {
+    const onAnimationEndHandler = () => {
+      // modalRef.current?.close();
+      modalRef.current?.classList.remove(styles.close);
+      modalRef.current?.removeEventListener('animationend', onAnimationEndHandler);
+    };
+
+    if (modalRef.current?.open) {
+      modalRef.current.addEventListener('animationend', onAnimationEndHandler);
+      modalRef.current.classList.add(styles.close);
+    }
+  });
+
+  const openModalEvent = useEventCallback(() => {
+    handleOpen();
+    modalRef.current?.showModal();
+    modalRef.current?.classList.remove(styles.close);
+  });
+
+  const keyDownHandler: KeyboardEventHandler<HTMLDialogElement> = (event) => {
+    if (event.key === 'Escape' && modalRef.current.contains(event.target as HTMLElement)) {
+      event.preventDefault();
+      onClose?.();
     }
   };
 
-  // delay the transition state so the CSS transition kicks in after toggling the `open` prop
-  useEffect(() => {
-    const activeElement = document.activeElement as HTMLElement;
-    const appView = document.querySelector('#root') as HTMLDivElement;
+  const closeHandler: ReactEventHandler<HTMLDialogElement> = (event) => {
+    if (modalRef.current.contains(event.target as HTMLElement)) {
+      onClose?.();
+      handleClose();
+    }
+  };
 
+  useEffect(() => {
     if (open) {
-      // store last focussed element
-      if (activeElement) {
-        lastFocus.current = activeElement;
-      }
-
-      // reset the visible state
-      setVisible(true);
-
-      // make sure main content is hidden for screen readers and inert
-      if (appView) {
-        appView.inert = true;
-      }
-
-      // prevent scrolling under the modal
-      document.body.style.marginRight = `${scrollbarSize()}px`;
-      document.body.style.overflowY = 'hidden';
+      openModalEvent();
     } else {
-      if (appView) {
-        appView.inert = false;
-      }
-
-      document.body.style.removeProperty('margin-right');
-      document.body.style.removeProperty('overflow-y');
+      closeModalEvent();
     }
-  }, [open]);
-
-  useEffect(() => {
-    if (visible) {
-      // focus the first element in the modal
-      if (modalRef.current) {
-        const interactiveElement = modalRef.current.querySelectorAll(
-          'div[role="dialog"] input, div[role="dialog"] a, div[role="dialog"] button, div[role="dialog"] [tabindex]',
-        )[0] as HTMLElement | null;
-
-        if (interactiveElement) interactiveElement.focus();
-      }
-    } else {
-      // restore last focussed element
-      if (lastFocus.current) {
-        lastFocus.current.focus();
-      }
-    }
-  }, [visible]);
-
-  if (!open && !visible) return null;
+  }, [openModalEvent, closeModalEvent, open]);
 
   return ReactDOM.createPortal(
-    <Fade open={open} duration={300} onCloseAnimationEnd={() => setVisible(false)}>
-      <div className={styles.modal} onKeyDown={keyDownEventHandler} ref={modalRef}>
-        <div className={styles.backdrop} onClick={onClose} data-testid={testId('backdrop')} />
-        <div className={styles.container} {...ariaAtributes}>
-          <AnimationComponent open={open} duration={200} className={animationContainerClassName}>
-            {children}
-          </AnimationComponent>
-        </div>
-      </div>
-    </Fade>,
+    <dialog
+      className={classNames(className, { [styles.centered]: centered })}
+      onKeyDown={keyDownHandler}
+      onClose={closeHandler}
+      ref={modalRef}
+      role={role}
+      {...ariaAttributes}
+    >
+      <AnimationComponent open={open} duration={300} className={animationContainerClassName} onCloseAnimationEnd={() => modalRef.current?.close()}>
+        {children}
+      </AnimationComponent>
+    </dialog>,
     document.querySelector('body') as HTMLElement,
   );
 };

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -88,11 +88,20 @@ const Modal: React.FC<Props> = ({
     }
   }, [openModalEvent, closeModalEvent, open]);
 
+  const clickHandler: ReactEventHandler<HTMLDialogElement> = (event) => {
+    // Backdrop click (the dialog itself) will close the modal
+    if (event.target === modalRef.current) {
+      onClose?.();
+      handleClose();
+    }
+  };
+
   return ReactDOM.createPortal(
     <dialog
       className={classNames(className, { [styles.centered]: centered })}
       onKeyDown={keyDownHandler}
       onClose={closeHandler}
+      onClick={clickHandler}
       ref={modalRef}
       role={role}
       {...ariaAttributes}

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes, type KeyboardEventHandler, type ReactEventHandler, useEffect, useRef, useCallback } from 'react';
+import React, { type HTMLAttributes, type KeyboardEventHandler, type ReactEventHandler, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 import classNames from 'classnames';
@@ -76,9 +76,9 @@ const Modal: React.FC<Props> = ({
     }
   };
 
-  const onCloseAnimationEnd = useCallback(() => {
+  const closeAnimationEndHandler = () => {
     modalRef.current?.close();
-  }, []);
+  };
 
   useEffect(() => {
     if (open) {
@@ -106,7 +106,7 @@ const Modal: React.FC<Props> = ({
       role={role}
       {...ariaAttributes}
     >
-      <AnimationComponent open={open} duration={300} className={animationContainerClassName} onCloseAnimationEnd={onCloseAnimationEnd}>
+      <AnimationComponent open={open} duration={300} className={animationContainerClassName} onCloseAnimationEnd={closeAnimationEndHandler}>
         {children}
       </AnimationComponent>
     </dialog>,

--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes, type KeyboardEventHandler, type ReactEventHandler, useEffect, useRef } from 'react';
+import React, { type HTMLAttributes, type KeyboardEventHandler, type ReactEventHandler, useEffect, useRef, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 import classNames from 'classnames';
@@ -76,6 +76,10 @@ const Modal: React.FC<Props> = ({
     }
   };
 
+  const onCloseAnimationEnd = useCallback(() => {
+    modalRef.current?.close();
+  }, []);
+
   useEffect(() => {
     if (open) {
       openModalEvent();
@@ -93,7 +97,7 @@ const Modal: React.FC<Props> = ({
       role={role}
       {...ariaAttributes}
     >
-      <AnimationComponent open={open} duration={300} className={animationContainerClassName} onCloseAnimationEnd={() => modalRef.current?.close()}>
+      <AnimationComponent open={open} duration={300} className={animationContainerClassName} onCloseAnimationEnd={onCloseAnimationEnd}>
         {children}
       </AnimationComponent>
     </dialog>,

--- a/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.module.scss
@@ -3,22 +3,6 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 
 //
-// jwSidebarBackdrop
-// --------------------------------
-
-.backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: variables.$sidebar-z-index - 1;
-  display: none;
-  width: 100%;
-  height: 100%;
-  background: theme.$modal-backdrop-bg;
-  transition: all 0.3s ease;
-}
-
-//
 // jwSidebar
 // --------------------------------
 
@@ -26,14 +10,12 @@
   position: fixed;
   top: 0;
   z-index: variables.$sidebar-z-index;
-  display: none;
+  display: inline-block;
   width: 270px;
   max-width: 90vw;
   height: 100dvh;
   overflow-y: auto;
   background-color: var(--body-background-color);
-  transform: translateX(-100%);
-  transition: transform 0.3s cubic-bezier(0.52, 0.51, 0.2, 1);
 
   ul {
     margin: 0;
@@ -54,29 +36,4 @@
   max-height: 100%;
   padding: variables.$base-spacing 0;
   -webkit-overflow-scrolling: touch;
-}
-
-//
-// mediaQueries
-// --------------------------------
-
-@include responsive.mobile-and-tablet() {
-  .sidebar {
-    display: inline-block;
-
-    &.open {
-      transform: translateX(0);
-    }
-  }
-
-  .backdrop {
-    display: inline-block;
-    visibility: hidden;
-    opacity: 0;
-
-    &.visible {
-      visibility: visible;
-      opacity: 1;
-    }
-  }
 }

--- a/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from '@testing-library/react';
 
 import { renderWithRouter } from '../../../test/utils';
 import Button from '../Button/Button';
@@ -8,23 +9,55 @@ import Sidebar from './Sidebar';
 describe('<SideBar />', () => {
   const playlistMenuItems = [<Button key="key" label="Home" to="/" />];
 
-  test('renders sideBar opened', () => {
-    const { container } = renderWithRouter(
-      <Sidebar isOpen={true} onClose={vi.fn()}>
-        {playlistMenuItems}
-      </Sidebar>,
-    );
-
-    expect(container).toMatchSnapshot();
+  beforeAll(() => {
+    vi.useFakeTimers();
   });
 
-  test('renders sideBar closed', () => {
-    const { container } = renderWithRouter(
-      <Sidebar isOpen={false} onClose={vi.fn()}>
-        {playlistMenuItems}
-      </Sidebar>,
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  test('renders sideBar opened', async () => {
+    const { baseElement, getByText } = await act(() =>
+      renderWithRouter(
+        <Sidebar isOpen={true} onClose={vi.fn()}>
+          {playlistMenuItems}
+        </Sidebar>,
+      ),
     );
 
-    expect(container).toMatchSnapshot();
+    await act(() => vi.runAllTimers());
+
+    expect(getByText('Home')).toBeVisible();
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  test('renders sideBar closed', async () => {
+    const { baseElement, queryByText } = await act(() =>
+      renderWithRouter(
+        <Sidebar isOpen={false} onClose={vi.fn()}>
+          {playlistMenuItems}
+        </Sidebar>,
+      ),
+    );
+
+    await act(() => vi.runAllTimers());
+
+    expect(queryByText('Home')).toBeNull();
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  test('should add overflowY hidden on the body element when open', async () => {
+    const onClose = vi.fn();
+    const { container, rerender } = await act(() => renderWithRouter(<Sidebar isOpen={true} onClose={onClose} />));
+
+    expect(container.parentNode).toHaveStyle({ overflowY: 'hidden' });
+
+    act(() => rerender(<Sidebar isOpen={false} onClose={onClose} />));
+
+    await act(() => vi.runAllTimers()); // wait for close animation
+
+    expect(onClose).toHaveBeenCalled();
+    expect(container.parentNode).not.toHaveStyle({ overflowY: 'hidden' });
   });
 });

--- a/packages/ui-react/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ui-react/src/components/Sidebar/Sidebar.tsx
@@ -1,11 +1,11 @@
-import React, { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
-import classNames from 'classnames';
+import React, { type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import Close from '@jwp/ott-theme/assets/icons/close.svg?react';
 
 import IconButton from '../IconButton/IconButton';
 import Icon from '../Icon/Icon';
-import scrollbarSize from '../../utils/dom';
+import Modal, { type AnimationProps } from '../Modal/Modal';
+import Slide from '../Animation/Slide/Slide';
 
 import styles from './Sidebar.module.scss';
 
@@ -15,83 +15,18 @@ type SidebarProps = {
   children?: ReactNode;
 };
 
+const SlideLeft = ({ children, ...props }: AnimationProps) => (
+  <Slide direction="left" {...props}>
+    {children}
+  </Slide>
+);
+
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
   const { t } = useTranslation('menu');
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
-  const sidebarRef = useRef<HTMLDivElement>(null);
-  const [visible, setVisible] = useState(false);
-
-  const htmlAttributes = { inert: !isOpen ? '' : undefined }; // inert is not yet officially supported in react. see: https://github.com/facebook/react/pull/24730
-
-  useEffect(() => {
-    if (isOpen) {
-      // Before inert on the body is applied in Layout, we need to set this ref
-      lastFocusedElementRef.current = document.activeElement as HTMLElement;
-
-      // When opened, adjust the margin-right to accommodate for the scrollbar width to prevent UI shifts in background
-      document.body.style.marginRight = `${scrollbarSize()}px`;
-      document.body.style.overflowY = 'hidden';
-
-      // Scroll the sidebar to the top if the user has previously scrolled down in the sidebar
-      if (sidebarRef.current) {
-        sidebarRef.current.scrollTop = 0;
-      }
-    } else {
-      document.body.style.removeProperty('margin-right');
-      document.body.style.removeProperty('overflow-y');
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    const handleEscKey = (event: KeyboardEvent) => {
-      if (isOpen && event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscKey);
-
-    return () => {
-      document.removeEventListener('keydown', handleEscKey);
-    };
-  }, [isOpen, onClose]);
-
-  useEffect(() => {
-    const sidebarElement = sidebarRef.current;
-    const handleTransitionEnd = () => {
-      setVisible(isOpen);
-    };
-
-    sidebarElement?.addEventListener('transitionend', handleTransitionEnd);
-
-    return () => {
-      sidebarElement?.removeEventListener('transitionend', handleTransitionEnd);
-    };
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (visible) {
-      sidebarRef.current?.querySelectorAll('a')[0]?.focus({ preventScroll: true });
-    } else {
-      lastFocusedElementRef.current?.focus({ preventScroll: true });
-    }
-  }, [visible]);
 
   return (
-    <Fragment>
-      <div
-        className={classNames(styles.backdrop, {
-          [styles.visible]: isOpen,
-        })}
-        onClick={onClose}
-      />
-      <div
-        ref={sidebarRef}
-        className={classNames(styles.sidebar, {
-          [styles.open]: isOpen,
-        })}
-        id="sidebar"
-        {...htmlAttributes}
-      >
+    <Modal open={isOpen} onClose={onClose} AnimationComponent={SlideLeft}>
+      <div className={styles.sidebar} id="sidebar">
         <div className={styles.heading}>
           <IconButton onClick={onClose} aria-label={t('close_menu')}>
             <Icon icon={Close} />
@@ -101,7 +36,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, children }) => {
           {children}
         </nav>
       </div>
-    </Fragment>
+    </Modal>
   );
 };
 

--- a/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/ui-react/src/components/Sidebar/__snapshots__/Sidebar.test.tsx.snap
@@ -1,102 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<SideBar /> > renders sideBar closed 1`] = `
-<div>
-  <div
-    class="_backdrop_577f70"
+<body
+  style=""
+>
+  <div />
+  <dialog
+    class=""
   />
-  <div
-    class="_sidebar_577f70"
-    id="sidebar"
-    inert=""
-  >
-    <div
-      class="_heading_577f70"
-    >
-      <button
-        aria-label="close_menu"
-        class="_iconButton_0fef65"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="_icon_585b29"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-          />
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-        </svg>
-      </button>
-    </div>
-    <nav
-      class="_group_577f70"
-    >
-      <a
-        aria-current="page"
-        class="_button_f8f296 _default_f8f296 _outlined_f8f296 _active_f8f296"
-        href="/"
-      >
-        <span>
-          Home
-        </span>
-      </a>
-    </nav>
-  </div>
-</div>
+</body>
 `;
 
 exports[`<SideBar /> > renders sideBar opened 1`] = `
-<div>
-  <div
-    class="_backdrop_577f70 _visible_577f70"
-  />
-  <div
-    class="_sidebar_577f70 _open_577f70"
-    id="sidebar"
+<body
+  style="margin-right: 0px; overflow-y: hidden;"
+>
+  <div />
+  <dialog
+    class=""
+    open=""
   >
     <div
-      class="_heading_577f70"
+      style="transition: transform 0.3s ease, opacity 0.3s ease; transform: translate(0, 0); opacity: 1; z-index: 15;"
     >
-      <button
-        aria-label="close_menu"
-        class="_iconButton_0fef65"
-        type="button"
+      <div
+        class="_sidebar_577f70"
+        id="sidebar"
       >
-        <svg
-          aria-hidden="true"
-          class="_icon_585b29"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="_heading_577f70"
         >
-          <path
-            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-          />
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-        </svg>
-      </button>
+          <button
+            aria-label="close_menu"
+            class="_iconButton_0fef65"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="_icon_585b29"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+              />
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+            </svg>
+          </button>
+        </div>
+        <nav
+          class="_group_577f70"
+        >
+          <a
+            aria-current="page"
+            class="_button_f8f296 _default_f8f296 _outlined_f8f296 _active_f8f296"
+            href="/"
+          >
+            <span>
+              Home
+            </span>
+          </a>
+        </nav>
+      </div>
     </div>
-    <nav
-      class="_group_577f70"
-    >
-      <a
-        aria-current="page"
-        class="_button_f8f296 _default_f8f296 _outlined_f8f296 _active_f8f296"
-        href="/"
-      >
-        <span>
-          Home
-        </span>
-      </a>
-    </nav>
-  </div>
-</div>
+  </dialog>
+</body>
 `;

--- a/packages/ui-react/src/containers/AccountModal/AccountModal.module.scss
+++ b/packages/ui-react/src/containers/AccountModal/AccountModal.module.scss
@@ -2,9 +2,11 @@
 @use '@jwp/ott-ui-react/src/styles/theme';
 
 .banner {
+  height: 80px;
   text-align: center;
 
   > img {
     max-width: 50%;
+    max-height: 100%;
   }
 }

--- a/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
+++ b/packages/ui-react/src/containers/AccountModal/AccountModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
@@ -67,7 +67,7 @@ const AccountModal = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const viewParam = useQueryParam('u');
-  const [view, setView] = useState(viewParam);
+  const viewParamRef = useRef(viewParam);
   const message = useQueryParam('message');
   const { loading, user } = useAccountStore(({ loading, user }) => ({ loading, user }), shallow);
   const config = useConfigStore((s) => s.config);
@@ -81,9 +81,10 @@ const AccountModal = () => {
     navigate(modalURLFromLocation(location, 'login'));
   });
 
-  useEffect(() => {
-    // make sure the last view is rendered even when the modal gets closed
-    if (viewParam) setView(viewParam);
+  // make sure the last view is rendered even when the modal gets closed
+  const view = useMemo(() => {
+    if (viewParam) viewParamRef.current = viewParam;
+    return viewParamRef.current;
   }, [viewParam]);
 
   useEffect(() => {
@@ -165,8 +166,12 @@ const AccountModal = () => {
   const dialogSize = ['delete-account-confirmation'].includes(view ?? '') ? 'large' : 'small';
 
   return (
-    <Dialog size={dialogSize} open={!!viewParam} onClose={closeHandler} role="dialog">
-      {shouldShowBanner && banner && <div className={styles.banner}>{<img src={banner} alt="" />}</div>}
+    <Dialog size={dialogSize} open={!!viewParam} onClose={closeHandler}>
+      {shouldShowBanner && banner && (
+        <div className={styles.banner}>
+          <img src={banner} alt="" />
+        </div>
+      )}
       {renderForm()}
     </Dialog>
   );

--- a/packages/ui-react/src/containers/Cinema/Cinema.test.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.test.tsx
@@ -6,6 +6,7 @@ import ApiService from '@jwp/ott-common/src/services/ApiService';
 import GenericEntitlementService from '@jwp/ott-common/src/services/GenericEntitlementService';
 import JWPEntitlementService from '@jwp/ott-common/src/services/JWPEntitlementService';
 import WatchHistoryController from '@jwp/ott-common/src/controllers/WatchHistoryController';
+import { act } from '@testing-library/react';
 
 import { renderWithRouter } from '../../../test/utils';
 
@@ -38,17 +39,19 @@ describe('<Cinema>', () => {
       tracks: [],
     } as PlaylistItem;
 
-    const { baseElement } = renderWithRouter(
-      <Cinema
-        item={item}
-        onPlay={() => null}
-        onPause={() => null}
-        open
-        title={item.title}
-        primaryMetadata="Primary metadata"
-        onClose={vi.fn()}
-        onNext={vi.fn()}
-      />,
+    const { baseElement } = await act(() =>
+      renderWithRouter(
+        <Cinema
+          item={item}
+          onPlay={() => null}
+          onPause={() => null}
+          open
+          title={item.title}
+          primaryMetadata="Primary metadata"
+          onClose={vi.fn()}
+          onNext={vi.fn()}
+        />,
+      ),
     );
 
     expect(baseElement).toMatchSnapshot();

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -80,8 +80,8 @@ const Cinema: React.FC<Props> = ({
   }, [open]);
 
   return (
-    <Modal open={open} animationContainerClassName={styles.cinemaContainer} onClose={onClose}>
-      <div className={styles.cinema} aria-modal="true" role="dialog" aria-label={t('videoplayer')}>
+    <Modal open={open} animationContainerClassName={styles.cinemaContainer} onClose={onClose} aria-label={t('videoplayer')}>
+      <div className={styles.cinema}>
         <Fade className={styles.overlayFade} open={!isPlaying || userActive || overlayHasFocus} keepMounted>
           <div className={styles.playerOverlay} onFocus={() => setOverlayHasFocus(true)} onBlur={() => setOverlayHasFocus(false)}>
             <div className={styles.playerContent}>

--- a/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
+++ b/packages/ui-react/src/containers/Cinema/__snapshots__/Cinema.test.tsx.snap
@@ -5,90 +5,77 @@ exports[`<Cinema> > renders and matches snapshot 1`] = `
   style="margin-right: 0px; overflow-y: hidden;"
 >
   <div />
-  <div
-    style="transition: opacity 0.3s ease-in-out; opacity: 0; will-change: opacity;"
+  <dialog
+    aria-label="videoplayer"
+    class=""
+    open=""
   >
     <div
-      class="_modal_6c6c55"
+      class="_cinemaContainer_555f3c"
+      style="transition: transform 0.3s ease-out; transform: scale(1);"
     >
       <div
-        class="_backdrop_6c6c55"
-        data-testid="backdrop"
-      />
-      <div
-        class="_container_6c6c55"
+        class="_cinema_555f3c"
       >
         <div
-          class="_cinemaContainer_555f3c"
-          style="transition: transform 0.2s ease-out; transform: scale(0.7);"
+          class="_overlayFade_555f3c"
+          style="transition: opacity 0.25s ease-in-out; opacity: 1; will-change: opacity;"
         >
           <div
-            aria-label="videoplayer"
-            aria-modal="true"
-            class="_cinema_555f3c"
-            role="dialog"
+            class="_playerOverlay_555f3c"
           >
             <div
-              class="_overlayFade_555f3c"
-              style="transition: opacity 0.25s ease-in-out; opacity: 0; will-change: opacity;"
+              class="_playerContent_555f3c"
             >
-              <div
-                class="_playerOverlay_555f3c"
+              <button
+                aria-label="common:back"
+                class="_iconButton_0fef65 _backButton_555f3c"
+                type="button"
               >
-                <div
-                  class="_playerContent_555f3c"
+                <svg
+                  aria-hidden="true"
+                  class="_icon_585b29"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <button
-                    aria-label="common:back"
-                    class="_iconButton_0fef65 _backButton_555f3c"
-                    type="button"
+                  <path
+                    d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
+                  />
+                </svg>
+              </button>
+              <div>
+                <h1
+                  class="_title_555f3c"
+                >
+                  Test item title
+                </h1>
+                <div
+                  class="_metaContainer_555f3c"
+                >
+                  <div
+                    class="_primaryMetadata_555f3c"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="_icon_585b29"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z"
-                      />
-                    </svg>
-                  </button>
-                  <div>
-                    <h1
-                      class="_title_555f3c"
-                    >
-                      Test item title
-                    </h1>
-                    <div
-                      class="_metaContainer_555f3c"
-                    >
-                      <div
-                        class="_primaryMetadata_555f3c"
-                      >
-                        Primary metadata
-                      </div>
-                    </div>
+                    Primary metadata
                   </div>
                 </div>
               </div>
             </div>
-            <div
-              class="_loadingOverlay_eb61cb _inline_eb61cb"
-            >
-              <div
-                class="_buffer_d122df"
-              >
-                <div />
-                <div />
-                <div />
-                <div />
-              </div>
-            </div>
+          </div>
+        </div>
+        <div
+          class="_loadingOverlay_eb61cb _inline_eb61cb"
+        >
+          <div
+            class="_buffer_d122df"
+          >
+            <div />
+            <div />
+            <div />
+            <div />
           </div>
         </div>
       </div>
     </div>
-  </div>
+  </dialog>
 </body>
 `;

--- a/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
+++ b/packages/ui-react/src/containers/Layout/__snapshots__/Layout.test.tsx.snap
@@ -71,60 +71,6 @@ exports[`<Layout /> > renders layout 1`] = `
         tabindex="-1"
       />
     </div>
-    <div
-      class="_backdrop_577f70"
-    />
-    <div
-      class="_sidebar_577f70"
-      id="sidebar"
-      inert=""
-    >
-      <div
-        class="_heading_577f70"
-      >
-        <button
-          aria-label="close_menu"
-          class="_iconButton_0fef65"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="_icon_585b29"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-            />
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-          </svg>
-        </button>
-      </div>
-      <nav
-        class="_group_577f70"
-      >
-        <ul>
-          <li>
-            <a
-              aria-current="page"
-              class="_menuButton_91706b _active_91706b"
-              href="/"
-              tabindex="0"
-            >
-              <span>
-                home
-              </span>
-            </a>
-          </li>
-        </ul>
-        <hr
-          class="_separator_e15dbc"
-        />
-      </nav>
-    </div>
   </div>
 </div>
 `;

--- a/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
+++ b/packages/ui-react/src/containers/Profiles/DeleteProfile.tsx
@@ -47,7 +47,7 @@ const DeleteProfile = () => {
   if (view !== 'delete-profile') return null;
   return (
     <div>
-      <Dialog open={!!viewParam} onClose={closeHandler} role="dialog" aria-labelledby="delete-profile-heading">
+      <Dialog open={!!viewParam} onClose={closeHandler} aria-labelledby="delete-profile-heading">
         {isDeleting && <LoadingOverlay />}
         <div className={styles.deleteModal}>
           <div>

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -27,8 +27,8 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
   if (!item) return null;
 
   return (
-    <Modal open={open} onClose={onClose}>
-      <div className={styles.container} role="dialog" aria-modal="true" aria-labelledby="trailer-modal-title">
+    <Modal open={open} onClose={onClose} aria-labelledby="trailer-modal-title" centered>
+      <div className={styles.container}>
         <Player
           item={item}
           onPlay={handlePlay}

--- a/packages/ui-react/src/hooks/useModal.ts
+++ b/packages/ui-react/src/hooks/useModal.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect } from 'react';
+
+import scrollbarSize from '../utils/dom';
+
+const removeBodyScrolling = () => {
+  document.body.style.marginRight = `${scrollbarSize(true)}px`;
+  document.body.style.overflowY = 'hidden';
+};
+
+const restoreBodyScrolling = () => {
+  const dialogs = Array.from(document.querySelectorAll('dialog'));
+  const openDialogs = dialogs.filter((dialog) => dialog.open).length;
+
+  if (!openDialogs) {
+    document.body.style.removeProperty('margin-right');
+    document.body.style.removeProperty('overflow-y');
+  }
+};
+
+// shared variable between `useModal` usages
+let originElement: HTMLElement | undefined;
+
+export const useModal = () => {
+  const restoreFocus = useCallback(() => {
+    // restore focus when the focus is "lost" to the body element
+    if (!originElement || document.activeElement !== document.body) {
+      return;
+    }
+
+    const dialogs = Array.from(document.querySelectorAll('dialog'));
+    const openDialogs = dialogs.filter((dialog) => dialog.open).length;
+
+    // this was the last open dialog
+    if (openDialogs === 0) {
+      originElement.focus();
+      originElement = undefined;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      restoreBodyScrolling();
+      restoreFocus();
+    };
+  }, [restoreFocus]);
+
+  const handleOpen = useCallback(() => {
+    if (!originElement) {
+      originElement = document.activeElement as HTMLElement;
+    }
+
+    removeBodyScrolling();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    restoreFocus();
+    restoreBodyScrolling();
+  }, [restoreFocus]);
+
+  return { handleOpen, handleClose };
+};

--- a/packages/ui-react/src/pages/User/User.test.tsx
+++ b/packages/ui-react/src/pages/User/User.test.tsx
@@ -87,7 +87,11 @@ describe('User Component tests', () => {
       })),
     });
     mockService(FavoritesController, { clear: vi.fn() });
-    mockService(CheckoutController, { getSubscriptionSwitches: vi.fn(), getSubscriptionOfferIds: vi.fn().mockReturnValue([]) });
+    mockService(CheckoutController, {
+      initialiseOffers: vi.fn().mockResolvedValue([]),
+      getSubscriptionSwitches: vi.fn(),
+      getSubscriptionOfferIds: vi.fn().mockReturnValue([]),
+    });
     mockService(ProfileController, { listProfiles: vi.fn(), isEnabled: vi.fn().mockReturnValue(false) });
 
     useConfigStore.setState({
@@ -109,15 +113,17 @@ describe('User Component tests', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('Payments Page', () => {
+  test('Payments Page', async () => {
     act(() => {
       useAccountStore.setState(data);
       mockWindowLocation('u/payments');
     });
-    const { container } = renderWithRouter(
-      <Routes>
-        <Route path="/u/*" element={<User />} />
-      </Routes>,
+    const { container } = await act(() =>
+      renderWithRouter(
+        <Routes>
+          <Route path="/u/*" element={<User />} />
+        </Routes>,
+      ),
     );
 
     expect(container).toMatchSnapshot();

--- a/packages/ui-react/test/utils.tsx
+++ b/packages/ui-react/test/utils.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider } from 'react-router-dom';
 import React, { type ReactElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { render, act, type RenderOptions } from '@testing-library/react';
+import { act, render, type RenderOptions } from '@testing-library/react';
 
 import QueryProvider from '../src/containers/QueryProvider/QueryProvider';
 import { AriaAnnouncerProvider } from '../src/containers/AnnouncementProvider/AnnoucementProvider';

--- a/packages/ui-react/vitest.setup.ts
+++ b/packages/ui-react/vitest.setup.ts
@@ -2,7 +2,23 @@ import 'vi-fetch/setup';
 import 'reflect-metadata';
 import '@testing-library/jest-dom'; // Including this for the expect extensions
 import 'react-app-polyfill/stable';
+import 'wicg-inert';
 import type { ComponentType } from 'react';
+import { fireEvent } from '@testing-library/react';
+
+beforeAll(() => {
+  // these methods don't exist in JSDOM: https://github.com/jsdom/jsdom/issues/3294
+  HTMLDialogElement.prototype.show = vi.fn().mockImplementation(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.showModal = vi.fn().mockImplementation(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn().mockImplementation(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+    fireEvent(this, new Event('close'));
+  });
+});
 
 const country = {
   af: 'Afghanistan',

--- a/platforms/web/test-e2e/tests/login/account_test.ts
+++ b/platforms/web/test-e2e/tests/login/account_test.ts
@@ -31,7 +31,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
   });
 
   Scenario(`I can close the modal by clicking outside - ${providerName}`, async ({ I }) => {
-    I.forceClick('div[data-testid="backdrop"]');
+    I.forceClick('dialog[open]');
 
     I.dontSee('Email');
     I.dontSee('Password');

--- a/platforms/web/test-e2e/tests/login/account_test.ts
+++ b/platforms/web/test-e2e/tests/login/account_test.ts
@@ -36,7 +36,7 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     I.dontSee('Email');
     I.dontSee('Password');
     I.dontSeeElement(constants.loginFormSelector);
-  });
+  }).tag('@desktop-only');
 
   Scenario(`I can toggle to view password - ${providerName}`, async ({ I }) => {
     await passwordUtils.testPasswordToggling(I);

--- a/platforms/web/test-e2e/tests/offers/choose_offer_test.ts
+++ b/platforms/web/test-e2e/tests/offers/choose_offer_test.ts
@@ -66,6 +66,7 @@ function runTestSuite(props: ProviderProps, providerName: string) {
     I.amOnPage(constants.paymentsUrl);
 
     I.click('Complete subscription');
+    I.waitForLoaderDone();
     I.see('Choose plan');
     I.see('Watch this on JW OTT Web App');
 
@@ -92,6 +93,7 @@ function runTestSuite(props: ProviderProps, providerName: string) {
     paidLoginContext = await I.registerOrLogin(paidLoginContext);
 
     I.amOnPage(constants.offersUrl);
+    I.waitForLoaderDone();
 
     I.click(props.monthlyOffer.label);
     I.seeCssPropertiesOnElements(props.monthlyOffer.label, { color: '#000000' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11447,7 +11447,7 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-wicg-inert@^3.1.1:
+wicg-inert@^3.1.1, wicg-inert@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.1.2.tgz#df10cf756b773a96fce107c3ddcd43be5d1e3944"
   integrity sha512-Ba9tGNYxXwaqKEi9sJJvPMKuo063umUPsHN0JJsjrs2j8KDSzkWLMZGZ+MH1Jf1Fq4OWZ5HsESJID6nRza2ang==


### PR DESCRIPTION
## Description

This PR is an alternative to #485. In the modal manager PR, we try to manage everything ourselves, which gives us ultimate control but is risky and needs to be maintained in the future.

The [HTML Dialog](https://caniuse.com/dialog) element has been out for some time now, but I actually never used it because of the browser support. But looking at the support table, I don't see why we shouldn't use it. Over 96% of the global browsers support the HTML Dialog element.

Using the native dialog element removes the need for the ModalProvider, because we can use the DOM to close open modals.

Only the body scrolling was still possible so I modified the `useModal` hook to hide the scrollbars when a modal is open.

Although we don't have to manage focus anymore, I did find one edge case when opening the account modal from the sidebar. Because the last focused element doesn't exist anymore (I fixed this in the ModalProvider), the body receives focus when closing the last modal.

This is a proposal PR, so let me know if you have any feedback or criticism.
