### PR TITLE
Fix / Remove focus outline around main element

### DIFF
--- a/packages/ui-react/src/containers/Layout/Layout.module.scss
+++ b/packages/ui-react/src/containers/Layout/Layout.module.scss
@@ -8,4 +8,5 @@
 
 .main {
   height: 100%;
+  outline: none;
 }


### PR DESCRIPTION
## Description

This PR contains a small adjustment that prevents an unwanted focus outline from appearing in certain situations. See the example for the visual bug that was found (on mobile):
 
<img src="https://github.com/jwplayer/ott-web-app/assets/48496458/1a192041-a4ab-4f90-8ede-0b7751197509" width="35%"/>

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
