### PR TITLE
fix: update plan types and access bridge port for the unit test workflow

### DIFF
--- a/.github/workflows/test-unit-snapshot.yml
+++ b/.github/workflows/test-unit-snapshot.yml
@@ -26,6 +26,6 @@ jobs:
           APP_API_SECRET: dummy_secret
           APP_STRIPE_SECRET: dummy_stripe_secret
           APP_BIND_ADDR: localhost
-          APP_BIND_PORT: 8080
+          APP_BIND_PORT: 3000
           APP_ACCESS_CONTROL_API_HOST: https://test-cdn.jwplayer.com
           APP_SIMS_API_HOST: https://test-sims.jwplayer.com

--- a/.github/workflows/test-unit-snapshot.yml
+++ b/.github/workflows/test-unit-snapshot.yml
@@ -26,6 +26,6 @@ jobs:
           APP_API_SECRET: dummy_secret
           APP_STRIPE_SECRET: dummy_stripe_secret
           APP_BIND_ADDR: localhost
-          APP_BIND_PORT: 3000
+          APP_BIND_PORT: 3001
           APP_ACCESS_CONTROL_API_HOST: https://test-cdn.jwplayer.com
           APP_SIMS_API_HOST: https://test-sims.jwplayer.com

--- a/packages/common/types/plans.ts
+++ b/packages/common/types/plans.ts
@@ -1,5 +1,9 @@
 type AccessOptions = {
   drm_policy_id: string;
+  include_tags: string[] | null;
+  exclude_tags: string[] | null;
+  include_custom_params: string[] | null;
+  exclude_custom_params: string[] | null;
 };
 
 type PlanExternalProviders = {
@@ -15,10 +19,12 @@ export type AccessControlPlan = {
 
 export type Plan = {
   id: string;
+  original_id: number;
   exp: number;
-  access_model: 'free' | 'freeauth' | 'svod';
-  access: AccessOptions;
   metadata: {
+    name: string;
+    access: AccessOptions;
+    access_model: 'free' | 'freeauth' | 'svod';
     external_providers: PlanExternalProviders;
   };
 };

--- a/platforms/access-bridge/test/fixtures.ts
+++ b/platforms/access-bridge/test/fixtures.ts
@@ -44,24 +44,40 @@ export const VIEWER: Viewer = {
 };
 
 // Plan mock creation function
-const createMockPlan = ({ id, exp, access_model, access, metadata }: Plan): Plan => ({
+const createMockPlan = ({ id, original_id, exp, metadata }: Plan): Plan => ({
   id,
+  original_id,
   exp,
-  access_model,
-  access,
-  metadata,
+  metadata: {
+    name: metadata.name || '',
+    access: {
+      drm_policy_id: metadata.access.drm_policy_id,
+      include_tags: metadata.access.include_tags || [],
+      exclude_tags: metadata.access.exclude_tags || [],
+      include_custom_params: metadata.access.include_custom_params || [],
+      exclude_custom_params: metadata.access.exclude_custom_params || [],
+    },
+    access_model: metadata.access_model,
+    external_providers: metadata.external_providers || {},
+  },
 });
 
 export const PLANS = {
   VALID: [
     createMockPlan({
       id: 'plan1234',
+      original_id: 123456,
       exp: FUTURE_EXPIRY,
-      access_model: 'svod',
-      access: {
-        drm_policy_id: 'drm_policy_123',
-      },
       metadata: {
+        name: 'Test plan',
+        access: {
+          drm_policy_id: 'drm_policy_123',
+          include_tags: [],
+          exclude_tags: [],
+          include_custom_params: [],
+          exclude_custom_params: [],
+        },
+        access_model: 'svod',
         external_providers: {
           stripe: 'stripe_id',
         },
@@ -71,12 +87,18 @@ export const PLANS = {
   FREE: [
     createMockPlan({
       id: 'free1234',
+      original_id: 123457,
       exp: FUTURE_EXPIRY,
-      access_model: 'free',
-      access: {
-        drm_policy_id: 'drm_policy_456',
-      },
       metadata: {
+        name: 'Free plan',
+        access: {
+          drm_policy_id: 'drm_policy_456',
+          include_tags: [],
+          exclude_tags: [],
+          include_custom_params: [],
+          exclude_custom_params: [],
+        },
+        access_model: 'free',
         external_providers: {},
       },
     }),
@@ -84,12 +106,18 @@ export const PLANS = {
   INVALID: [
     createMockPlan({
       id: 'plan123456',
+      original_id: 123458,
       exp: FUTURE_EXPIRY,
-      access_model: 'svod',
-      access: {
-        drm_policy_id: 'drm_policy_789',
-      },
       metadata: {
+        name: 'Invalid plan',
+        access: {
+          drm_policy_id: 'drm_policy_789',
+          include_tags: [],
+          exclude_tags: [],
+          include_custom_params: [],
+          exclude_custom_params: [],
+        },
+        access_model: 'svod',
         external_providers: {},
       },
     }),
@@ -97,12 +125,18 @@ export const PLANS = {
   EXPIRED: [
     createMockPlan({
       id: 'plan1234',
+      original_id: 123459,
       exp: PAST_EXPIRY,
-      access_model: 'svod',
-      access: {
-        drm_policy_id: 'drm_policy_101',
-      },
       metadata: {
+        name: 'Expired plan',
+        access: {
+          drm_policy_id: 'drm_policy_101',
+          include_tags: [],
+          exclude_tags: [],
+          include_custom_params: [],
+          exclude_custom_params: [],
+        },
+        access_model: 'svod',
         external_providers: {},
       },
     }),


### PR DESCRIPTION
## Description

Small type corrections is needed in order to match the required Plans structure for the opened PRs.
Also, the unit test workflow is failing due to port already in use, I assume updating the access bridge to use another port will resolve that.

This PR solves # .

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [ ] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [ ] Rebased & ready to merge without conflicts
- [ ] Reviewed own code
