### PR TITLE
Feat / app metadata insertion

### DIFF
--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -14,6 +14,8 @@ APP_FOOTER_TEXT="\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | 
 #APP_GTM_TAG_ID
 #APP_GOOGLE_SITE_VERIFICATION_ID
 
+# APP_APPLE_ITUNES_APP=
+
 # override with custom fonts. supports Google Fonts (eg. APP_BODY_FONT_FAMILY=google:Roboto,system:Verdana - use Roboto and fallback to Verdana)
 #APP_BODY_FONT_FAMILY
 #APP_BODY_ALT_FONT_FAMILY

--- a/platforms/web/.env
+++ b/platforms/web/.env
@@ -14,7 +14,9 @@ APP_FOOTER_TEXT="\u00a9 JW Player | [jwplayer.com](https://www.jwplayer.com/) | 
 #APP_GTM_TAG_ID
 #APP_GOOGLE_SITE_VERIFICATION_ID
 
-# APP_APPLE_ITUNES_APP=
+# app metadata, for smart app banner (iOS) and native app banner (Android)
+# APP_APPLE_ITUNES_APP
+# APP_GOOGLE_RELATED_APPLICATION_ID
 
 # override with custom fonts. supports Google Fonts (eg. APP_BODY_FONT_FAMILY=google:Roboto,system:Verdana - use Roboto and fallback to Verdana)
 #APP_BODY_FONT_FAMILY

--- a/platforms/web/scripts/build-tools/buildTools.ts
+++ b/platforms/web/scripts/build-tools/buildTools.ts
@@ -40,7 +40,7 @@ export const getFileCopyTargets = (mode: string): Target[] => {
   return fileCopyTargets;
 };
 
