### PR TITLE
Fix / waiting for payment PPV/TVOD offers

### DIFF
--- a/packages/common/src/controllers/AccountController.ts
+++ b/packages/common/src/controllers/AccountController.ts
@@ -419,7 +419,7 @@ export default class AccountController {
     let pendingOffer: Offer | null = null;
 
     if (!activeSubscription && !!retry && retry > 0) {
-      const retryDelay = 1500; // Any initial delay has already occured, so we can set this to a fixed value
+      const retryDelay = 1500; // Any initial delay has already occurred, so we can set this to a fixed value
 
       return await this.reloadSubscriptions({ delay: retryDelay, retry: retry - 1 });
     }

--- a/packages/common/src/controllers/CheckoutController.ts
+++ b/packages/common/src/controllers/CheckoutController.ts
@@ -27,6 +27,7 @@ import { useCheckoutStore } from '../stores/CheckoutStore';
 import { useAccountStore } from '../stores/AccountStore';
 import { FormValidationError } from '../errors/FormValidationError';
 import { determineSwitchDirection } from '../utils/subscription';
+import { logDev } from '../utils/common';
 
 @injectable()
 export default class CheckoutController {
@@ -52,10 +53,14 @@ export default class CheckoutController {
       useCheckoutStore.setState({ subscriptionOffers });
     }
 
-    if (!useCheckoutStore.getState().switchSubscriptionOffers.length) {
-      const subscriptionSwitches = await this.getSubscriptionSwitches();
-      const switchSubscriptionOffers = subscriptionSwitches ? await this.getOffers({ offerIds: subscriptionSwitches }) : [];
-      useCheckoutStore.setState({ switchSubscriptionOffers });
+    try {
+      if (!useCheckoutStore.getState().switchSubscriptionOffers.length) {
+        const subscriptionSwitches = await this.getSubscriptionSwitches();
+        const switchSubscriptionOffers = subscriptionSwitches ? await this.getOffers({ offerIds: subscriptionSwitches }) : [];
+        useCheckoutStore.setState({ switchSubscriptionOffers });
+      }
+    } catch (error) {
+      logDev('Failed to get subscription switches', error);
     }
   };
 

--- a/packages/hooks-react/src/useCheckAccess.ts
+++ b/packages/hooks-react/src/useCheckAccess.ts
@@ -8,7 +8,7 @@ type IntervalCheckAccessPayload = {
   interval?: number;
   iterations?: number;
   offerId?: string;
-  callback?: (hasAccess: boolean) => void;
+  callback?: ({ hasAccess, offerId }: { hasAccess: boolean; offerId: string }) => void;
 };
 
 const useCheckAccess = () => {
@@ -23,20 +23,28 @@ const useCheckAccess = () => {
 
   const intervalCheckAccess = useCallback(
     ({ interval = 3000, iterations = 5, offerId, callback }: IntervalCheckAccessPayload) => {
-      if (!offerId && offers?.[0]) {
-        offerId = offers[0];
+      if (!offerId) {
+        offerId = offers?.[0] || '';
+      }
+
+      if (!offerId) {
+        callback?.({ hasAccess: false, offerId: '' });
+        return;
       }
 
       intervalRef.current = window.setInterval(async () => {
         const hasAccess = await accountController.checkEntitlements(offerId);
 
         if (hasAccess) {
-          await accountController.reloadSubscriptions({ retry: 10, delay: 2000 });
-          callback?.(true);
+          window.clearInterval(intervalRef.current);
+          // No duplicate retry mechanism. This can also be a TVOD offer which isn't validated using the
+          // reloadSubscriptions method.
+          await accountController.reloadSubscriptions();
+          callback?.({ hasAccess: true, offerId: offerId || '' });
         } else if (--iterations === 0) {
           window.clearInterval(intervalRef.current);
           setErrorMessage(t('payment.longer_than_usual'));
-          callback?.(false);
+          callback?.({ hasAccess: false, offerId: offerId || '' });
         }
       }, interval);
     },

--- a/packages/hooks-react/src/useCheckAccess.ts
+++ b/packages/hooks-react/src/useCheckAccess.ts
@@ -22,11 +22,7 @@ const useCheckAccess = () => {
   const offers = checkoutController.getSubscriptionOfferIds();
 
   const intervalCheckAccess = useCallback(
-    ({ interval = 3000, iterations = 5, offerId, callback }: IntervalCheckAccessPayload) => {
-      if (!offerId) {
-        offerId = offers?.[0] || '';
-      }
-
+    ({ interval = 3000, iterations = 5, offerId = offers?.[0], callback }: IntervalCheckAccessPayload) => {
       if (!offerId) {
         callback?.({ hasAccess: false, offerId: '' });
         return;

--- a/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
+++ b/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
@@ -23,11 +23,18 @@ const WaitingForPayment = () => {
       interval: 3000,
       iterations: 5,
       offerId,
-      callback: (hasAccess) => {
+      callback: ({ hasAccess, offerId }) => {
         if (!hasAccess) return;
 
         announce(t('checkout.payment_success'), 'success');
-        navigate(modalURLFromLocation(location, 'welcome'));
+
+        // close the modal for PPV/TVOD offers
+        if (offerId.startsWith('C') || offerId.startsWith('P')) {
+          // should we show a dedicated modal for TVOD access?
+          navigate(modalURLFromLocation(location, null));
+        } else {
+          navigate(modalURLFromLocation(location, 'welcome'));
+        }
       },
     });
     //eslint-disable-next-line

--- a/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
+++ b/packages/ui-react/src/components/WaitingForPayment/WaitingForPayment.tsx
@@ -30,7 +30,7 @@ const WaitingForPayment = () => {
 
         // close the modal for PPV/TVOD offers
         if (offerId.startsWith('C') || offerId.startsWith('P')) {
-          // should we show a dedicated modal for TVOD access?
+          // @TODO should we show a dedicated modal for TVOD access?
           navigate(modalURLFromLocation(location, null));
         } else {
           navigate(modalURLFromLocation(location, 'welcome'));

--- a/platforms/web/test-e2e/utils/constants.ts
+++ b/platforms/web/test-e2e/utils/constants.ts
@@ -81,7 +81,7 @@ export default {
         paymentFee: formatPrice(0, 'EUR', 'NL'),
       },
       inplayer: {
-        label: `label[for="S38279"]`,
+        label: `label[for="S118699_38279"]`,
         price: formatPrice(6.99, 'EUR'),
         paymentFee: formatPrice(0, 'EUR'),
       },
@@ -93,7 +93,7 @@ export default {
         paymentFee: formatPrice(0, 'EUR', 'NL'),
       },
       inplayer: {
-        label: `label[for="S38280"]`,
+        label: `label[for="S118699_38280"]`,
         price: formatPrice(50, 'EUR'),
         paymentFee: formatPrice(0, 'EUR'),
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,7 +1879,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/set-array@^1.2.1":
+"@jridgewell/set-array@^1.0.1", "@jridgewell/set-array@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
@@ -9925,7 +9925,7 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9941,15 +9941,6 @@ string-width@^2.1.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -10048,7 +10039,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10068,13 +10059,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -11689,16 +11673,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description

This PR fixes issue #518. I've updated the formatted `offerId` in the JWP integration. The `offerId` is now composed of the offer prefix, asset ID, and access fee ID. The composed offer ID is added to the URL when the user is sent to the waiting for payments modal. The integration is responsible for retrieving the asset ID when needed.

I also encountered a problem because the `getSubscriptionSwitches` method threw an error in the `initialiseOffers` method. This caused the query to retry a few times before resolving, making the Choose offers modal really slow.

The third change is that the welcome modal isn't shown to users buying PPV access since the welcome modal shows a message stating "You now have access to all content", which isn't true when buying access to a single item.
