### PR TITLE
Fix / live tag overlap issues

### DIFF
--- a/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.module.scss
+++ b/packages/ui-react/src/components/EpgProgramItem/EpgProgramItem.module.scss
@@ -59,7 +59,7 @@
 .epgLiveTag {
   position: absolute;
   bottom: 20px;
-  left: 68px;
+  left: 20px;
   display: flex;
   align-items: center;
   padding: 2px 6px;
@@ -76,8 +76,8 @@
     bottom: initial;
     left: initial;
     justify-content: center;
-    width: 35px;
-    padding: initial;
+    align-self: flex-start;
+    padding: 0 6px;
     font-size: 10px;
   }
 }


### PR DESCRIPTION
## Description

A small UI fix for the live tag in the EPG component. This only happens when setting the language to Spanish which uses more text for the live label (en vivo).

**Before:**

<img width="462" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/44bf51ff-6684-4919-99c9-ed660a508580">

<img width="376" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/c50f2588-ad6c-49e9-abda-35a65484a4d6">
 
**After:**

<img width="360" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/669ed5ab-8391-4ccf-bab0-305da667f598">

<img width="362" alt="image" src="https://github.com/jwplayer/ott-web-app/assets/3996119/bb0b0373-c8f8-4704-b1d9-adaf82336348">

