### PR TITLE
Chore / Upgrade github workflow dependencies

### DIFF
--- a/.github/workflows/release-build-tag-release.yml
+++ b/.github/workflows/release-build-tag-release.yml
@@ -11,11 +11,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: ['20']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/release-build-tag-release.yml
+++ b/.github/workflows/release-build-tag-release.yml
@@ -9,10 +9,6 @@ jobs:
   create-new-release-version:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: ['20']
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-create-release-candidate-branch.yml
+++ b/.github/workflows/release-create-release-candidate-branch.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           ref: release
@@ -40,7 +40,7 @@ jobs:
           input-file: 'CHANGELOG.md'
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.ACTION_TOKEN }}
           title: Release Candidate - ${{ steps.changelog.outputs.tag }}${{ github.ref_name != 'develop' && ' (Hotfix)' || ''}}

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -6,16 +6,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: ['20']
-
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20.x'
       - name: yarn install, lint
         run: |
           yarn install

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: ['20']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: yarn install, lint

--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -34,7 +34,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/test-unit-snapshot.yml
+++ b/.github/workflows/test-unit-snapshot.yml
@@ -2,7 +2,7 @@ name: Test - Unit and Snapshot
 
 on:
   push:
-    branches: [ 'develop', 'release' ]
+    branches: ['develop', 'release']
   pull_request:
 
 jobs:
@@ -11,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: ['20']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: yarn install and test

--- a/.github/workflows/test-unit-snapshot.yml
+++ b/.github/workflows/test-unit-snapshot.yml
@@ -9,16 +9,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: ['20']
-
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20.x'
       - name: yarn install and test
         run: |
           yarn

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -19,15 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20']
         config: [desktop, mobile]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: '20.x'
       - name: Install dependencies
         run: |
           yarn

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
+        node-version: ['20']
         config: [desktop, mobile]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
           WORKER_COUNT: 2
       - name: Uploading artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: allure-report-${{ matrix.config }}
           path: ./platforms/web/test-e2e/output/${{ matrix.config }}


### PR DESCRIPTION
While working on PR #566 I noticed we use an outdated version for Node and our dependencies in Github Workflow-files. So I incremented the version numbers to use the latest available version.

Fixes these deprecation warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show more
 

<br class="Apple-interchange-newline">

> [!WARNING]
> actions/upload-artifact@v3 is scheduled for deprecation on **November 30, 2024**. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
> Similarly, v1/v2 are scheduled for deprecation on **June 30, 2024**.
> Please update your workflow to use v4 of the artifact actions.
> This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.

[codeql-action](https://github.com/github/) v2 (deprecated, support will end on December 5th, 2024) 