### PR TITLE
Feat / support more items in header navigation (opinionated)

### DIFF
--- a/packages/ui-react/src/components/Header/Header.module.scss
+++ b/packages/ui-react/src/components/Header/Header.module.scss
@@ -10,7 +10,7 @@
 
 .header {
   height: variables.$header-height;
-  padding: 10px calc(#{variables.$base-spacing} * 2);
+  padding: 0 calc(#{variables.$base-spacing} * 2);
   color: var(--header-contrast-color, variables.$white);
   background: var(--header-background, transparent);
 
@@ -39,6 +39,8 @@
   position: relative;
   display: flex;
   flex-direction: row;
+  align-items: center;
+  gap: variables.$base-spacing;
   height: 100%;
 }
 
@@ -66,20 +68,22 @@
 //
 .brand {
   align-self: center;
-  margin-right: variables.$base-spacing;
 }
 
 //
 // Header navigation
 //
 .nav {
-  display: inline-block;
+  display: flex;
   flex: 1;
   align-items: center;
+  padding: calc(variables.$base-spacing / 2) 0;
+  overflow: hidden;
 
   > ul {
     margin: 0;
     padding: 0;
+    white-space: nowrap;
     list-style-type: none;
 
     li {
@@ -157,9 +161,9 @@
 
   &::after {
     position: absolute;
-    bottom: calc(((variables.$header-height - 36px) / 2) * -1);
-    left: 0;
-    width: 100%;
+    right: calc(variables.$base-spacing / 2);
+    bottom: 0;
+    left: calc(variables.$base-spacing / 2);
     height: 2px;
     background-color: variables.$white;
     content: '';
@@ -177,7 +181,7 @@
 @include responsive.mobile-and-tablet() {
   .header {
     height: variables.$header-height-mobile;
-    padding: 10px calc(#{variables.$base-spacing} * 2);
+    padding: 10px calc(variables.$base-spacing * 2);
   }
 
   .menu {
@@ -186,7 +190,6 @@
 
   .brand {
     flex: 1;
-    margin-left: variables.$base-spacing;
   }
 
   .nav {
@@ -208,8 +211,6 @@
   }
 
   .brand {
-    margin-right: 0;
-    margin-left: 0;
     text-align: center;
   }
 

--- a/packages/ui-react/src/components/Header/HeaderNavigation.tsx
+++ b/packages/ui-react/src/components/Header/HeaderNavigation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 import Button from '../Button/Button';
 
@@ -9,10 +9,29 @@ type NavItem = {
   to: string;
 };
 
+const scrollOffset = 100;
+
 const HeaderNavigation = ({ navItems }: { navItems: NavItem[] }) => {
+  const navRef = useRef<HTMLElement>(null);
+
+  const focusHandler = (event: React.FocusEvent) => {
+    if (!navRef.current) return;
+
+    const navRect = navRef.current.getBoundingClientRect();
+    const targetRect = (event.target as HTMLElement).getBoundingClientRect();
+
+    // get the element offset position within the navigation scroll container
+    const targetScrollTo = targetRect.left + navRef.current.scrollLeft - navRect.left;
+    // the first half items will reset the scroll offset to 0
+    // all elements after will be scrolled into view with an offset, so that the previous item is still visible
+    const scrollTo = targetScrollTo < navRect.width / 2 ? 0 : targetScrollTo - scrollOffset;
+
+    navRef.current.scrollTo({ left: scrollTo, behavior: 'smooth' });
+  };
+
   return (
-    <nav className={styles.nav}>
-      <ul>
+    <nav className={styles.nav} ref={navRef}>
+      <ul onFocus={focusHandler}>
         {navItems.map((item, index) => (
           <li key={index}>
             <Button activeClassname={styles.navButton} label={item.label} to={item.to} variant="text" />

--- a/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.module.scss
@@ -20,15 +20,6 @@
   top: 10px;
 }
 
-.buttonContainer {
-  // this is a visual fix for putting a button with background besides a transparent button
-  margin-left: variables.$base-spacing;
-
-  > button:first-child {
-    margin-right: calc(#{variables.$base-spacing} / 2);
-  }
-}
-
 .menuItems {
   width: auto;
   margin: 0;

--- a/packages/ui-react/src/components/UserMenu/UserMenu.tsx
+++ b/packages/ui-react/src/components/UserMenu/UserMenu.tsx
@@ -33,10 +33,10 @@ const UserMenu = ({ isLoggedIn, favoritesEnabled, open, onClose, onOpen, onLogin
 
   if (!isLoggedIn) {
     return (
-      <div className={styles.buttonContainer}>
+      <>
         <Button onClick={onLoginButtonClick} label={t('sign_in')} aria-haspopup="dialog" />
         <Button variant="contained" color="primary" onClick={onSignUpButtonClick} label={t('sign_up')} aria-haspopup="dialog" />
-      </div>
+      </>
     );
   }
 

--- a/packages/ui-react/src/containers/HeaderSearch/HeaderSearch.module.scss
+++ b/packages/ui-react/src/containers/HeaderSearch/HeaderSearch.module.scss
@@ -5,16 +5,17 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/utils';
 
 .searchContainer {
-  position: absolute;
-  left: -#{variables.$search-bar-width-desktop};
   display: flex;
   width: variables.$search-bar-width-desktop;
 
   > div:first-child {
     flex: 1;
+    margin-right: calc(variables.$base-spacing / 2);
   }
 
   @include responsive.mobile-and-tablet() {
+    position: absolute;
+    top: 0;
     right: 0;
     left: 0;
     width: auto;


### PR DESCRIPTION
## Description

This one was not planned, but was mentioned multiple times internally. Our config has 7 menu items which currently break over multiple lines. This breaks the layout a bit, but I initially decided that it can be solved by removing menu items.

Some time later I reconsidered this and had an idea that I wanted to test. I think it works pretty well and solves the layout issues in our config.

**Before**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/0fa3add4-d1ad-4430-ae8f-acba3041e537)

**After**

![image](https://github.com/jwplayer/ott-web-app/assets/3996119/3c217d57-00ad-4dd0-b1b9-aa1099288fe5)

**How it works**

https://github.com/jwplayer/ott-web-app/assets/3996119/bc0466b5-e475-4e55-b969-1ee34d09a809

When a button receives focus, the offset position within the scroll container is calculated. If needed, the navigation is scrolled to the target element with an offset.

Preview: https://ottwebapp--pr573-feat-header-navigati-c9ryg6am.web.app/?app-config=eoncwnho