### PR TITLE
Fix / live channels custom screen

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -36,10 +36,12 @@ export const CONTENT_TYPE = {
   series: 'series',
   // Separate episode page
   episode: 'episode',
-  // Page with a list of channels
+  // Page with a list of live channels
   live: 'live',
-  // Separate channel page
+  // Live channel (24x7)
   liveChannel: 'livechannel',
+  // Temporary live stream that starts at a specific time
+  liveEvent: 'liveevent',
   // Static page with markdown
   page: 'page',
   // Page with shelves list

--- a/packages/common/src/utils/ScreenMap.ts
+++ b/packages/common/src/utils/ScreenMap.ts
@@ -1,5 +1,7 @@
 import type { Playlist, PlaylistItem } from '../../types/playlist';
 
+import { isContentType } from './common';
+
 type ScreenPredicate<T> = (data?: T) => boolean;
 
 type ScreenDefinition<T, C> = {
@@ -16,7 +18,7 @@ export class ScreenMap<T extends Playlist | PlaylistItem, C> {
   }
 
   registerByContentType(component: C, contentType: string) {
-    this.register(component, (data) => data?.contentType?.toLowerCase() === contentType);
+    this.register(component, (data) => !!data && isContentType(data, contentType));
   }
 
   registerDefault(component: C) {

--- a/packages/common/src/utils/common.ts
+++ b/packages/common/src/utils/common.ts
@@ -1,3 +1,5 @@
+import type { Playlist, PlaylistItem } from '../../types/playlist';
+
 export function debounce<T extends (...args: any[]) => void>(callback: T, wait = 200) {
   let timeout: NodeJS.Timeout | null;
   return (...args: unknown[]) => {
@@ -101,6 +103,8 @@ export function logDev(message: unknown, ...optionalParams: unknown[]) {
     }
   }
 }
+
+export const isContentType = (item: PlaylistItem | Playlist, contentType: string) => item.contentType?.toLowerCase() === contentType.toLowerCase();
 
 export const isTruthyCustomParamValue = (value: unknown): boolean => ['true', '1', 'yes', 'on'].includes(String(value)?.toLowerCase());
 

--- a/packages/common/src/utils/liveEvent.ts
+++ b/packages/common/src/utils/liveEvent.ts
@@ -1,4 +1,7 @@
 import type { PlaylistItem } from '../../types/playlist';
+import { CONTENT_TYPE } from '../constants';
+
+import { isContentType } from './common';
 
 export enum EventState {
   PRE_LIVE = 'PRE_LIVE',
@@ -15,7 +18,7 @@ export const enum MediaStatus {
 }
 
 export const isLiveEvent = (playlistItem?: PlaylistItem) => {
-  return !!playlistItem && !!playlistItem['VCH.EventState'] && !!playlistItem['VCH.ScheduledStart'];
+  return !!playlistItem && isContentType(playlistItem, CONTENT_TYPE.liveEvent);
 };
 
 export const isScheduledOrLiveMedia = (playlistItem: PlaylistItem) => {

--- a/packages/common/src/utils/media.ts
+++ b/packages/common/src/utils/media.ts
@@ -1,5 +1,7 @@
-import type { Playlist, PlaylistItem } from '../../types/playlist';
+import type { PlaylistItem } from '../../types/playlist';
 import { CONTENT_TYPE } from '../constants';
+
+import { isContentType } from './common';
 
 type RequiredProperties<T, P extends keyof T> = T & Required<Pick<T, P>>;
 
@@ -7,9 +9,6 @@ type DeprecatedPlaylistItem = {
   seriesPlayListId?: string;
   seriesPlaylistId?: string;
 };
-
-export const isPlaylist = (item: unknown): item is Playlist => !!item && typeof item === 'object' && 'feedid' in item;
-export const isPlaylistItem = (item: unknown): item is PlaylistItem => !!item && typeof item === 'object' && 'mediaid' in item;
 
 // For the deprecated series flow we store seriesId in custom params
 export const getSeriesPlaylistIdFromCustomParams = (item: (PlaylistItem & DeprecatedPlaylistItem) | undefined) =>
@@ -22,12 +21,12 @@ export const isLegacySeriesFlow = (item: PlaylistItem) => {
 
 // For the new series flow we use contentType custom param to define media item to be series
 // In this case media item and series item have the same id
-export const isSeriesContentType = (item: PlaylistItem) => item.contentType?.toLowerCase() === CONTENT_TYPE.series;
+export const isSeriesContentType = (item: PlaylistItem) => isContentType(item, CONTENT_TYPE.series);
 
 export const isSeries = (item: PlaylistItem) => isLegacySeriesFlow(item) || isSeriesContentType(item);
 
 export const isEpisode = (item: PlaylistItem) => {
-  return typeof item?.episodeNumber !== 'undefined' || item?.contentType?.toLowerCase() === CONTENT_TYPE.episode;
+  return typeof item?.episodeNumber !== 'undefined' || isContentType(item, CONTENT_TYPE.episode);
 };
 
 export const getLegacySeriesPlaylistIdFromEpisodeTags = (item: PlaylistItem | undefined) => {
@@ -47,5 +46,4 @@ export const getLegacySeriesPlaylistIdFromEpisodeTags = (item: PlaylistItem | un
   return;
 };
 
-export const isLiveChannel = (item: PlaylistItem): item is RequiredProperties<PlaylistItem, 'contentType' | 'liveChannelsId'> =>
-  item.contentType?.toLowerCase() === CONTENT_TYPE.liveChannel && !!item.liveChannelsId;
+export const isLiveChannel = (item: PlaylistItem): item is RequiredProperties<PlaylistItem, 'contentType'> => isContentType(item, CONTENT_TYPE.liveChannel);

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import { formatDurationTag, formatLocalizedDateTime, formatSeriesMetaString } from '@jwp/ott-common/src/utils/formatting';
 import { isLiveChannel, isSeries } from '@jwp/ott-common/src/utils/media';
-import { MediaStatus } from '@jwp/ott-common/src/utils/liveEvent';
+import { isLiveEvent, MediaStatus } from '@jwp/ott-common/src/utils/liveEvent';
 import Lock from '@jwp/ott-theme/assets/icons/lock.svg?react';
 import Today from '@jwp/ott-theme/assets/icons/today.svg?react';
 import { testId } from '@jwp/ott-common/src/utils/common';
@@ -110,7 +110,7 @@ function Card({
       {!featured && !disabled && (
         <div className={styles.titleContainer}>
           {heading}
-          {!!scheduledStart && (
+          {!!scheduledStart && isLiveEvent(item) && (
             <div className={classNames(styles.scheduledStart, { [styles.loading]: loading })}>{formatLocalizedDateTime(scheduledStart, language)}</div>
           )}
         </div>

--- a/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
@@ -16,6 +16,7 @@ import MediaMovie from './mediaScreens/MediaMovie/MediaMovie';
 import MediaSeries from './mediaScreens/MediaSeries/MediaSeries';
 import MediaLiveChannel from './mediaScreens/MediaLiveChannel/MediaLiveChannel';
 import MediaEpisode from './mediaScreens/MediaEpisode/MediaEpisode';
+import MediaEvent from './mediaScreens/MediaEvent/MediaEvent';
 
 export const mediaScreenMap = new ScreenMap<PlaylistItem, ScreenComponent<PlaylistItem>>();
 
@@ -23,6 +24,7 @@ export const mediaScreenMap = new ScreenMap<PlaylistItem, ScreenComponent<Playli
 mediaScreenMap.registerByContentType(MediaSeries, CONTENT_TYPE.series);
 mediaScreenMap.registerByContentType(MediaEpisode, CONTENT_TYPE.episode);
 mediaScreenMap.registerByContentType(MediaLiveChannel, CONTENT_TYPE.liveChannel);
+mediaScreenMap.registerByContentType(MediaEvent, CONTENT_TYPE.liveEvent);
 mediaScreenMap.registerByContentType(MediaStaticPage, CONTENT_TYPE.page);
 mediaScreenMap.registerDefault(MediaMovie);
 

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaLiveChannel/MediaLiveChannel.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaLiveChannel/MediaLiveChannel.tsx
@@ -1,24 +1,25 @@
 import { Navigate } from 'react-router-dom';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
-import { isLiveChannel } from '@jwp/ott-common/src/utils/media';
 import { liveChannelsURL } from '@jwp/ott-common/src/utils/urlFormatting';
 
 import type { ScreenComponent } from '../../../../../types/screens';
-import ErrorPage from '../../../../components/ErrorPage/ErrorPage';
 import Loading from '../../../Loading/Loading';
+import MediaMovie from '../MediaMovie/MediaMovie';
 
 const MediaLiveChannel: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
-  const liveChannelsId = isLiveChannel(data) ? data.liveChannelsId : undefined;
+  const liveChannelsId = data.liveChannelsId;
 
-  if (data && !isLoading && liveChannelsId) {
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  // this live channel is part of a live channels (TV Guide) page
+  if (liveChannelsId) {
     return <Navigate to={liveChannelsURL(liveChannelsId, data.mediaid)} replace={true}></Navigate>;
   }
 
-  if (!liveChannelsId) {
-    return <ErrorPage title="Live channel not found" />;
-  }
-
-  return <Loading />;
+  // this live channel is "just" a media item
+  return <MediaMovie data={data} isLoading={isLoading} />;
 };
 
 export default MediaLiveChannel;

--- a/platforms/web/src/screenMapping.ts
+++ b/platforms/web/src/screenMapping.ts
@@ -1,6 +1,4 @@
-import { isLiveEvent } from '@jwp/ott-common/src/utils/liveEvent';
 import { CONTENT_TYPE } from '@jwp/ott-common/src/constants';
-import MediaEvent from '@jwp/ott-ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent';
 import { mediaScreenMap } from '@jwp/ott-ui-react/src/pages/ScreenRouting/MediaScreenRouter';
 import MediaHub from '@jwp/ott-ui-react/src/pages/ScreenRouting/mediaScreens/MediaHub/MediaHub';
 
@@ -43,7 +41,4 @@ import MediaHub from '@jwp/ott-ui-react/src/pages/ScreenRouting/mediaScreens/Med
 export default function registerCustomScreens() {
   // Hub is an example screen for the media router
   mediaScreenMap.registerByContentType(MediaHub, CONTENT_TYPE.hub);
-
-  // todo: remove the isLiveEvent function when the media item's contain the correct contentType(without the VCH prefix)
-  mediaScreenMap.register(MediaEvent, isLiveEvent);
 }


### PR DESCRIPTION
## Description

This PR introduces two changes and a fix:

**Use `contentType` matching for live events custom screen instead of custom params**

- Add util function for contentType matching
- Remove custom mediaEvent screen from screenMapping.ts file


**Add support for live channels without TV Guide page**

When creating a 24x7 live channel via JWP dashboard the liveChannel contentType is added. This contentType was originally used only for live streams with a TV Guide (EPG). Now, this is only the case when the `liveChannelsId` param is present on the media item.

**Remove live event start date for 24x7 live channels**

The card shows the live event start date for 24x7 live channels because live channels contain the same parameters. Now the card will only show the event start date for live events.

### Steps completed:

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [ ] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
