### PR TITLE
Fix / Override search query cache

### DIFF
--- a/packages/hooks-react/src/usePlaylist.ts
+++ b/packages/hooks-react/src/usePlaylist.ts
@@ -33,7 +33,7 @@ export const getPlaylistQueryOptions = ({
 
   return {
     enabled: !!contentId && enabled,
-    queryKey: ['playlist', type, contentId],
+    queryKey: ['playlist', type, contentId, params],
     queryFn: async () => {
       if (type === PLAYLIST_TYPE.playlist) {
         const playlist = await apiService.getPlaylistById(contentId, params);


### PR DESCRIPTION
While testing (yesterday) we discovered when a regular search query is performed using `usePlaylist`, you will indefinitely  see the first search results you encountered. This is caused by the `queryKey` being the same across all your search queries.

This doesn't happen when using `useAppContentSearch`. This bug has already been present for 2 months. 

By applying the search params to the `queryKey`, we make sure the cache is invalidated.

Example video of the bug:

https://github.com/user-attachments/assets/59ca76f8-6e88-46a9-962d-1225f1f4ae07

Ticket: https://videodock.atlassian.net/browse/OTT-2291
