### PR TITLE
Fix / card grid rendering previous items

### DIFF
--- a/packages/ui-react/src/components/CardGrid/CardGrid.tsx
+++ b/packages/ui-react/src/components/CardGrid/CardGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import InfiniteScroll from 'react-infinite-scroller';
 import type { Playlist, PlaylistItem } from '@jwp/ott-common/types/playlist';
@@ -46,6 +46,8 @@ export type CardGridProps = {
   getUrl: (item: PlaylistItem) => string;
 };
 
+const getCellKey = (item: PlaylistItem) => item.mediaid;
+
 function CardGrid({
   playlist,
   watchHistory,
@@ -75,6 +77,25 @@ function CardGrid({
     setRowCount(INITIAL_ROW_COUNT);
   }, [playlist.feedid]);
 
+  const renderCell = useCallback(
+    (playlistItem: PlaylistItem, tabIndex: number) => (
+      <Card
+        tabIndex={tabIndex}
+        progress={watchHistory ? watchHistory[playlistItem.mediaid] : undefined}
+        url={getUrl(playlistItem)}
+        onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
+        loading={isLoading}
+        isCurrent={currentCardItem && currentCardItem.mediaid === playlistItem.mediaid}
+        currentLabel={currentCardLabel}
+        isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
+        posterAspect={posterAspect}
+        item={playlistItem}
+        headingLevel={headingLevel}
+      />
+    ),
+    [accessModel, currentCardItem, currentCardLabel, getUrl, hasSubscription, headingLevel, isLoading, isLoggedIn, onCardHover, posterAspect, watchHistory],
+  );
+
   return (
     <InfiniteScroll
       pageStart={0}
@@ -87,21 +108,8 @@ function CardGrid({
         className={classNames(styles.container, styles[`cols-${visibleTiles}`])}
         data={loadMore ? playlist.playlist : playlist.playlist.slice(0, rowCount * visibleTiles)}
         columnCount={visibleTiles}
-        renderCell={(playlistItem: PlaylistItem, tabIndex: number) => (
-          <Card
-            tabIndex={tabIndex}
-            progress={watchHistory ? watchHistory[playlistItem.mediaid] : undefined}
-            url={getUrl(playlistItem)}
-            onHover={typeof onCardHover === 'function' ? () => onCardHover(playlistItem) : undefined}
-            loading={isLoading}
-            isCurrent={currentCardItem && currentCardItem.mediaid === playlistItem.mediaid}
-            currentLabel={currentCardLabel}
-            isLocked={isLocked(accessModel, isLoggedIn, hasSubscription, playlistItem)}
-            posterAspect={posterAspect}
-            item={playlistItem}
-            headingLevel={headingLevel}
-          />
-        )}
+        renderCell={renderCell}
+        getCellKey={getCellKey}
       />
     </InfiniteScroll>
   );

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -9,7 +9,7 @@ type Props<Item> = {
   columnCount: number;
   data: Item[];
   renderCell: (item: Item, tabIndex: number) => JSX.Element;
-  getCellKey: (item: Item, rowIndex: number, columnIndex: number) => string;
+  getCellKey: (item: Item) => string;
 };
 
 const scrollIntoViewThrottled = throttle(function (focusedElement: HTMLElement) {
@@ -17,7 +17,7 @@ const scrollIntoViewThrottled = throttle(function (focusedElement: HTMLElement) 
 }, 300);
 
 // Keyboard-accessible grid layout, with focus management
-const LayoutGrid = <Item extends { mediaid: string }>({ className, columnCount, data, renderCell, getCellKey }: Props<Item>) => {
+const LayoutGrid = <Item extends object>({ className, columnCount, data, renderCell, getCellKey }: Props<Item>) => {
   const [currentRowIndex, setCurrentRowIndex] = useState(0);
   const [currentColumnIndex, setCurrentColumnIndex] = useState(0);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -121,7 +121,7 @@ const LayoutGrid = <Item extends { mediaid: string }>({ className, columnCount, 
             <div
               role="gridcell"
               id={`layout_grid_${rowIndex}-${columnIndex}`}
-              key={getCellKey(item, rowIndex, columnIndex)}
+              key={getCellKey(item)}
               aria-colindex={columnIndex}
               className={styles.cell}
               style={gridCellStyle}

--- a/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
+++ b/packages/ui-react/src/components/LayoutGrid/LayoutGrid.tsx
@@ -1,6 +1,6 @@
 import { throttle } from '@jwp/ott-common/src/utils/common';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import styles from './LayoutGrid.module.scss';
 
@@ -9,6 +9,7 @@ type Props<Item> = {
   columnCount: number;
   data: Item[];
   renderCell: (item: Item, tabIndex: number) => JSX.Element;
+  getCellKey: (item: Item, rowIndex: number, columnIndex: number) => string;
 };
 
 const scrollIntoViewThrottled = throttle(function (focusedElement: HTMLElement) {
@@ -16,7 +17,7 @@ const scrollIntoViewThrottled = throttle(function (focusedElement: HTMLElement) 
 }, 300);
 
 // Keyboard-accessible grid layout, with focus management
-const LayoutGrid = <Item extends object>({ className, columnCount, data, renderCell }: Props<Item>) => {
+const LayoutGrid = <Item extends { mediaid: string }>({ className, columnCount, data, renderCell, getCellKey }: Props<Item>) => {
   const [currentRowIndex, setCurrentRowIndex] = useState(0);
   const [currentColumnIndex, setCurrentColumnIndex] = useState(0);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -110,6 +111,8 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [columnCount]);
 
+  const gridCellStyle = useMemo(() => ({ width: `${Math.round(100 / columnCount)}%` }), [columnCount]);
+
   return (
     <div role="grid" ref={gridRef} aria-rowcount={rowCount} className={className} onKeyDown={handleKeyDown}>
       {Array.from({ length: rowCount }).map((_, rowIndex) => (
@@ -118,10 +121,10 @@ const LayoutGrid = <Item extends object>({ className, columnCount, data, renderC
             <div
               role="gridcell"
               id={`layout_grid_${rowIndex}-${columnIndex}`}
-              key={columnIndex}
+              key={getCellKey(item, rowIndex, columnIndex)}
               aria-colindex={columnIndex}
               className={styles.cell}
-              style={{ width: `${Math.round(100 / columnCount)}%` }}
+              style={gridCellStyle}
             >
               {renderCell(item, currentRowIndex === rowIndex && currentColumnIndex === columnIndex ? 0 : -1)}
             </div>


### PR DESCRIPTION
## Description

When switching playlists pages or using the playlist filters in a wrapped shelf, the cards would render the previous item briefly. This creates some noise in the loading state as multiple page changes occur stacked.

This PR addresses that and also includes some performance improvements. The main cause of the old item being shown was the `key` being set to the column index in the grid. Because this doesn't change when a new playlist is set as prop, the card doesn't re-render immediately and keeps the previous poster image.
