### PR TITLE
Feat / show external payment explanation

### DIFF
--- a/packages/ui-react/src/components/Payment/Payment.module.scss
+++ b/packages/ui-react/src/components/Payment/Payment.module.scss
@@ -73,6 +73,10 @@
   }
 }
 
+.explanation {
+  font-size: 14px;
+}
+
 .cardDetails {
   display: flex;
   margin-top: calc(#{variables.$base-spacing} * 2);

--- a/packages/ui-react/src/components/Payment/Payment.test.tsx
+++ b/packages/ui-react/src/components/Payment/Payment.test.tsx
@@ -38,6 +38,7 @@ describe('<Payment>', () => {
         setSelectedOfferId={vi.fn()}
         isUpgradeOffer={undefined}
         setIsUpgradeOffer={vi.fn()}
+        isExternalPaymentProvider={false}
       />,
     );
 

--- a/packages/ui-react/src/components/Payment/Payment.tsx
+++ b/packages/ui-react/src/components/Payment/Payment.tsx
@@ -58,13 +58,9 @@ type Props = {
   setSelectedOfferId: (offerId: string | null) => void;
   isUpgradeOffer: boolean | undefined;
   setIsUpgradeOffer: (isUpgradeOffer: boolean | undefined) => void;
-};
-
-const EXTERNAL_PAYMENT_METHODS = ['Apple In-App', 'Android In-App', 'Roku In-App'];
-const STORE_LINKS: Record<string, string> = {
-  apple: 'https://support.apple.com/en-qa/118428',
-  android: 'https://support.google.com/googleplay/answer/7018481?hl=en',
-  roku: 'https://support.roku.com/article/208756478',
+  isExternalPaymentProvider: boolean;
+  paymentProvider?: string;
+  paymentProviderLink?: string;
 };
 
 const Payment = ({
@@ -93,6 +89,9 @@ const Payment = ({
   setSelectedOfferId,
   isUpgradeOffer,
   setIsUpgradeOffer,
+  isExternalPaymentProvider,
+  paymentProvider,
+  paymentProviderLink,
 }: Props): JSX.Element => {
   const subscriptionDetailsId = useOpaqueId('subscription-details');
   const paymentMethodId = useOpaqueId('payment-method');
@@ -160,9 +159,6 @@ const Payment = ({
     }
   }
 
-  const isExternalPaymentProvider = activeSubscription && EXTERNAL_PAYMENT_METHODS.includes(activeSubscription.paymentMethod);
-  const paymentProvider = activeSubscription?.paymentMethod.split(' ')[0] || 'unknown';
-  const paymentProviderLink = STORE_LINKS[paymentProvider.toLowerCase()];
   const showChangeSubscriptionButton = (!isExternalPaymentProvider && offerSwitchesAvailable) || (!isChangingOffer && !canRenewSubscription);
 
   return (

--- a/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
+++ b/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
@@ -44,6 +44,13 @@ const processBillingReceipt = (receipt: Blob | string, transactionId: string) =>
   }
 };
 
+const EXTERNAL_PAYMENT_METHODS = ['Apple In-App', 'Android In-App', 'Roku In-App'];
+const STORE_LINKS: Record<string, string> = {
+  apple: 'https://support.apple.com/en-qa/118428',
+  android: 'https://support.google.com/googleplay/answer/7018481?hl=en',
+  roku: 'https://support.roku.com/article/208756478',
+};
+
 const PaymentContainer = () => {
   const accountController = getModule(AccountController);
 
@@ -94,6 +101,9 @@ const PaymentContainer = () => {
   }
 
   const pendingDowngradeOfferId = (customer.metadata?.[`${activeSubscription?.subscriptionId}_pending_downgrade`] as string) || '';
+  const isExternalPaymentProvider = !!activeSubscription && EXTERNAL_PAYMENT_METHODS.includes(activeSubscription.paymentMethod);
+  const paymentProvider = activeSubscription?.paymentMethod.split(' ')[0] || 'unknown';
+  const paymentProviderLink = STORE_LINKS[paymentProvider.toLowerCase()];
 
   return (
     <Payment
@@ -122,6 +132,9 @@ const PaymentContainer = () => {
       setSelectedOfferId={(offerId: string | null) => setSelectedOfferId(offerId)}
       isUpgradeOffer={isUpgradeOffer}
       setIsUpgradeOffer={(isUpgradeOffer: boolean | undefined) => setIsUpgradeOffer(isUpgradeOffer)}
+      isExternalPaymentProvider={isExternalPaymentProvider}
+      paymentProvider={paymentProvider}
+      paymentProviderLink={paymentProviderLink}
     />
   );
 };

--- a/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
+++ b/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
@@ -46,8 +46,8 @@ const processBillingReceipt = (receipt: Blob | string, transactionId: string) =>
 
 const EXTERNAL_PAYMENT_METHODS = ['Apple In-App', 'Android In-App', 'Roku In-App'];
 const STORE_LINKS: Record<string, string> = {
-  apple: 'https://support.apple.com/en-qa/118428',
-  android: 'https://support.google.com/googleplay/answer/7018481?hl=en',
+  apple: 'https://support.apple.com/118428',
+  android: 'https://support.google.com/googleplay/answer/7018481',
   roku: 'https://support.roku.com/article/208756478',
 };
 

--- a/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
+++ b/packages/ui-react/src/containers/PaymentContainer/PaymentContainer.tsx
@@ -44,10 +44,10 @@ const processBillingReceipt = (receipt: Blob | string, transactionId: string) =>
   }
 };
 
-const EXTERNAL_PAYMENT_METHODS = ['Apple In-App', 'Android In-App', 'Roku In-App'];
+const EXTERNAL_PAYMENT_METHODS = ['Apple In-App', 'Google In-App', 'Roku In-App'];
 const STORE_LINKS: Record<string, string> = {
   apple: 'https://support.apple.com/118428',
-  android: 'https://support.google.com/googleplay/answer/7018481',
+  google: 'https://support.google.com/googleplay/answer/7018481',
   roku: 'https://support.roku.com/article/208756478',
 };
 

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -77,6 +77,10 @@
     "yearly": "Yearly",
     "yearly_subscription": "Yearly subscription"
   },
+  "external_payment": {
+    "explanation": "This subscription is managed via {{paymentProvider}}.",
+    "manage_subscription": "Click here for more information."
+  },
   "login": {
     "email": "Email",
     "facebook": "Sign in with Facebook",

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -83,6 +83,10 @@
     "yearly": "Anual",
     "yearly_subscription": "Suscripción anual"
   },
+  "external_payment": {
+    "explanation": "Esta suscripción se gestiona a través de {{paymentProvider}}.",
+    "manage_subscription": "Haga clic aquí para más información."
+  },
   "login": {
     "email": "Correo electrónico",
     "facebook": "Inicia sesión con Facebook",


### PR DESCRIPTION
## Description

If a user has purchased a subscription via Google, Apple or Roku stores, managing the subscription via the web app is not possible (or very difficult).

This PR adds a message that the subscription is managed through an external payment provider and a link with information on how to manage your subscription instead.

The "Change subscription" button is also removed when an external payment provider is used.

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/ce45be99-30ef-4a47-b90d-ada6c124c52d)

