### PR TITLE
Fix / first episode switching per season

### DIFF
--- a/packages/hooks-react/src/series/useFirstEpisode.ts
+++ b/packages/hooks-react/src/series/useFirstEpisode.ts
@@ -1,0 +1,24 @@
+import { useQuery } from 'react-query';
+import type { Series } from '@jwp/ott-common/types/series';
+import ApiService from '@jwp/ott-common/src/services/ApiService';
+import { getModule } from '@jwp/ott-common/src/modules/container';
+import { CACHE_TIME, STALE_TIME } from '@jwp/ott-common/src/constants';
+
+export const useFirstEpisode = ({ series }: { series: Series | undefined }) => {
+  const apiService = getModule(ApiService);
+
+  const { isLoading, data } = useQuery(
+    ['first-episode', series?.series_id],
+    async () => {
+      const item = await apiService.getEpisodes({ seriesId: series?.series_id, pageLimit: 1 });
+
+      return item?.episodes?.[0];
+    },
+    { staleTime: STALE_TIME, cacheTime: CACHE_TIME, enabled: !!series?.series_id },
+  );
+
+  return {
+    isLoading,
+    data,
+  };
+};


### PR DESCRIPTION
## Description

We found a bug in the series screen when switching seasons. This bug causes the "Start watching" button to re-render because the first episode is based on the season episodes. 

We believe that the first episode should always be the first episode in the season and not the currently selected season. The episode in a different season can still be selected.

I also wanted to fix the "loading" state which empties the screen when loading a different episode. We can improve this by either optimistic load the next episode or keep the previous data by loading. This refactor became pretty big so I abandoned this for now. I could decrease the load time by loading the episode and seriesLookup in parallel. The media id was the same, although I'm not sure if this is always the case. @AntonLantukh do you know this?
