### PR TITLE
Feat / screen animations

### DIFF
--- a/packages/ui-react/src/components/Animation/Animation.tsx
+++ b/packages/ui-react/src/components/Animation/Animation.tsx
@@ -15,6 +15,8 @@ type Props = {
 
 export type Status = 'opening' | 'open' | 'closing' | 'closed';
 
+const triggerReflow = (element: HTMLElement | null) => element?.scrollTop;
+
 const Animation: React.FC<Props> = ({
   className,
   createStyle,
@@ -26,6 +28,7 @@ const Animation: React.FC<Props> = ({
   keepMounted = false,
   children,
 }) => {
+  const nodeRef = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<Status>('closed');
   const [hasOpenedBefore, setHasOpenedBefore] = useState<boolean>(false);
 
@@ -35,6 +38,9 @@ const Animation: React.FC<Props> = ({
   // use event callbacks to ignore reactive dependencies
   const openEvent = useEventCallback(() => {
     setHasOpenedBefore(true);
+    // trigger a reflow to ensure the transition is respected after mount
+    triggerReflow(nodeRef.current);
+
     timeout.current = window.setTimeout(() => setStatus('opening'), delay);
     timeout2.current = window.setTimeout(() => {
       setStatus('open');
@@ -70,7 +76,7 @@ const Animation: React.FC<Props> = ({
   }
 
   return (
-    <div style={createStyle(status)} className={className}>
+    <div style={createStyle(status)} className={className} ref={nodeRef}>
       {children}
     </div>
   );

--- a/packages/ui-react/src/components/Header/Header.module.scss
+++ b/packages/ui-react/src/components/Header/Header.module.scss
@@ -27,7 +27,8 @@
   // Make header static
   //
   &.static {
-    position: static;
+    position: relative;
+    z-index: 1;
     width: 100%;
   }
 }

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -16,6 +16,7 @@ import usePlaylists from '@jwp/ott-hooks-react/src/usePlaylists';
 import Shelf from '../../components/Shelf/Shelf';
 import InfiniteScrollLoader from '../../components/InfiniteScrollLoader/InfiniteScrollLoader';
 import ErrorPage from '../../components/ErrorPage/ErrorPage';
+import Fade from '../../components/Animation/Fade/Fade';
 
 import styles from './ShelfList.module.scss';
 
@@ -76,20 +77,22 @@ const ShelfList = ({ rows }: Props) => {
               data-testid={testId(`shelf-${featured ? 'featured' : type === 'playlist' ? slugify(title || playlist?.title) : type}`)}
               aria-label={title || playlist?.title}
             >
-              <Shelf
-                loading={isPlaceholderData}
-                error={error}
-                type={type}
-                playlist={playlist}
-                watchHistory={type === PersonalShelf.ContinueWatching ? watchHistoryDictionary : undefined}
-                title={title || playlist?.title}
-                featured={featured}
-                accessModel={accessModel}
-                isLoggedIn={!!user}
-                hasSubscription={!!subscription}
-                posterAspect={posterAspect}
-                visibleTilesDelta={visibleTilesDelta}
-              />
+              <Fade duration={250} delay={index * 33} open>
+                <Shelf
+                  loading={isPlaceholderData}
+                  error={error}
+                  type={type}
+                  playlist={playlist}
+                  watchHistory={type === PersonalShelf.ContinueWatching ? watchHistoryDictionary : undefined}
+                  title={title || playlist?.title}
+                  featured={featured}
+                  accessModel={accessModel}
+                  isLoggedIn={!!user}
+                  hasSubscription={!!subscription}
+                  posterAspect={posterAspect}
+                  visibleTilesDelta={visibleTilesDelta}
+                />
+              </Fade>
             </section>
           );
         })}

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -19,111 +19,115 @@ exports[`Home Component tests > Home test 1`] = `
         data-testid="shelf-this-is-a-playlist"
       >
         <div
-          class="_shelf_81910b"
+          style="transition: opacity 0.25s ease-in-out; opacity: 0; will-change: opacity;"
         >
-          <h2
-            class="_title_81910b"
-          >
-            This is a playlist
-          </h2>
           <div
-            class="TileSlider _slider_81910b"
+            class="_shelf_81910b"
           >
-            <div
-              class="TileSlider-gestures"
-              style="margin-left: -4px; margin-right: -4px;"
+            <h2
+              class="_title_81910b"
             >
-              <ul
-                class="TileSlider-list"
-                style="left: calc(0%); transform: translateX(0%);"
+              This is a playlist
+            </h2>
+            <div
+              class="TileSlider _slider_81910b"
+            >
+              <div
+                class="TileSlider-gestures"
+                style="margin-left: -4px; margin-right: -4px;"
               >
-                <li
-                  aria-hidden="false"
-                  class="TileSlider--visible"
-                  style="width: 20%; padding-left: 4px; padding-right: 4px;"
+                <ul
+                  class="TileSlider-list"
+                  style="left: calc(0%); transform: translateX(0%);"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="My video"
-                    href="/m/abcddabc/my-video"
-                    role="button"
-                    tabindex="0"
+                  <li
+                    aria-hidden="false"
+                    class="TileSlider--visible"
+                    style="width: 20%; padding-left: 4px; padding-right: 4px;"
                   >
-                    <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        My video
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                    <a
+                      class="_card_d75732"
+                      data-testid="My video"
+                      href="/m/abcddabc/my-video"
+                      role="button"
+                      tabindex="0"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          My video
+                        </h3>
+                      </div>
+                      <div
+                        class="_poster_d75732 _aspect169_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_meta_d75732"
                         >
                           <div
-                            class="_tag_d75732"
+                            class="_tags_d75732"
                           >
-                            6 min
+                            <div
+                              class="_tag_d75732"
+                            >
+                              6 min
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-                <li
-                  aria-hidden="false"
-                  class="TileSlider--visible"
-                  style="width: 20%; padding-left: 4px; padding-right: 4px;"
-                >
-                  <a
-                    class="_card_d75732"
-                    data-testid="Other Vids"
-                    href="/m/zzzaaazz/other-vids"
-                    role="button"
-                    tabindex="0"
+                    </a>
+                  </li>
+                  <li
+                    aria-hidden="false"
+                    class="TileSlider--visible"
+                    style="width: 20%; padding-left: 4px; padding-right: 4px;"
                   >
-                    <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        Other Vids
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                    <a
+                      class="_card_d75732"
+                      data-testid="Other Vids"
+                      href="/m/zzzaaazz/other-vids"
+                      role="button"
+                      tabindex="0"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          Other Vids
+                        </h3>
+                      </div>
+                      <div
+                        class="_poster_d75732 _aspect169_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_meta_d75732"
                         >
                           <div
-                            class="_tag_d75732"
+                            class="_tags_d75732"
                           >
-                            6 min
+                            <div
+                              class="_tag_d75732"
+                            >
+                              6 min
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div
-              aria-live="polite"
-              class="hidden"
-            >
-              slide_indicator
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                aria-live="polite"
+                class="hidden"
+              >
+                slide_indicator
+              </div>
             </div>
           </div>
         </div>
@@ -134,111 +138,115 @@ exports[`Home Component tests > Home test 1`] = `
         data-testid="shelf-second-playlist"
       >
         <div
-          class="_shelf_81910b"
+          style="transition: opacity 0.25s ease-in-out; opacity: 0; will-change: opacity;"
         >
-          <h2
-            class="_title_81910b"
-          >
-            Second Playlist
-          </h2>
           <div
-            class="TileSlider _slider_81910b"
+            class="_shelf_81910b"
           >
-            <div
-              class="TileSlider-gestures"
-              style="margin-left: -4px; margin-right: -4px;"
+            <h2
+              class="_title_81910b"
             >
-              <ul
-                class="TileSlider-list"
-                style="left: calc(0%); transform: translateX(0%);"
+              Second Playlist
+            </h2>
+            <div
+              class="TileSlider _slider_81910b"
+            >
+              <div
+                class="TileSlider-gestures"
+                style="margin-left: -4px; margin-right: -4px;"
               >
-                <li
-                  aria-hidden="false"
-                  class="TileSlider--visible"
-                  style="width: 20%; padding-left: 4px; padding-right: 4px;"
+                <ul
+                  class="TileSlider-list"
+                  style="left: calc(0%); transform: translateX(0%);"
                 >
-                  <a
-                    class="_card_d75732"
-                    data-testid="My video"
-                    href="/m/abcddabc/my-video"
-                    role="button"
-                    tabindex="0"
+                  <li
+                    aria-hidden="false"
+                    class="TileSlider--visible"
+                    style="width: 20%; padding-left: 4px; padding-right: 4px;"
                   >
-                    <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        My video
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                    <a
+                      class="_card_d75732"
+                      data-testid="My video"
+                      href="/m/abcddabc/my-video"
+                      role="button"
+                      tabindex="0"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          My video
+                        </h3>
+                      </div>
+                      <div
+                        class="_poster_d75732 _aspect169_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_meta_d75732"
                         >
                           <div
-                            class="_tag_d75732"
+                            class="_tags_d75732"
                           >
-                            6 min
+                            <div
+                              class="_tag_d75732"
+                            >
+                              6 min
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-                <li
-                  aria-hidden="false"
-                  class="TileSlider--visible"
-                  style="width: 20%; padding-left: 4px; padding-right: 4px;"
-                >
-                  <a
-                    class="_card_d75732"
-                    data-testid="Other Vids"
-                    href="/m/zzzaaazz/other-vids"
-                    role="button"
-                    tabindex="0"
+                    </a>
+                  </li>
+                  <li
+                    aria-hidden="false"
+                    class="TileSlider--visible"
+                    style="width: 20%; padding-left: 4px; padding-right: 4px;"
                   >
-                    <div
-                      class="_titleContainer_d75732"
-                    >
-                      <h3
-                        class="_title_d75732"
-                      >
-                        Other Vids
-                      </h3>
-                    </div>
-                    <div
-                      class="_poster_d75732 _aspect169_d75732"
+                    <a
+                      class="_card_d75732"
+                      data-testid="Other Vids"
+                      href="/m/zzzaaazz/other-vids"
+                      role="button"
+                      tabindex="0"
                     >
                       <div
-                        class="_meta_d75732"
+                        class="_titleContainer_d75732"
+                      >
+                        <h3
+                          class="_title_d75732"
+                        >
+                          Other Vids
+                        </h3>
+                      </div>
+                      <div
+                        class="_poster_d75732 _aspect169_d75732"
                       >
                         <div
-                          class="_tags_d75732"
+                          class="_meta_d75732"
                         >
                           <div
-                            class="_tag_d75732"
+                            class="_tags_d75732"
                           >
-                            6 min
+                            <div
+                              class="_tag_d75732"
+                            >
+                              6 min
+                            </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div
-              aria-live="polite"
-              class="hidden"
-            >
-              slide_indicator
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                aria-live="polite"
+                class="hidden"
+              >
+                slide_indicator
+              </div>
             </div>
           </div>
         </div>

--- a/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
@@ -10,6 +10,7 @@ import useMedia from '@jwp/ott-hooks-react/src/useMedia';
 import type { ScreenComponent } from '../../../types/screens';
 import Loading from '../Loading/Loading';
 import ErrorPage from '../../components/ErrorPage/ErrorPage';
+import Fade from '../../components/Animation/Fade/Fade';
 
 import MediaStaticPage from './mediaScreens/MediaStaticPage/MediaStaticPage';
 import MediaMovie from './mediaScreens/MediaMovie/MediaMovie';
@@ -35,10 +36,10 @@ mediaScreenMap.register(MediaSeries, (item) => !!item && isLegacySeriesFlow(item
 const MediaScreenRouter = () => {
   const params = useParams();
   const id = params.id || '';
-  const { isLoading, isFetching, error, data } = useMedia(id);
+  const { isFetching, error, data } = useMedia(id);
   const { t } = useTranslation('error');
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 
@@ -48,7 +49,11 @@ const MediaScreenRouter = () => {
 
   const MediaScreen = mediaScreenMap.getScreen(data);
 
-  return <MediaScreen data={data} isLoading={isFetching} />;
+  return (
+    <Fade key={id} open>
+      <MediaScreen data={data} isLoading={isFetching} />
+    </Fade>
+  );
 };
 
 export default MediaScreenRouter;

--- a/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/MediaScreenRouter.tsx
@@ -36,10 +36,10 @@ mediaScreenMap.register(MediaSeries, (item) => !!item && isLegacySeriesFlow(item
 const MediaScreenRouter = () => {
   const params = useParams();
   const id = params.id || '';
-  const { isFetching, error, data } = useMedia(id);
+  const { isLoading, isFetching, error, data } = useMedia(id);
   const { t } = useTranslation('error');
 
-  if (isFetching) {
+  if (isLoading) {
     return <Loading />;
   }
 
@@ -50,7 +50,7 @@ const MediaScreenRouter = () => {
   const MediaScreen = mediaScreenMap.getScreen(data);
 
   return (
-    <Fade key={id} open>
+    <Fade open>
       <MediaScreen data={data} isLoading={isFetching} />
     </Fade>
   );

--- a/packages/ui-react/src/pages/ScreenRouting/PlaylistScreenRouter.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/PlaylistScreenRouter.tsx
@@ -10,6 +10,7 @@ import type { AppMenuType } from '@jwp/ott-common/types/config';
 import Loading from '../Loading/Loading';
 import ErrorPage from '../../components/ErrorPage/ErrorPage';
 import type { ScreenComponent } from '../../../types/screens';
+import Fade from '../../components/Animation/Fade/Fade';
 
 import PlaylistGrid from './playlistScreens/PlaylistGrid/PlaylistGrid';
 import PlaylistLiveChannels from './playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels';
@@ -28,10 +29,10 @@ const PlaylistScreenRouter = ({ type }: { type: AppMenuType }) => {
   const params = useParams();
   const id = params.id || '';
 
-  const { isLoading, isFetching, error, data } = usePlaylist(id, {}, true, true, type);
+  const { isFetching, error, data } = usePlaylist(id, {}, true, true, type);
   const { t } = useTranslation('error');
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 
@@ -45,7 +46,11 @@ const PlaylistScreenRouter = ({ type }: { type: AppMenuType }) => {
 
   const Screen = type === APP_CONFIG_ITEM_TYPE.content_list ? contentScreenMap.getScreen(data) : playlistScreenMap.getScreen(data);
 
-  return <Screen data={data} isLoading={isFetching} />;
+  return (
+    <Fade key={id} open>
+      <Screen data={data} isLoading={isFetching} />
+    </Fade>
+  );
 };
 
 export default PlaylistScreenRouter;

--- a/platforms/web/src/styles/main.scss
+++ b/platforms/web/src/styles/main.scss
@@ -24,7 +24,7 @@ body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: scroll; // this prevents layout jumps when navigating between screens
   color: var(--body-color);
   font-family: var(--body-font-family);
   font-size: variables.$body-font-size;


### PR DESCRIPTION
## Description

This PR makes the transitions to screens (home, playlist and media) more smooth by adding a fade transition. 

To prevent layout jumps while navigating the app, I also set the body `overflow-y` to `scroll` to make the viewport width stable. 

The shelf list on the homepage uses a staggered animation (each shelf fades in with a small delay). 

**Edit** I noticed that the screen fade in animation didn't work every time. After some debugging, I found this is caused by a browser optimisation causing it to batch the paint. By manually triggering a reflow, the animation does work every time. There are alternatives like the [Web Animation API](https://caniuse.com/web-animation), but this isn't supported on older devices (TV platforms).

https://github.com/user-attachments/assets/8782548e-add9-41b4-ad84-255e4de5330e

Let me know what you think! 😄 