### PR TITLE
Fix / generic consent_required validation message

### DIFF
--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -126,7 +126,7 @@ const RegistrationForm: React.FC<Props> = ({
                 value={consentValues[consent.name] || ''}
                 required={consent.required}
                 error={!!consentError}
-                helperText={consentErrors?.includes(consent.name) ? t('registration.consent_required', { field: consent.name }) : undefined}
+                helperText={t('registration.consent_required')}
                 onChange={onConsentChange}
                 lang={htmlLang}
               />

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -134,7 +134,7 @@
   },
   "registration": {
     "already_account": "Already have an account?",
-    "consent_required": "This field is required, please fill in {{field}} to continue.",
+    "consent_required": "Consent required, please check the box to continue.",
     "consents_error": "Please accept all required consents to continue.",
     "continue": "Continue",
     "email": "Email",

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -144,7 +144,7 @@
   },
   "registration": {
     "already_account": "¿Ya tienes una cuenta?",
-    "consent_required": "Este campo es obligatorio, por favor completa {{field}} para continuar.",
+    "consent_required": "Se requiere consentimiento, marque la casilla para continuar.",
     "consents_error": "Acepte todos los consentimientos necesarios para continuar.",
     "continue": "Continuar",
     "email": "Correo electrónico",


### PR DESCRIPTION
This makes the validation message more generic so it can be used for all custom consent fields.

This fixes issues like this:
<img width="408" alt="Screenshot 2024-04-30 at 13 13 10" src="https://github.com/jwplayer/ott-web-app/assets/1019129/5079db03-b564-4c7f-9b06-a158fddb979b">

Internally we agreed upon keeping it generic instead of transforming the (technical) name to a human-friendly name.

Ticket: https://videodock.atlassian.net/browse/OTT-1547