### PR TITLE
Fix / Restrict text length to avoid scrolling issue

### DIFF
--- a/packages/ui-react/src/components/CollapsibleText/CollapsibleText.tsx
+++ b/packages/ui-react/src/components/CollapsibleText/CollapsibleText.tsx
@@ -4,6 +4,7 @@ import ChevronRight from '@jwp/ott-theme/assets/icons/chevron_right.svg?react';
 
 import IconButton from '../IconButton/IconButton';
 import Icon from '../Icon/Icon';
+import useBreakpoint from '../../hooks/useBreakpoint';
 
 import styles from './CollapsibleText.module.scss';
 
@@ -14,6 +15,7 @@ type Props = {
 
 const CollapsibleText: React.FC<Props> = ({ text, className }: Props) => {
   const divRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
+  const breakpoint = useBreakpoint();
   const [doesFlowOver, setDoesFlowOver] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
@@ -24,7 +26,7 @@ const CollapsibleText: React.FC<Props> = ({ text, className }: Props) => {
 
   useEffect(() => {
     divRef.current && setDoesFlowOver(divRef.current.scrollHeight > divRef.current.offsetHeight + clippablePixels || maxHeight < divRef.current.offsetHeight);
-  }, [maxHeight, text]);
+  }, [maxHeight, text, breakpoint]);
 
   return (
     <div className={classNames(styles.collapsibleText)}>

--- a/packages/ui-react/src/components/CollapsibleText/CollapsibleText.tsx
+++ b/packages/ui-react/src/components/CollapsibleText/CollapsibleText.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React, { useEffect, useRef, useState } from 'react';
 import ChevronRight from '@jwp/ott-theme/assets/icons/chevron_right.svg?react';
-import useBreakpoint from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 
 import IconButton from '../IconButton/IconButton';
 import Icon from '../Icon/Icon';
@@ -11,25 +10,21 @@ import styles from './CollapsibleText.module.scss';
 type Props = {
   text: string;
   className?: string;
-  maxHeight?: 'none' | number;
 };
 
-const CollapsibleText: React.FC<Props> = ({ text, className, maxHeight = 'none' }: Props) => {
+const CollapsibleText: React.FC<Props> = ({ text, className }: Props) => {
   const divRef = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLDivElement>;
-  const breakpoint = useBreakpoint();
   const [doesFlowOver, setDoesFlowOver] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
   const ariaLabel = expanded ? 'Collapse' : 'Expand';
 
   const clippablePixels = 4;
+  const maxHeight = 60;
 
   useEffect(() => {
-    divRef.current &&
-      setDoesFlowOver(
-        divRef.current.scrollHeight > divRef.current.offsetHeight + clippablePixels || (maxHeight !== 'none' && maxHeight < divRef.current.offsetHeight),
-      );
-  }, [maxHeight, text, breakpoint]);
+    divRef.current && setDoesFlowOver(divRef.current.scrollHeight > divRef.current.offsetHeight + clippablePixels || maxHeight < divRef.current.offsetHeight);
+  }, [maxHeight, text]);
 
   return (
     <div className={classNames(styles.collapsibleText)}>

--- a/packages/ui-react/src/components/CollapsibleText/__snapshots__/CollapsibleText.test.tsx.snap
+++ b/packages/ui-react/src/components/CollapsibleText/__snapshots__/CollapsibleText.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<CollapsibleText> > renders and matches snapshot 1`] = `
     <p
       class="_textContainer_561522"
       id="collapsible-content"
-      style="max-height: none;"
+      style="max-height: 60px;"
     >
       Test...
     </p>

--- a/packages/ui-react/src/components/Hero/Hero.tsx
+++ b/packages/ui-react/src/components/Hero/Hero.tsx
@@ -1,8 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import useBreakpoint, { Breakpoint } from '../../hooks/useBreakpoint';
-import CollapsibleText from '../CollapsibleText/CollapsibleText';
+import TruncatedText from '../TruncatedText/TruncatedText';
 import Image from '../Image/Image';
 
 import styles from './Hero.module.scss';
@@ -14,8 +13,6 @@ type Props = {
 };
 
 const Hero = ({ title, description, image }: Props) => {
-  const breakpoint: Breakpoint = useBreakpoint();
-  const isMobile = breakpoint === Breakpoint.xs;
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
@@ -24,7 +21,7 @@ const Hero = ({ title, description, image }: Props) => {
       <div className={styles.posterFade} />
       <div className={styles.info}>
         <h1 className={styles.title}>{title}</h1>
-        <CollapsibleText text={description} className={styles.description} maxHeight={isMobile ? 60 : 'none'} />
+        <TruncatedText text={description} maximumLines={8} className={styles.description} />
       </div>
     </div>
   );

--- a/packages/ui-react/src/components/Hero/Hero.tsx
+++ b/packages/ui-react/src/components/Hero/Hero.tsx
@@ -1,8 +1,10 @@
 import classNames from 'classnames';
 import React from 'react';
 
-import TruncatedText from '../TruncatedText/TruncatedText';
+import useBreakpoint, { Breakpoint } from '../../hooks/useBreakpoint';
+import CollapsibleText from '../CollapsibleText/CollapsibleText';
 import Image from '../Image/Image';
+import TruncatedText from '../TruncatedText/TruncatedText';
 
 import styles from './Hero.module.scss';
 
@@ -13,6 +15,8 @@ type Props = {
 };
 
 const Hero = ({ title, description, image }: Props) => {
+  const breakpoint: Breakpoint = useBreakpoint();
+  const isMobile = breakpoint === Breakpoint.xs;
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
@@ -21,7 +25,11 @@ const Hero = ({ title, description, image }: Props) => {
       <div className={styles.posterFade} />
       <div className={styles.info}>
         <h1 className={styles.title}>{title}</h1>
-        <TruncatedText text={description} maximumLines={8} className={styles.description} />
+        {isMobile ? (
+          <CollapsibleText text={description} className={styles.description} />
+        ) : (
+          <TruncatedText text={description} maximumLines={8} className={styles.description} />
+        )}
       </div>
     </div>
   );

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.module.scss
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.module.scss
@@ -1,0 +1,5 @@
+.truncatedText {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.test.tsx
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { axe } from 'vitest-axe';
 import { render } from '@testing-library/react';
 
 import TruncatedText from './TruncatedText';
@@ -9,11 +8,5 @@ describe('<TruncatedText>', () => {
     const { container } = render(<TruncatedText text="Test..." maximumLines={8} />);
 
     expect(container).toMatchSnapshot();
-  });
-
-  test('WCAG 2.2 (AA) compliant', async () => {
-    const { container } = render(<TruncatedText text="Test..." maximumLines={8} />);
-
-    expect(await axe(container, { runOnly: ['wcag21a', 'wcag21aa', 'wcag22aa'] })).toHaveNoViolations();
   });
 });

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.test.tsx
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { axe } from 'vitest-axe';
+import { render } from '@testing-library/react';
+
+import TruncatedText from './TruncatedText';
+
+describe('<TruncatedText>', () => {
+  test('renders and matches snapshot', () => {
+    const { container } = render(<TruncatedText text="Test..." maximumLines={8} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  test('WCAG 2.2 (AA) compliant', async () => {
+    const { container } = render(<TruncatedText text="Test..." maximumLines={8} />);
+
+    expect(await axe(container, { runOnly: ['wcag21a', 'wcag21aa', 'wcag22aa'] })).toHaveNoViolations();
+  });
+});

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
+import classNames from 'classnames';
+
+import CollapsibleText from '../CollapsibleText/CollapsibleText';
+
+import styles from './TruncatedText.module.scss';
+
+type TruncatedTextProps = {
+  text: string;
+  maximumLines: number;
+  className?: string;
+};
+
+const TruncatedText: React.FC<TruncatedTextProps> = ({ text, maximumLines, className }) => {
+  const breakpoint: Breakpoint = useBreakpoint();
+  const isMobile = breakpoint === Breakpoint.xs;
+
+  if (isMobile) {
+    return <CollapsibleText text={text} className={className} />;
+  }
+
+  return (
+    <div
+      className={classNames(styles.truncatedText, className)}
+      style={{
+        maxHeight: `calc(1.5em * ${maximumLines})`,
+        WebkitLineClamp: maximumLines,
+      }}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default TruncatedText;

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 import classNames from 'classnames';
-
-import CollapsibleText from '../CollapsibleText/CollapsibleText';
 
 import styles from './TruncatedText.module.scss';
 
@@ -13,13 +10,6 @@ type TruncatedTextProps = {
 };
 
 const TruncatedText: React.FC<TruncatedTextProps> = ({ text, maximumLines, className }) => {
-  const breakpoint: Breakpoint = useBreakpoint();
-  const isMobile = breakpoint === Breakpoint.xs;
-
-  if (isMobile) {
-    return <CollapsibleText text={text} className={className} />;
-  }
-
   return (
     <div
       className={classNames(styles.truncatedText, className)}

--- a/packages/ui-react/src/components/TruncatedText/__snapshots__/TruncatedText.test.tsx.snap
+++ b/packages/ui-react/src/components/TruncatedText/__snapshots__/TruncatedText.test.tsx.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`<TruncatedText> > renders and matches snapshot 1`] = `
+<div>
+  <div
+    class="_truncatedText_b1c064"
+    style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8;"
+  >
+    Test...
+  </div>
+</div>
+`;

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -46,7 +46,7 @@ const VideoDetails: React.VFC<Props> = ({
               <div className={styles.primaryMetadata}>{primaryMetadata}</div>
               {secondaryMetadata && <div className={styles.secondaryMetadata}>{secondaryMetadata}</div>}
             </div>
-            <TruncatedText text={description} maximumLines={8} className={styles.description} />
+            <TruncatedText text={description} maximumLines={120} className={styles.description} />
 
             <div className={styles.buttonBar}>
               {startWatchingButton}

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import { testId } from '@jwp/ott-common/src/utils/common';
+import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 
 import TruncatedText from '../TruncatedText/TruncatedText';
 import Image from '../Image/Image';
+import CollapsibleText from '../CollapsibleText/CollapsibleText';
 
 import styles from './VideoDetails.module.scss';
 
@@ -32,6 +34,8 @@ const VideoDetails: React.VFC<Props> = ({
   trailerButton,
   children,
 }) => {
+  const breakpoint: Breakpoint = useBreakpoint();
+  const isMobile = breakpoint === Breakpoint.xs;
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
@@ -46,8 +50,11 @@ const VideoDetails: React.VFC<Props> = ({
               <div className={styles.primaryMetadata}>{primaryMetadata}</div>
               {secondaryMetadata && <div className={styles.secondaryMetadata}>{secondaryMetadata}</div>}
             </div>
-            <TruncatedText text={description} maximumLines={12} className={styles.description} />
-
+            {isMobile ? (
+              <CollapsibleText text={description} className={styles.description} />
+            ) : (
+              <TruncatedText text={description} maximumLines={12} className={styles.description} />
+            )}
             <div className={styles.buttonBar}>
               {startWatchingButton}
               {trailerButton}

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import { testId } from '@jwp/ott-common/src/utils/common';
-import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 
-import CollapsibleText from '../CollapsibleText/CollapsibleText';
+import TruncatedText from '../TruncatedText/TruncatedText';
 import Image from '../Image/Image';
 
 import styles from './VideoDetails.module.scss';
@@ -33,8 +32,6 @@ const VideoDetails: React.VFC<Props> = ({
   trailerButton,
   children,
 }) => {
-  const breakpoint: Breakpoint = useBreakpoint();
-  const isMobile = breakpoint === Breakpoint.xs;
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
 
   return (
@@ -49,7 +46,7 @@ const VideoDetails: React.VFC<Props> = ({
               <div className={styles.primaryMetadata}>{primaryMetadata}</div>
               {secondaryMetadata && <div className={styles.secondaryMetadata}>{secondaryMetadata}</div>}
             </div>
-            <CollapsibleText text={description} className={styles.description} maxHeight={isMobile ? 60 : 'none'} />
+            <TruncatedText text={description} maximumLines={8} className={styles.description} />
 
             <div className={styles.buttonBar}>
               {startWatchingButton}

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.tsx
@@ -46,7 +46,7 @@ const VideoDetails: React.VFC<Props> = ({
               <div className={styles.primaryMetadata}>{primaryMetadata}</div>
               {secondaryMetadata && <div className={styles.secondaryMetadata}>{secondaryMetadata}</div>}
             </div>
-            <TruncatedText text={description} maximumLines={120} className={styles.description} />
+            <TruncatedText text={description} maximumLines={12} className={styles.description} />
 
             <div className={styles.buttonBar}>
               {startWatchingButton}

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           </div>
           <div
             class="_truncatedText_b1c064 _description_d0c133"
-            style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8;"
+            style="max-height: calc(1.5em * 120); -webkit-line-clamp: 120;"
           >
             Video description
           </div>

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           </div>
           <div
             class="_truncatedText_b1c064 _description_d0c133"
-            style="max-height: calc(1.5em * 120); -webkit-line-clamp: 120;"
+            style="max-height: calc(1.5em * 12); -webkit-line-clamp: 12;"
           >
             Video description
           </div>

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -46,15 +46,10 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
             </div>
           </div>
           <div
-            class="_collapsibleText_561522"
+            class="_truncatedText_b1c064 _description_d0c133"
+            style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8;"
           >
-            <p
-              class="_textContainer_561522 _description_d0c133"
-              id="collapsible-content"
-              style="max-height: none;"
-            >
-              Video description
-            </p>
+            Video description
           </div>
           <div
             class="_buttonBar_d0c133"

--- a/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
+++ b/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { testId } from '@jwp/ott-common/src/utils/common';
+import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 
+import CollapsibleText from '../CollapsibleText/CollapsibleText';
 import TruncatedText from '../TruncatedText/TruncatedText';
 
 import styles from './VideoDetailsInline.module.scss';
@@ -16,6 +18,9 @@ type Props = {
 };
 
 const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetadata, shareButton, favoriteButton, trailerButton }) => {
+  const breakpoint: Breakpoint = useBreakpoint();
+  const isMobile = breakpoint === Breakpoint.xs;
+
   const TitleComponent = typeof title === 'string' ? 'h1' : 'div';
 
   return (
@@ -27,7 +32,11 @@ const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetada
         {favoriteButton}
         {shareButton}
       </div>
-      <TruncatedText text={description} maximumLines={20} className={styles.description} />
+      {isMobile ? (
+        <CollapsibleText text={description} className={styles.description} />
+      ) : (
+        <TruncatedText text={description} maximumLines={12} className={styles.description} />
+      )}
     </div>
   );
 };

--- a/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
+++ b/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
@@ -27,7 +27,7 @@ const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetada
         {favoriteButton}
         {shareButton}
       </div>
-      <TruncatedText text={description} maximumLines={12} className={styles.description} />
+      <TruncatedText text={description} maximumLines={20} className={styles.description} />
     </div>
   );
 };

--- a/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
+++ b/packages/ui-react/src/components/VideoDetailsInline/VideoDetailsInline.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { testId } from '@jwp/ott-common/src/utils/common';
-import useBreakpoint, { Breakpoint } from '@jwp/ott-ui-react/src/hooks/useBreakpoint';
 
-import CollapsibleText from '../CollapsibleText/CollapsibleText';
+import TruncatedText from '../TruncatedText/TruncatedText';
 
 import styles from './VideoDetailsInline.module.scss';
 
@@ -17,9 +16,6 @@ type Props = {
 };
 
 const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetadata, shareButton, favoriteButton, trailerButton }) => {
-  const breakpoint: Breakpoint = useBreakpoint();
-  const isMobile = breakpoint === Breakpoint.xs;
-
   const TitleComponent = typeof title === 'string' ? 'h1' : 'div';
 
   return (
@@ -31,7 +27,7 @@ const VideoDetailsInline: React.FC<Props> = ({ title, description, primaryMetada
         {favoriteButton}
         {shareButton}
       </div>
-      <CollapsibleText text={description} className={styles.description} maxHeight={isMobile ? 60 : 'none'} />
+      <TruncatedText text={description} maximumLines={12} className={styles.description} />
     </div>
   );
 };


### PR DESCRIPTION
## Description

**Issue:** The video detail page starts halfway down the viewport when a media item has a very long description, because the "Start Watching" button receives focus.

#### Solution
By limiting the number of lines in the video description, we not only ensure that the page does not start halfway down, but it also aligns better with the designs and overall visuals. 

- I've introduced a reusable `TruncatedText` component and modified `CollapsibleText` to remove the unnecessary `maxHeight` prop. Added a `maxHeight` constant with the original value for readability in calculations.
- Verified the fix with video descriptions of various lengths and tested with 175% zoom on smaller screens to ensure proper line limit and prevent page scrolling.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [x] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code

#### Example 
<img width="45%" src="https://github.com/jwplayer/ott-web-app/assets/48496458/b59b5534-8296-4047-b0e0-3eb4fbfc8153"/>