### PR TITLE
Fix /  Make related videos section semantically correct (a11y)

### DIFF
--- a/packages/ui-react/src/components/VideoLayout/VideoLayout.tsx
+++ b/packages/ui-react/src/components/VideoLayout/VideoLayout.tsx
@@ -194,7 +194,7 @@ const VideoLayout: React.FC<Props> = ({
       primaryMetadata={primaryMetadata}
       secondaryMetadata={secondaryMetadata}
     >
-      {playlist && <div className={styles.relatedVideos}>{renderRelatedVideos(true)}</div>}
+      {playlist && <section className={styles.relatedVideos}>{renderRelatedVideos(true)}</section>}
       {children}
       {player}
     </VideoDetails>


### PR DESCRIPTION
This minor changes makes the related videos section semantically corrrect