### PR TITLE
Feat / Add backClick event support for player

### DIFF
--- a/packages/ui-react/src/components/Player/Player.tsx
+++ b/packages/ui-react/src/components/Player/Player.tsx
@@ -244,9 +244,12 @@ const Player: React.FC<Props> = ({
     return () => {
       if (playerRef.current) {
         // Detaching events before component unmount
-        if (!backClickRef.current) {
-          playerRef.current.remove();
+        detachEvents();
+        if (backClickRef.current) {
+          backClickRef.current = false;
+          return;
         }
+        playerRef.current.remove();
       }
     };
   }, [detachEvents, backClickRef]);

--- a/packages/ui-react/src/components/Player/Player.tsx
+++ b/packages/ui-react/src/components/Player/Player.tsx
@@ -58,6 +58,7 @@ const Player: React.FC<Props> = ({
   const playerElementRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<JWPlayer>();
   const loadingRef = useRef(false);
+  const backClickRef = useRef(false);
   const [libLoaded, setLibLoaded] = useState(!!window.jwplayer);
   const startTimeRef = useRef(startTime);
 
@@ -88,7 +89,10 @@ const Player: React.FC<Props> = ({
   const handlePlaylistItem = useEventCallback(onPlaylistItem);
   const handlePlaylistItemCallback = useEventCallback(onPlaylistItemCallback);
   const handleNextClick = useEventCallback(onNext);
-  const handleBackClick = useEventCallback(onBackClick);
+  const handleBackClick = useEventCallback(() => {
+    backClickRef.current = true;
+    onBackClick?.();
+  });
   const handleReady = useEventCallback(() => onReady && onReady(playerRef.current));
 
   const attachEvents = useCallback(() => {
@@ -240,13 +244,12 @@ const Player: React.FC<Props> = ({
     return () => {
       if (playerRef.current) {
         // Detaching events before component unmount
-        detachEvents();
-        if (!onBackClick) {
+        if (!backClickRef.current) {
           playerRef.current.remove();
         }
       }
     };
-  }, [detachEvents, onBackClick]);
+  }, [detachEvents, backClickRef]);
 
   return (
     <div className={styles.container} data-testid={testId('player-container')}>

--- a/packages/ui-react/src/components/Player/Player.tsx
+++ b/packages/ui-react/src/components/Player/Player.tsx
@@ -30,6 +30,7 @@ type Props = {
   onFirstFrame?: () => void;
   onRemove?: () => void;
   onNext?: () => void;
+  onBackClick?: () => void;
   onPlaylistItem?: () => void;
   onPlaylistItemCallback?: (item: PlaylistItem) => Promise<undefined | PlaylistItem>;
 };
@@ -49,6 +50,7 @@ const Player: React.FC<Props> = ({
   onPlaylistItem,
   onPlaylistItemCallback,
   onNext,
+  onBackClick,
   feedId,
   startTime = 0,
   autostart,
@@ -86,6 +88,7 @@ const Player: React.FC<Props> = ({
   const handlePlaylistItem = useEventCallback(onPlaylistItem);
   const handlePlaylistItemCallback = useEventCallback(onPlaylistItemCallback);
   const handleNextClick = useEventCallback(onNext);
+  const handleBackClick = useEventCallback(onBackClick);
   const handleReady = useEventCallback(() => onReady && onReady(playerRef.current));
 
   const attachEvents = useCallback(() => {
@@ -100,6 +103,7 @@ const Player: React.FC<Props> = ({
     playerRef.current?.on('remove', handleRemove);
     playerRef.current?.on('playlistItem', handlePlaylistItem);
     playerRef.current?.on('nextClick', handleNextClick);
+    playerRef.current?.on('backClick', handleBackClick);
     playerRef.current?.setPlaylistItemCallback(handlePlaylistItemCallback);
   }, [
     handleReady,
@@ -114,6 +118,7 @@ const Player: React.FC<Props> = ({
     handlePlaylistItem,
     handleNextClick,
     handlePlaylistItemCallback,
+    handleBackClick,
   ]);
 
   const detachEvents = useCallback(() => {
@@ -236,10 +241,12 @@ const Player: React.FC<Props> = ({
       if (playerRef.current) {
         // Detaching events before component unmount
         detachEvents();
-        playerRef.current.remove();
+        if (!onBackClick) {
+          playerRef.current.remove();
+        }
       }
     };
-  }, [detachEvents]);
+  }, [detachEvents, onBackClick]);
 
   return (
     <div className={styles.container} data-testid={testId('player-container')}>

--- a/packages/ui-react/src/containers/Cinema/Cinema.tsx
+++ b/packages/ui-react/src/containers/Cinema/Cinema.tsx
@@ -109,6 +109,7 @@ const Cinema: React.FC<Props> = ({
           onUserActive={handleUserActive}
           onUserInActive={handleUserInactive}
           onNext={handleNext}
+          onBackClick={onClose}
           liveEndDateTime={liveEndDateTime}
           liveFromBeginning={liveFromBeginning}
           liveStartDateTime={liveStartDateTime}

--- a/packages/ui-react/src/containers/PlayerContainer/PlayerContainer.tsx
+++ b/packages/ui-react/src/containers/PlayerContainer/PlayerContainer.tsx
@@ -20,6 +20,7 @@ type Props = {
   onUserActive?: () => void;
   onUserInActive?: () => void;
   onNext?: () => void;
+  onBackClick?: () => void;
   feedId?: string;
   liveStartDateTime?: string | null;
   liveEndDateTime?: string | null;
@@ -37,6 +38,7 @@ const PlayerContainer: React.FC<Props> = ({
   onUserActive,
   onUserInActive,
   onNext,
+  onBackClick,
   liveEndDateTime,
   liveFromBeginning,
   liveStartDateTime,
@@ -88,6 +90,7 @@ const PlayerContainer: React.FC<Props> = ({
       onUserActive={onUserActive}
       onUserInActive={onUserInActive}
       onNext={onNext}
+      onBackClick={onBackClick}
       onPlaylistItemCallback={handlePlaylistItemCallback}
       startTime={startTime}
       autostart={autostart}

--- a/packages/ui-react/types/jwplayer.d.ts
+++ b/packages/ui-react/types/jwplayer.d.ts
@@ -7,6 +7,7 @@ interface EventParams extends jwplayer.EventParams {
   nextClick: () => void;
   pipEnter: () => void;
   pipLeave: () => void;
+  backClick: () => void;
 }
 
 type ConfigOptions = {


### PR DESCRIPTION
`backClick` is a [documented](https://github.com/jwplayer/jwplayer-tizen-app?tab=readme-ov-file#creating-your-own-player-screen) event of JWPlayer which is only used on the Tizen platform. It was not implemented yet in the OTT platform.

The conditional `playerRef.current.remove();` is needed because otherwise the player tries to remove itself twice (also in the internal JW event `backClick` [handler](https://github.com/jwplayer/jwplayer/blob/30353cd1e1f3017a96ef2854ef758fb4f479cd7a/src/js/view/controls/tizen/tizen-controls.ts#L218)) causing an error.

Ticket: https://videodock.atlassian.net/browse/OTT-1613