### PR TITLE
Fix / Wait for isGeoBlocked status and cache it’s value

### DIFF
--- a/packages/hooks-react/src/useProtectedMedia.ts
+++ b/packages/hooks-react/src/useProtectedMedia.ts
@@ -26,6 +26,6 @@ export default function useProtectedMedia(item: PlaylistItem) {
   return {
     ...contentProtectionQuery,
     isGeoBlocked,
-    isLoading: contentProtectionQuery.isLoading && isLoading,
+    isLoading: contentProtectionQuery.isLoading || isLoading,
   };
 }

--- a/packages/hooks-react/src/useProtectedMedia.ts
+++ b/packages/hooks-react/src/useProtectedMedia.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from 'react-query';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 import ApiService from '@jwp/ott-common/src/services/ApiService';
 import { getModule } from '@jwp/ott-common/src/modules/container';
@@ -7,21 +7,25 @@ import useContentProtection from './useContentProtection';
 
 export default function useProtectedMedia(item: PlaylistItem) {
   const apiService = getModule(ApiService);
-
-  const [isGeoBlocked, setIsGeoBlocked] = useState(false);
   const contentProtectionQuery = useContentProtection('media', item.mediaid, (token, drmPolicyId) => apiService.getMediaById(item.mediaid, token, drmPolicyId));
 
-  useEffect(() => {
-    const m3u8 = contentProtectionQuery.data?.sources.find((source) => source.file.indexOf('.m3u8') !== -1);
-    if (m3u8) {
-      fetch(m3u8.file, { method: 'HEAD' }).then((response) => {
-        response.status === 403 && setIsGeoBlocked(true);
-      });
-    }
-  }, [contentProtectionQuery.data]);
+  const { isLoading, data: isGeoBlocked } = useQuery(
+    ['media', 'geo', item.mediaid],
+    () => {
+      const m3u8 = contentProtectionQuery.data?.sources.find((source) => source.file.indexOf('.m3u8') !== -1);
+      if (m3u8) {
+        return fetch(m3u8.file, { method: 'HEAD' }).then((response) => response.status === 403);
+      }
+      return false;
+    },
+    {
+      enabled: contentProtectionQuery.isFetched,
+    },
+  );
 
   return {
     ...contentProtectionQuery,
     isGeoBlocked,
+    isLoading: contentProtectionQuery.isLoading && isLoading,
   };
 }


### PR DESCRIPTION
Wait for the `isGeoBlocked` status to be known before mounting/unmounting the player. Otherwise you can run into player errors, because the player is destructed before it has time to be fully initialized caused by the conditional component rendering in `PlayerContainer`.

We also utilize TanStack Query to cache it's value.

These errors happen in the console while the player is not present in the DOM. It does not interfere with the user.
We experienced this issue on Tizen while pressing keys (LRUD) when the PlayerError is shown.
