### PR TITLE
Feat / add ellipsis to card title

### DIFF
--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -29,13 +29,12 @@
 
   &.featured {
     .title {
+      display: inline-block;
       height: variables.$base-line-height;
       padding-right: 8px;
       font-family: var(--body-font-family);
       font-size: 34px;
-      line-height: variables.$base-line-height;
       white-space: nowrap;
-      text-overflow: ellipsis;
       text-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
 
       @include responsive.mobile-only {
@@ -145,6 +144,7 @@ $aspects: ((1, 1), (2, 1), (2, 3), (4, 3), (5, 3), (16, 9), (9, 16), (9, 13));
 }
 
 .title {
+  display: -webkit-box;
   height: calc(variables.$base-line-height * 2);
   overflow: hidden;
   color: var(--card-color);
@@ -153,7 +153,10 @@ $aspects: ((1, 1), (2, 1), (2, 3), (4, 3), (5, 3), (16, 9), (9, 16), (9, 13));
   font-size: 1em;
   line-height: variables.$base-line-height;
   text-align: left;
+  text-overflow: ellipsis;
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 3px 4px rgba(0, 0, 0, 0.12), 0 1px 5px rgba(0, 0, 0, 0.2);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 
   &.loading {
     &::before {


### PR DESCRIPTION
## Description

This PR adds an ellipsis to the card title using line-clamp and display -webkit-box.

Example title: "Mikimachi Shishimai Performed In The 61st Jumangoku Festival" where the last two words aren't visible. 

**Before**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/83f9b400-c179-42b4-9e93-871a7094b4c0)


**After**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/400f6429-4e36-488c-bfe2-6be99117ca21)


Fixes OTT-589
