### PR TITLE
Feat / make button states consistent

### DIFF
--- a/packages/ui-react/src/components/Button/Button.module.scss
+++ b/packages/ui-react/src/components/Button/Button.module.scss
@@ -1,6 +1,5 @@
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
-@use '@jwp/ott-ui-react/src/styles/accessibility';
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 
 $small-button-height: 28px;
@@ -58,8 +57,7 @@ $large-button-height: 40px;
     background-color: theme.$btn-default-bg;
 
     &:focus {
-      @include accessibility.accessibleOutline;
-      outline-offset: 1px;
+      outline-offset: 2px;
     }
   }
 
@@ -68,8 +66,7 @@ $large-button-height: 40px;
     background-color: var(--highlight-color, theme.$btn-primary-bg);
 
     &:focus {
-      @include accessibility.accessibleOutline;
-      outline-offset: 1px;
+      outline-offset: 2px;
     }
   }
 

--- a/packages/ui-react/src/components/Button/Button.module.scss
+++ b/packages/ui-react/src/components/Button/Button.module.scss
@@ -25,14 +25,17 @@ $large-button-height: 40px;
   border-radius: 4px;
   outline: none;
   cursor: pointer;
-  transition: background-color 0.1s ease, transform 0.1s ease;
+  transition: background-color 0.1s ease, transform 0.1s ease, opacity 0.1s ease;
 
   @media (hover: hover) and (pointer: fine) {
     &:not(.disabled) {
-      &:hover,
-      &:focus {
+      &:hover {
         z-index: 1;
         transform: scale(1.05);
+      }
+
+      &:active {
+        opacity: 0.8
       }
     }
   }
@@ -53,6 +56,10 @@ $large-button-height: 40px;
   &.default {
     color: currentColor;
     background-color: theme.$btn-default-bg;
+
+    &:focus {
+      @include accessibility.accessibleOutline;
+    }
   }
 
   &.primary {
@@ -60,21 +67,18 @@ $large-button-height: 40px;
     background-color: var(--highlight-color, theme.$btn-primary-bg);
 
     &:focus {
-      @include accessibility.accessibleOutlineContrast;
+      @include accessibility.accessibleOutline;
     }
   }
 
   &.outlined {
     border: 1px solid rgba(255, 255, 255, 0.3);
 
-    &:not(.disabled) {
-      &.active,
-      &:focus {
-        color: var(--highlight-contrast-color, theme.$btn-primary-color);
-        background-color: var(--highlight-color, theme.$btn-primary-bg);
-        border-color: var(--highlight-color, theme.$btn-primary-bg);
-        outline: none;
-      }
+    &.active {
+      color: var(--highlight-contrast-color, theme.$btn-primary-color);
+      background-color: var(--highlight-color, theme.$btn-primary-bg);
+      border-color: var(--highlight-color, theme.$btn-primary-bg);
+      outline: none;
     }
   }
 
@@ -83,7 +87,6 @@ $large-button-height: 40px;
     opacity: 0.9;
 
     &:not(.disabled) {
-      &.active,
       &:focus {
         opacity: 1;
       }
@@ -92,6 +95,10 @@ $large-button-height: 40px;
         z-index: 1;
         background: theme.$btn-default-bg;
         opacity: 1;
+      }
+
+      &:active {
+        opacity: 0.8;
       }
     }
   }

--- a/packages/ui-react/src/components/Button/Button.module.scss
+++ b/packages/ui-react/src/components/Button/Button.module.scss
@@ -59,6 +59,7 @@ $large-button-height: 40px;
 
     &:focus {
       @include accessibility.accessibleOutline;
+      outline-offset: 1px;
     }
   }
 
@@ -68,6 +69,7 @@ $large-button-height: 40px;
 
     &:focus {
       @include accessibility.accessibleOutline;
+      outline-offset: 1px;
     }
   }
 

--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -57,7 +57,8 @@
       background: linear-gradient(to top, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0));
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       transform: scale(1.02);
     }
   }

--- a/packages/ui-react/src/components/IconButton/IconButton.module.scss
+++ b/packages/ui-react/src/components/IconButton/IconButton.module.scss
@@ -1,4 +1,3 @@
-@use '@jwp/ott-ui-react/src/styles/accessibility';
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
 
