### PR TITLE
Fix / favicon paths

### DIFF
--- a/platforms/web/scripts/build-tools/buildTools.ts
+++ b/platforms/web/scripts/build-tools/buildTools.ts
@@ -82,10 +82,10 @@ export const getGoogleFontTags = (fonts: ExternalFont[]): HtmlTagDescriptor[] =>
 
 export const generateIconTags = (basePath: string, favIconSizes: number[], appleIconSizes: number[]) => {
   const favIconTags = favIconSizes.map((size) => {
-    return `<link rel="icon" type="image/png" sizes="${size}x${size}" href="${basePath}/favicon-${size}x${size}.png">`;
+    return `<link rel="icon" type="image/png" sizes="${size}x${size}" href="${basePath}pwa-${size}x${size}.png">`;
   });
   const appleIconTags = appleIconSizes.map((size) => {
-    return `<link rel="apple-touch-icon" href="${basePath}/apple-touch-icon-${size}x${size}.png">`;
+    return `<link rel="apple-touch-icon" href="${basePath}apple-touch-icon-${size}x${size}.png">`;
   });
   return [...favIconTags, ...appleIconTags].join('\n');
 };

--- a/platforms/web/test-e2e/tests/seo_test.ts
+++ b/platforms/web/test-e2e/tests/seo_test.ts
@@ -1,11 +1,25 @@
 import { testConfigs } from '@jwp/ott-testing/constants';
 
+import { favIconSizes, appleIconSizes } from './../../pwa-assets.config';
+
 import constants from '#utils/constants';
 
 Feature('seo').retry(Number(process.env.TEST_RETRY_COUNT) || 0);
 
 Before(({ I }) => {
   I.useConfig(testConfigs.basicNoAuth);
+});
+
+Scenario('It renders all favicons correcty', ({ I }) => {
+  I.seeAttributesOnElements('link[sizes="any"]', { href: `${constants.baseUrl}images/icons/favicon.ico`, rel: 'icon', type: 'image/x-icon' });
+  for (const size of favIconSizes) {
+    const sizes = `${size}x${size}`;
+    I.seeAttributesOnElements(`link[sizes="${sizes}"]`, { href: `${constants.baseUrl}images/icons/pwa-${sizes}.png`, rel: 'icon', type: 'image/png' });
+  }
+  for (const size of appleIconSizes) {
+    const sizes = `${size}x${size}`;
+    I.seeElementInDOM(`link[rel="apple-touch-icon"][href="/images/icons/apple-touch-icon-${sizes}.png"]`);
+  }
 });
 
 Scenario('It renders the correct meta tags for the home screen', ({ I }) => {


### PR DESCRIPTION
While working on `@vitejs/plugin-legacy` I noticed some incorrect definitions in `index.html`.

I guess we didn't notice this because the (fallback) favicon.ico gets rendered in the browser.

I also wrote an e2e test, to verify if all favicons with correct paths get rendered in the browser to prevent an issue like this from happening in the future.