### PR TITLE
Fix / Generic consents validation message & show message after submission

### DIFF
--- a/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/packages/ui-react/src/components/RegistrationForm/RegistrationForm.tsx
@@ -126,7 +126,7 @@ const RegistrationForm: React.FC<Props> = ({
                 value={consentValues[consent.name] || ''}
                 required={consent.required}
                 error={!!consentError}
-                helperText={t('registration.consent_required')}
+                helperText={consentError ? t('registration.field_required') : undefined}
                 onChange={onConsentChange}
                 lang={htmlLang}
               />

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -134,7 +134,6 @@
   },
   "registration": {
     "already_account": "Already have an account?",
-    "consent_required": "Consent required, please check the box to continue.",
     "consents_error": "Please accept all required consents to continue.",
     "continue": "Continue",
     "email": "Email",

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -144,7 +144,6 @@
   },
   "registration": {
     "already_account": "¿Ya tienes una cuenta?",
-    "consent_required": "Se requiere consentimiento, marque la casilla para continuar.",
     "consents_error": "Acepte todos los consentimientos necesarios para continuar.",
     "continue": "Continuar",
     "email": "Correo electrónico",

--- a/platforms/web/test-e2e/tests/register_test.ts
+++ b/platforms/web/test-e2e/tests/register_test.ts
@@ -27,6 +27,9 @@ function runTestSuite(config: typeof testConfigs.svod, providerName: string) {
     I.see('Password');
     I.see('Use a minimum of 8 characters (case sensitive) with at least one number');
 
+    // No validation error messages in the account.registration.* namespace before form submission
+    I.dontSee('registration.', constants.customRegFields.topContainerSelector);
+
     if (await I.hasTermsAndConditionField()) {
       I.see('I accept the');
       I.see('Terms and Conditions');


### PR DESCRIPTION
I introduced a bug with this PR https://github.com/jwplayer/ott-web-app/pull/537

## Bug
After my change, the error message always showed up initially (before form submission) and I noticed that the `<CustomRegisterField />` can be used for all types of fields. In the situation I tested it with I have only seen checkboxes.

## Fix
I reused the already present (generic) `field_required` error message which equals the message "This field is required" without any specificity or guidance.  It originally was "This field is required, please fill in {{field}} to continue.", but the field name can be "technical" such as "broadcaster_terms" which we considered an issue. We originally wanted the extra information (such as _please fill in_ or _check the box_) to guide users, but keeping this intact for all types but this requires a lot of work and translation maintenance. In the end we think (and hope) the message is clear enough.

I also wrote an e2e test to prevent the bug from happening.

Ticket: https://videodock.atlassian.net/browse/OTT-1928
