### PR TITLE
Fix / Dropdown box arrow spacing

### DIFF
--- a/packages/ui-react/src/components/Select/Select.module.scss
+++ b/packages/ui-react/src/components/Select/Select.module.scss
@@ -72,7 +72,7 @@ $disabled-gradient: linear-gradient(to top, #ddd, $disabled-bg-color 33%);
   width: 100%;
   height: 36px;
   margin: 0;
-  padding: 2px 8px;
+  padding: 2px 24px 2px 8px;
   color: variables.$white;
   font-family: inherit;
   font-weight: theme.$body-font-weight-bold;


### PR DESCRIPTION
Microchange to fix overlapping in the dropdown box.

Old situation:
![Screenshot 2024-11-13 at 18 19 32](https://github.com/user-attachments/assets/d260feaa-7158-404e-901f-e1c26ab7e25a)

New situation:
![Screenshot 2024-11-13 at 18 19 40](https://github.com/user-attachments/assets/d86c5236-94b1-45f8-bf0b-132d46099f04)

Ticket: [OTT-2705](https://videodock.atlassian.net/browse/OTT-2705)