### PR TITLE
Fix / demo config reset

### DIFF
--- a/platforms/web/src/components/DemoConfigDialog/DemoConfigDialog.tsx
+++ b/platforms/web/src/components/DemoConfigDialog/DemoConfigDialog.tsx
@@ -1,6 +1,5 @@
 import React, { type ChangeEventHandler, type MouseEventHandler, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type NavigateFunction, useNavigate } from 'react-router';
 import { Helmet } from 'react-helmet';
 import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import { CONFIG_QUERY_KEY } from '@jwp/ott-common/src/constants';
@@ -12,6 +11,7 @@ import LoadingOverlay from '@jwp/ott-ui-react/src/components/LoadingOverlay/Load
 import DevStackTrace from '@jwp/ott-ui-react/src/components/DevStackTrace/DevStackTrace';
 import type { BootstrapData } from '@jwp/ott-hooks-react/src/useBootstrapApp';
 import { AppError } from '@jwp/ott-common/src/utils/error';
+import { PATH_HOME } from '@jwp/ott-common/src/paths';
 
 import styles from './DemoConfigDialog.module.scss';
 
@@ -32,26 +32,11 @@ const initialState: State = {
   loaded: false,
 };
 
-export function getConfigNavigateCallback(navigate: NavigateFunction) {
-  return (configSource: string) => {
-    navigate(
-      {
-        pathname: '/',
-        search: new URLSearchParams([[CONFIG_QUERY_KEY, configSource]]).toString(),
-      },
-      { replace: true },
-    );
-  };
-}
-
 const DemoConfigDialog = ({ query }: { query: BootstrapData }) => {
   const { data, isLoading, error, refetch, isSuccess } = query;
   const { configSource: selectedConfigSource } = data || {};
 
   const { t } = useTranslation('demo');
-  const navigate = useNavigate();
-  const navigateCallback = getConfigNavigateCallback(navigate);
-
   const [state, setState] = useState<State>(initialState);
 
   const errorTitle = error && error instanceof AppError ? error.payload.title : '';
@@ -91,7 +76,7 @@ const DemoConfigDialog = ({ query }: { query: BootstrapData }) => {
 
   const clearConfig = () => {
     setState(initialState);
-    navigateCallback('');
+    window.location.href = createURL(PATH_HOME, { [CONFIG_QUERY_KEY]: '' });
   };
 
   const isValidSource = (configSource: string) => configSource.match(regex)?.some((m) => m === configSource);
@@ -170,7 +155,7 @@ const DemoConfigDialog = ({ query }: { query: BootstrapData }) => {
             helpLink={'https://docs.jwplayer.com/platform/docs/ott-create-an-app-config'}
             error={typeof state.error === 'string' ? undefined : state.error}
           >
-            <form method={'GET'} target={'/'}>
+            <form method={'GET'}>
               <TextField
                 required
                 disabled={isLoading}

--- a/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
+++ b/platforms/web/src/components/DemoConfigDialog/__snapshots__/DemoConfigDialog.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`<DemoConfigDialog> > renders and matches snapshot error dialog 1`] = `
           </p>
           <form
             method="GET"
-            target="/"
           >
             <div
               class="_formField_a245e1 _textField_0fa545 _maxWidth_561a54"


### PR DESCRIPTION
## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR fixes the "Unselect this config" button in demo mode, which was not responding. This happened because `useTrackConfigKeyChange` keeps undoing the change. Hard-setting the `window.location.href` fixes it, much like we do in all other config switch navigations. I have also removed some code that became obsolete.

![Screenshot 2024-09-11 at 11 07 22](https://github.com/user-attachments/assets/0dd6a56b-2c65-4903-a35e-ab06510ba7b7)

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