@@ -21,7 +20,6 @@
   }
 
   &:focus {
-    @include accessibility.accessibleOutline;
     opacity: 1;
   }
 

--- a/packages/ui-react/src/components/IconButton/IconButton.module.scss
+++ b/packages/ui-react/src/components/IconButton/IconButton.module.scss
@@ -1,3 +1,4 @@
+@use '@jwp/ott-ui-react/src/styles/accessibility';
 @use '@jwp/ott-ui-react/src/styles/variables';
 @use '@jwp/ott-ui-react/src/styles/theme';
 
@@ -12,11 +13,19 @@
 
   cursor: pointer;
   opacity: 0.9;
-  transition: transform 0.1s ease;
+  transition: transform 0.1s ease, opacity 0.1s ease;
 
-  &:hover,
-  &:focus {
+  &:hover {
     transform: scale(1.1);
     opacity: 1;
+  }
+
+  &:focus {
+    @include accessibility.accessibleOutline;
+    opacity: 1;
+  }
+
+  &:active {
+    opacity: 0.8;
   }
 }

--- a/packages/ui-react/src/components/MenuButton/MenuButton.module.scss
+++ b/packages/ui-react/src/components/MenuButton/MenuButton.module.scss
@@ -25,7 +25,7 @@
   outline: none;
   cursor: pointer;
   opacity: 0.7;
-  transition: background 0.1s ease;
+  transition: background 0.1s ease, opacity 0.1s ease;
 
   > span {
     width: max-content;
@@ -41,10 +41,13 @@
 
   @media (hover: hover) and (pointer: fine) {
     &:hover,
-    &:active,
     &:focus {
       background: rgba(variables.$white, 0.08);
       opacity: 1;
+    }
+
+    &:active {
+      opacity: 0.8;
     }
   }
 }

--- a/packages/ui-react/src/styles/accessibility.scss
+++ b/packages/ui-react/src/styles/accessibility.scss
@@ -25,14 +25,14 @@ $focus-box-shadow: 0 0 1px 5px var(--highlight-color, variables.$white),
 }
 
 @mixin accessibleOutline {
-  body.is-tabbing & {
+  :global(body.is-tabbing) & {
     outline: 2px solid var(--highlight-color, #fff);
     box-shadow: 0 0 2px 3px var(--highlight-contrast-color, #000);
   }
 }
 
 @mixin accessibleOutlineContrast {
-  body.is-tabbing & {
+  :global(body.is-tabbing) & {
     outline: 2px solid var(--highlight-contrast-color, #fff);
     box-shadow: 0 0 2px 3px var(--highlight-color, #000);
   }

--- a/packages/ui-react/src/styles/accessibility.scss
+++ b/packages/ui-react/src/styles/accessibility.scss
@@ -46,7 +46,8 @@ $focus-box-shadow: 0 0 1px 5px var(--highlight-color, variables.$white),
     button,
     input {
       &:focus {
-        @include accessibleOutline;
+        outline: 2px solid var(--highlight-color, #fff);
+        box-shadow: 0 0 2px 3px var(--highlight-contrast-color, #000);
       }
     }
   }


### PR DESCRIPTION
## Description

This aligns and fixes some button state inconsistencies. Most importantly, the accessibility mixins weren't used correctly due to it being used in a CSS module file which converts `body.is-tabbing` to a scoped class name, e.g. `body.is-tabbing-g34tsda`.

- Fix a11y tabbing visibility for the primary button
- Remove the button scale effect when tabbing
- Separate focus and hover states (this fixes the button being in a selected state after pressing it)
- Align featured card hover and focus scale
- Added separate `:active` state for all buttons to indicate the pressing action (like it should)

**Before "Start watching" button focus**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/3eca1b09-5643-4420-bdb9-d485b2882ad6)

**After "Start watching" button focus**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/70ae30fd-fdb7-4edb-8455-d37d66f23830)

**Before "Favorites" button focus**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/8afa6a61-c6dd-40f5-9fd0-74cc54206748)

**After "Favorites" button focus**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/be7648dc-ad8e-429f-8b04-2869cde26a65)