-export const createHeadMetaTags = (tagData: Record<string, string | undefined>): HtmlTagDescriptor[] => {
+export const getMetaTags = (tagData: Record<string, string | undefined>): HtmlTagDescriptor[] => {
   return Object.entries(tagData)
     .filter(([_, value]) => !!value)
     .map(([name, content]) => ({
@@ -98,7 +98,7 @@ export const getRelatedApplications = ({
   if (appleAppId) {
     relatedApplications.push({
       platform: 'itunes',
-      url: `https://apps.apple.com/nl/app/${appleAppId}`,
+      url: `https://apps.apple.com/app/${appleAppId}`,
     });
   }
 

--- a/platforms/web/scripts/build-tools/buildTools.ts
+++ b/platforms/web/scripts/build-tools/buildTools.ts
@@ -39,19 +39,14 @@ export const getFileCopyTargets = (mode: string): Target[] => {
   return fileCopyTargets;
 };
 
-export const getGoogleVerificationTag = (env: Record<string, string>): HtmlTagDescriptor[] => {
-  if (!env.APP_GOOGLE_SITE_VERIFICATION_ID) return [];
-
-  return [
-    {
+export const createHeadMetaTags = (tagData: Record<string, string | undefined>): HtmlTagDescriptor[] => {
+  return Object.entries(tagData)
+    .filter(([_, value]) => !!value)
+    .map(([name, content]) => ({
       tag: 'meta',
       injectTo: 'head',
-      attrs: {
-        content: process.env.APP_GOOGLE_SITE_VERIFICATION_ID,
-        name: 'google-site-verification',
-      },
-    },
-  ];
+      attrs: { name, content },
+    }));
 };
 
 // @todo: move to common?

--- a/platforms/web/scripts/build-tools/buildTools.ts
+++ b/platforms/web/scripts/build-tools/buildTools.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import type { HtmlTagDescriptor } from 'vite';
+import type { ManifestOptions } from 'vite-plugin-pwa';
 import type { Target } from 'vite-plugin-static-copy';
 
 const initSettings = (mode: string) => {
@@ -83,6 +84,33 @@ export const generateIconTags = (basePath: string, favIconSizes: number[], apple
     return `<link rel="apple-touch-icon" href="${basePath}apple-touch-icon-${size}x${size}.png">`;
   });
   return [...favIconTags, ...appleIconTags].join('\n');
+};
+
+export const getRelatedApplications = ({
+  appleAppId,
+  googleAppId,
+}: {
+  appleAppId?: string | undefined;
+  googleAppId?: string | undefined;
+} = {}): ManifestOptions['related_applications'] => {
+  const relatedApplications = [];
+
+  if (appleAppId) {
+    relatedApplications.push({
+      platform: 'itunes',
+      url: `https://apps.apple.com/nl/app/${appleAppId}`,
+    });
+  }
+
+  if (googleAppId) {
+    relatedApplications.push({
+      platform: 'play',
+      id: googleAppId,
+      url: `https://play.google.com/store/apps/details?id=${googleAppId}`,
+    });
+  }
+
+  return relatedApplications;
 };
 
 const makeFontsUnique = (arr: ExternalFont[]) => {

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -19,6 +19,7 @@ import {
   getGtmTags,
   generateIconTags,
   createHeadMetaTags,
+  getRelatedApplications,
 } from './scripts/build-tools/buildTools';
 
 export default ({ mode, command }: ConfigEnv): UserConfigExport => {
@@ -55,7 +56,8 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
     'google-site-verification': env.APP_GOOGLE_SITE_VERIFICATION_ID,
   });
   const tags = [fontTags, metaTags, getGtmTags(env)].flat();
-  const related_applications = env.APP_GOOGLE_RELATED_APPLICATION_ID ? [{ platform: 'play', id: env.APP_GOOGLE_RELATED_APPLICATION_ID, url: '' }] : [];
+
+  const related_applications = getRelatedApplications({ appleAppId: env.APP_APPLE_ITUNES_APP, googleAppId: env.APP_GOOGLE_RELATED_APPLICATION_ID });
 
   const favicons = generateIconTags(basePath, favIconSizes, appleIconSizes);
 

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -18,7 +18,7 @@ import {
   getGoogleFontTags,
   getGtmTags,
   generateIconTags,
-  createHeadMetaTags,
+  getMetaTags,
   getRelatedApplications,
 } from './scripts/build-tools/buildTools';
 
@@ -51,7 +51,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
 
   // Head tags
   const fontTags = getGoogleFontTags([bodyFonts, bodyAltFonts].flat());
-  const metaTags = createHeadMetaTags({
+  const metaTags = getMetaTags({
     'apple-itunes-app': env.APP_APPLE_ITUNES_APP ? `app-id=${env.APP_APPLE_ITUNES_APP}` : undefined,
     'google-site-verification': env.APP_GOOGLE_SITE_VERIFICATION_ID,
   });

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -51,7 +51,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
   // Head tags
   const fontTags = getGoogleFontTags([bodyFonts, bodyAltFonts].flat());
   const metaTags = createHeadMetaTags({
-    'apple-itunes-app': env.APP_APPLE_ITUNES_APP,
+    'apple-itunes-app': env.APP_APPLE_ITUNES_APP ? `app-id=${env.APP_APPLE_ITUNES_APP}` : undefined,
     'google-site-verification': env.APP_GOOGLE_SITE_VERIFICATION_ID,
   });
   const tags = [fontTags, metaTags, getGtmTags(env)].flat();
@@ -80,8 +80,8 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
           theme_color: '#DD0000',
           orientation: 'any',
           background_color: '#000',
-          related_applications: [],
-          prefer_related_applications: false,
+          related_applications: env.APP_GOOGLE_RELATED_APPLICATION_ID ? [{ platform: 'play', id: env.APP_GOOGLE_RELATED_APPLICATION_ID, url: '' }] : [],
+          prefer_related_applications: !!env.APP_GOOGLE_RELATED_APPLICATION_ID,
           icons: [
             {
               src: 'images/icons/pwa-192x192.png',

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -16,9 +16,9 @@ import {
   extractExternalFonts,
   getFileCopyTargets,
   getGoogleFontTags,
-  getGoogleVerificationTag,
   getGtmTags,
   generateIconTags,
+  createHeadMetaTags,
 } from './scripts/build-tools/buildTools';
 
 export default ({ mode, command }: ConfigEnv): UserConfigExport => {
@@ -42,12 +42,20 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
     description: process.env.APP_DESCRIPTION || 'JW OTT Webapp is an open-source, dynamically generated video website.',
   };
 
+  // Fonts
   const bodyFonts = extractExternalFonts(env.APP_BODY_FONT_FAMILY);
   const bodyAltFonts = extractExternalFonts(env.APP_BODY_ALT_FONT_FAMILY);
-
-  const fontTags = getGoogleFontTags([bodyFonts, bodyAltFonts].flat());
   const bodyFontsString = bodyFonts.map((font) => font.fontFamily).join(', ');
   const bodyAltFontsString = bodyAltFonts.map((font) => font.fontFamily).join(', ');
+
+  // Head tags
+  const fontTags = getGoogleFontTags([bodyFonts, bodyAltFonts].flat());
+  const metaTags = createHeadMetaTags({
+    'apple-itunes-app': env.APP_APPLE_ITUNES_APP,
+    'google-site-verification': env.APP_GOOGLE_SITE_VERIFICATION_ID,
+  });
+  const tags = [fontTags, metaTags, getGtmTags(env)].flat();
+
   const favicons = generateIconTags(basePath, favIconSizes, appleIconSizes);
 
   return defineConfig({
@@ -91,7 +99,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
       createHtmlPlugin({
         minify: true,
         inject: {
-          tags: [getGoogleVerificationTag(env), fontTags, getGtmTags(env)].flat(),
+          tags,
           data: { ...app, favicons },
         },
       }),

--- a/platforms/web/vite.config.ts
+++ b/platforms/web/vite.config.ts
@@ -55,6 +55,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
     'google-site-verification': env.APP_GOOGLE_SITE_VERIFICATION_ID,
   });
   const tags = [fontTags, metaTags, getGtmTags(env)].flat();
+  const related_applications = env.APP_GOOGLE_RELATED_APPLICATION_ID ? [{ platform: 'play', id: env.APP_GOOGLE_RELATED_APPLICATION_ID, url: '' }] : [];
 
   const favicons = generateIconTags(basePath, favIconSizes, appleIconSizes);
 
@@ -80,7 +81,7 @@ export default ({ mode, command }: ConfigEnv): UserConfigExport => {
           theme_color: '#DD0000',
           orientation: 'any',
           background_color: '#000',
-          related_applications: env.APP_GOOGLE_RELATED_APPLICATION_ID ? [{ platform: 'play', id: env.APP_GOOGLE_RELATED_APPLICATION_ID, url: '' }] : [],
+          related_applications,
           prefer_related_applications: !!env.APP_GOOGLE_RELATED_APPLICATION_ID,
           icons: [
             {


### PR DESCRIPTION
## App metadata insertion

This PR makes it possible to add app metadata, to enable the typical [Smart app banner](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners) (iOS) and [Native app banner](https://developer.chrome.com/blog/app-install-banners-native#prefer_related_applications) (Android), by adding the app bundle id through the env var.


### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
