### PR TITLE
Refactor / update services members visibility and explicit inject

### DIFF
--- a/packages/common/src/services/ApiService.ts
+++ b/packages/common/src/services/ApiService.ts
@@ -28,14 +28,14 @@ export default class ApiService {
    * We use playlistLabel prop to define the label used for all media items inside.
    * That way we can change the behavior of the same media items being in different playlists
    */
-  private generateAlternateImageURL = ({ mediaId, label, playlistLabel }: { mediaId: string; label: string; playlistLabel?: string }) => {
+  protected generateAlternateImageURL = ({ mediaId, label, playlistLabel }: { mediaId: string; label: string; playlistLabel?: string }) => {
     const pathname = `/v2/media/${mediaId}/images/${playlistLabel || label}.webp`;
     const url = createURL(`${env.APP_API_BASE_URL}${pathname}`, { poster_fallback: 1, fallback: playlistLabel ? label : null });
 
     return url;
   };
 
-  private parseDate = (item: PlaylistItem, prop: string) => {
+  protected parseDate = (item: PlaylistItem, prop: string) => {
     const date = item[prop] as string | undefined;
 
     if (date && !isValid(new Date(date))) {
@@ -49,7 +49,7 @@ export default class ApiService {
   /**
    * Transform incoming content lists
    */
-  private transformContentList = (contentList: ContentList): Playlist => {
+  protected transformContentList = (contentList: ContentList): Playlist => {
     const { list, ...rest } = contentList;
 
     const playlist: Playlist = { ...rest, playlist: [] };
@@ -80,7 +80,7 @@ export default class ApiService {
   /**
    * Transform incoming playlists
    */
-  private transformPlaylist = (playlist: Playlist, relatedMediaId?: string) => {
+  protected transformPlaylist = (playlist: Playlist, relatedMediaId?: string) => {
     playlist.playlist = playlist.playlist.map((item) => this.transformMediaItem(item, playlist));
 
     // remove the related media item (when this is a recommendations playlist)

--- a/packages/common/src/services/ConfigService.ts
+++ b/packages/common/src/services/ConfigService.ts
@@ -13,10 +13,10 @@ import env from '../env';
 
 @injectable()
 export default class ConfigService {
-  private CONFIG_HOST = env.APP_API_BASE_URL;
+  protected CONFIG_HOST = env.APP_API_BASE_URL;
   // Explicitly set default config here as a local variable,
   // otherwise if it's a module level const, the merge below causes changes to nested properties
-  private DEFAULT_CONFIG: Config = {
+  protected DEFAULT_CONFIG: Config = {
     id: '',
     siteName: '',
     description: '',
@@ -33,7 +33,7 @@ export default class ConfigService {
     features: {},
   };
 
-  private enrichConfig = (config: Config): Config => {
+  protected enrichConfig = (config: Config): Config => {
     const { content, siteName } = config;
     const updatedContent = content.map((content) => Object.assign({ featured: false }, content));
 

--- a/packages/common/src/services/FavoriteService.ts
+++ b/packages/common/src/services/FavoriteService.ts
@@ -23,17 +23,21 @@ const schema = array(
 export default class FavoriteService {
   private PERSIST_KEY_FAVORITES = 'favorites';
 
-  private readonly apiService;
-  private readonly storageService;
-  private readonly accountService;
+  protected readonly apiService;
+  protected readonly storageService;
+  protected readonly accountService;
 
-  constructor(@inject(INTEGRATION_TYPE) integrationType: string, apiService: ApiService, storageService: StorageService) {
+  constructor(
+    @inject(INTEGRATION_TYPE) integrationType: string,
+    @inject(ApiService) apiService: ApiService,
+    @inject(StorageService) storageService: StorageService,
+  ) {
     this.apiService = apiService;
     this.storageService = storageService;
     this.accountService = getNamedModule(AccountService, integrationType, false);
   }
 
-  private validateFavorites(favorites: unknown) {
+  protected validateFavorites(favorites: unknown) {
     if (favorites && schema.validateSync(favorites)) {
       return favorites as SerializedFavorite[];
     }
@@ -41,13 +45,13 @@ export default class FavoriteService {
     return [];
   }
 
-  private async getFavoritesFromAccount(user: Customer) {
+  protected async getFavoritesFromAccount(user: Customer) {
     const favorites = await this.accountService?.getFavorites({ user });
 
     return this.validateFavorites(favorites);
   }
 
-  private async getFavoritesFromStorage() {
+  protected async getFavoritesFromStorage() {
     const favorites = await this.storageService.getItem(this.PERSIST_KEY_FAVORITES, true);
 
     return this.validateFavorites(favorites);

--- a/packages/common/src/services/GenericEntitlementService.ts
+++ b/packages/common/src/services/GenericEntitlementService.ts
@@ -5,7 +5,7 @@ import type { GetTokenResponse } from '../../types/entitlement';
 
 @injectable()
 export default class GenericEntitlementService {
-  private getToken = async <T>(url: string, body: unknown = {}, jwt?: string): Promise<T> => {
+  protected getToken = async <T>(url: string, body: unknown = {}, jwt?: string): Promise<T> => {
     const response = await fetch(url, {
       method: 'POST',
       headers: {

--- a/packages/common/src/services/JWPEntitlementService.ts
+++ b/packages/common/src/services/JWPEntitlementService.ts
@@ -5,7 +5,7 @@ import JWPAPIService from './integrations/jwp/JWPAPIService';
 
 @injectable()
 export default class JWPEntitlementService {
-  private readonly apiService;
+  protected readonly apiService;
 
   constructor(@inject(JWPAPIService) apiService: JWPAPIService) {
     this.apiService = apiService;

--- a/packages/common/src/services/SettingsService.ts
+++ b/packages/common/src/services/SettingsService.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import ini from 'ini';
 import { getI18n } from 'react-i18next';
 
@@ -12,9 +12,9 @@ import StorageService from './StorageService';
 
 @injectable()
 export default class SettingsService {
-  private readonly storageService;
+  protected readonly storageService;
 
-  constructor(storageService: StorageService) {
+  constructor(@inject(StorageService) storageService: StorageService) {
     this.storageService = storageService;
   }
 

--- a/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengAccountService.ts
@@ -49,17 +49,17 @@ import type { Response } from './types/api';
 
 @injectable()
 export default class CleengAccountService extends AccountService {
-  private readonly cleengService;
-  private readonly getCustomerIP;
-  private publisherId = '';
+  protected readonly cleengService;
+  protected readonly getCustomerIP;
+  protected publisherId = '';
 
-  private externalData: Record<string, unknown> = {};
+  protected externalData: Record<string, unknown> = {};
 
   accessModel: AccessModel = ACCESS_MODEL.AUTHVOD;
   svodOfferIds: string[] = [];
   sandbox = false;
 
-  constructor(cleengService: CleengService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
+  constructor(@inject(CleengService) cleengService: CleengService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
     super({
       canUpdateEmail: true,
       canSupportEmptyFullName: true,

--- a/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengCheckoutService.ts
@@ -32,10 +32,10 @@ import CleengService from './CleengService';
 
 @injectable()
 export default class CleengCheckoutService extends CheckoutService {
-  private readonly cleengService: CleengService;
-  private readonly getCustomerIP: GetCustomerIP;
+  protected readonly cleengService: CleengService;
+  protected readonly getCustomerIP: GetCustomerIP;
 
-  constructor(cleengService: CleengService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
+  constructor(@inject(CleengService) cleengService: CleengService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
     super();
     this.cleengService = cleengService;
     this.getCustomerIP = getCustomerIP;

--- a/packages/common/src/services/integrations/cleeng/CleengService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengService.ts
@@ -80,17 +80,17 @@ const getTokenExpiration = (token: string) => {
 
 @injectable()
 export default class CleengService {
-  private readonly storageService;
-  private readonly getCustomerIP;
-  private readonly channel: BroadcastChannel<MessageData>;
-  private readonly queue = new PromiseQueue();
-  private isRefreshing = false;
-  private expiration = -1;
+  protected readonly storageService;
+  protected readonly getCustomerIP;
+  protected readonly channel: BroadcastChannel<MessageData>;
+  protected readonly queue = new PromiseQueue();
+  protected isRefreshing = false;
+  protected expiration = -1;
 
   sandbox = false;
   tokens: Tokens | null = null;
 
-  constructor(storageService: StorageService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
+  constructor(@inject(StorageService) storageService: StorageService, @inject(GET_CUSTOMER_IP) getCustomerIP: GetCustomerIP) {
     this.storageService = storageService;
     this.getCustomerIP = getCustomerIP;
 

--- a/packages/common/src/services/integrations/cleeng/CleengSubscriptionService.ts
+++ b/packages/common/src/services/integrations/cleeng/CleengSubscriptionService.ts
@@ -1,4 +1,4 @@
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import { createURL } from '../../../utils/urlFormatting';
 import type {
@@ -17,9 +17,9 @@ import CleengService from './CleengService';
 
 @injectable()
 export default class CleengSubscriptionService extends SubscriptionService {
-  private readonly cleengService: CleengService;
+  protected readonly cleengService: CleengService;
 
-  constructor(cleengService: CleengService) {
+  constructor(@inject(CleengService) cleengService: CleengService) {
     super();
     this.cleengService = cleengService;
   }

--- a/packages/common/src/services/integrations/jwp/JWPAPIService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAPIService.ts
@@ -22,9 +22,9 @@ type RequestOptions = {
 
 @injectable()
 export default class JWPAPIService {
-  private readonly storageService: StorageService;
+  protected readonly storageService: StorageService;
 
-  private useSandboxEnv = true;
+  protected useSandboxEnv = true;
 
   constructor(@inject(StorageService) storageService: StorageService) {
     this.storageService = storageService;

--- a/packages/common/src/services/integrations/jwp/JWPAccountService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAccountService.ts
@@ -1,6 +1,6 @@
 import InPlayer, { Env } from '@inplayer-org/inplayer.js';
 import i18next from 'i18next';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
 import { formatConsentsToRegisterFields } from '../../../utils/collection';
 import type {
@@ -60,17 +60,17 @@ const JW_TERMS_URL = 'https://inplayer.com/legal/terms';
 
 @injectable()
 export default class JWPAccountService extends AccountService {
-  private readonly storageService;
-  private readonly apiService;
+  protected readonly storageService;
+  protected readonly apiService;
 
-  private clientId = '';
+  protected clientId = '';
 
   accessModel: AccessModel = ACCESS_MODEL.AUTHVOD;
   assetId: number | null = null;
   svodOfferIds: string[] = [];
   sandbox = false;
 
-  constructor(storageService: StorageService, apiService: JWPAPIService) {
+  constructor(@inject(StorageService) storageService: StorageService, @inject(JWPAPIService) apiService: JWPAPIService) {
     super({
       canUpdateEmail: false,
       canSupportEmptyFullName: false,

--- a/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPCheckoutService.ts
@@ -34,9 +34,9 @@ import JWPAPIService from './JWPAPIService';
 
 @injectable()
 export default class JWPCheckoutService extends CheckoutService {
-  private readonly cardPaymentProvider = 'stripe';
+  protected readonly cardPaymentProvider = 'stripe';
 
-  private readonly apiService;
+  protected readonly apiService;
 
   constructor(@inject(JWPAPIService) apiService: JWPAPIService) {
     super();

--- a/packages/common/src/services/integrations/jwp/JWPSubscriptionService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPSubscriptionService.ts
@@ -47,8 +47,8 @@ interface SubscriptionDetails extends JWPSubscription {
 
 @injectable()
 export default class JWPSubscriptionService extends SubscriptionService {
-  private readonly accountService: JWPAccountService;
-  private readonly apiService: JWPAPIService;
+  protected readonly accountService: JWPAccountService;
+  protected readonly apiService: JWPAPIService;
 
   constructor(@named('JWP') accountService: AccountService, @inject(JWPAPIService) apiService: JWPAPIService) {
     super();


### PR DESCRIPTION
When implementing services in other platforms we override certain existing services to add custom minor custom implementation. 

But we have two problems with this:

We can't access injected services when extending a service because they are all declared private. This means we have to inject the same service a second time and name it something else (`storageService2` for example).

The second problem is that when extending a class that injects services via the constructor, the injection fails when there is no `@inject(Service)` annotation. I believe this is because the class method descriptor is lost when extending the class, but I'm not sure. I think it's safer to explicit annotate the arguments which also makes it consistent.

