### PR TITLE
Fix / prevent recommendations as feed

### DIFF
--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -55,7 +55,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
 
   // Media
   const { isLoading: isTrailerLoading, data: trailerItem } = useMedia(media?.trailerId || '');
-  const { isLoading: isPlaylistLoading, data: playlist } = usePlaylist(playlistId || '');
+  const { isLoading: isPlaylistLoading, data: playlist } = usePlaylist(features?.recommendationsPlaylist || '', { related_media_id: id });
 
   // Event
   const liveEvent = useLiveEvent(media);
@@ -67,7 +67,7 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
 
   // Handlers
   const goBack = () => media && navigate(mediaURL({ id: media.mediaid, title: media.title, playlistId, play: false }));
-  const getUrl = (item: PlaylistItem) => mediaURL({ id: item.mediaid, title: item.title, playlistId });
+  const getUrl = (item: PlaylistItem) => mediaURL({ id: item.mediaid, title: item.title, playlistId: features?.recommendationsPlaylist });
 
   const handleComplete = useCallback(() => {
     if (!id || !playlist) return;


### PR DESCRIPTION
## Description

This small fix prevents the recommendations playlist ending up in the feed param (`?r=:feedId`). This can cause problems when navigating to a different screen that does consume the feed for fetching the playlist.

**Reproduction:**

- Go to: https://app-preview.jwplayer.com/p/DWEqMBXB/?app-config=mcqrzgxv
- Open a video
- Click around until you find a live event in related videos grid
- Click on the live event
- Observe an API error and empty related videos grid