### PR TITLE
Feat / Hero and HeroShelf improvements

### DIFF
--- a/packages/ui-react/src/components/Card/Card.module.scss
+++ b/packages/ui-react/src/components/Card/Card.module.scss
@@ -18,12 +18,7 @@
       position: relative;
       z-index: 1;
       outline: none !important;
-      box-shadow: none !important;
       transform: scale(1.05);
-
-      & .poster {
-        box-shadow: 0 0 0 3px var(--highlight-color, variables.$white), 0 8px 10px rgb(0 0 0 / 14%), 0 3px 14px rgb(0 0 0 / 12%), 0 4px 5px rgb(0 0 0 / 20%);
-      }
     }
   }
 
@@ -67,10 +62,6 @@
     &:hover {
       transform: scale(1);
       cursor: default;
-
-      & .poster {
-        box-shadow: none;
-      }
     }
   }
 }
@@ -84,8 +75,6 @@
   background-position: center;
   background-size: cover;
   border-radius: 4px;
-  box-shadow: 0 8px 10px rgb(0 0 0 / 14%), 0 3px 14px rgb(0 0 0 / 12%), 0 4px 5px rgb(0 0 0 / 20%);
-  transition: box-shadow 0.1s ease;
 
   &.current::after {
     position: absolute;

--- a/packages/ui-react/src/components/Hero/Hero.module.scss
+++ b/packages/ui-react/src/components/Hero/Hero.module.scss
@@ -32,7 +32,7 @@
 }
 
 .poster {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   z-index: -1;
@@ -41,13 +41,14 @@
   max-height: 700px;
   object-fit: cover;
   object-position: center 30%;
+  transition: opacity ease-out 0.3s;
 
   -webkit-mask-image: radial-gradient(farthest-corner at 80% 30%, rgba(0, 0, 0, 0.8) 20%, rgb(0 0 0 / 21%) 45%, rgb(0 0 0 / 0%) 73%);
   mask-image: radial-gradient(farthest-corner at 80% 30%, rgba(0, 0, 0, 0.8) 20%, rgb(0 0 0 / 21%) 45%, rgb(0 0 0 / 0%) 73%);
 }
 
 .posterFade {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   left: 0;

--- a/packages/ui-react/src/components/Hero/Hero.tsx
+++ b/packages/ui-react/src/components/Hero/Hero.tsx
@@ -1,6 +1,8 @@
-import React, { type PropsWithChildren } from 'react';
+import React, { useRef, type PropsWithChildren } from 'react';
 
 import Image from '../Image/Image';
+import { useScrolledDown } from '../../hooks/useScrolledDown';
+import useBreakpoint, { Breakpoint } from '../../hooks/useBreakpoint';
 
 import styles from './Hero.module.scss';
 
@@ -10,10 +12,17 @@ type Props = PropsWithChildren<{
 
 const Hero = ({ image, children }: Props) => {
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
+  const posterRef = useRef<HTMLImageElement>(null);
+  const breakpoint = useBreakpoint();
+  const isMobile = breakpoint <= Breakpoint.sm;
+
+  useScrolledDown(50, isMobile ? 150 : 500, (progress: number) => {
+    if (posterRef.current) posterRef.current.style.opacity = `${Math.max(1 - progress, 0.1)}`;
+  });
 
   return (
     <div className={styles.hero}>
-      <Image className={styles.poster} image={image} width={1280} alt={alt} />
+      <Image ref={posterRef} className={styles.poster} image={image} width={1280} alt={alt} />
       <div className={styles.posterFade} />
       <div className={styles.info}>{children}</div>
     </div>

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
@@ -8,7 +8,7 @@ $desktop-max-height: 700px;
 $desktop-min-height: 275px;
 
 $tablet-height: 70vw;
-$tablet-min-height: 375px;
+$tablet-min-height: 550px;
 
 $mobile-height: 70vh;
 $mobile-min-height: 450px;
@@ -47,13 +47,13 @@ $mobile-landscape-height: 100vh;
   }
 
   @include responsive.mobile-only() {
-    height: calc($mobile-height - variables.$header-height - var(--safe-area-top, 0));
+    height: calc($mobile-height - variables.$header-height - var(--safe-area-top, 0px));
     min-height: calc($mobile-min-height - variables.$header-height);
-    margin-top: var(--safe-area-top, 0);
   }
 
   @include responsive.mobile-only-landscape() {
     height: calc($mobile-landscape-height - variables.$header-height);
+    min-height: initial;
     padding: 0;
   }
 }
@@ -113,6 +113,7 @@ $mobile-landscape-height: 100vh;
 
   @include responsive.mobile-only-landscape() {
     height: $mobile-landscape-height;
+    min-height: initial;
   }
 }
 
@@ -178,7 +179,14 @@ $mobile-landscape-height: 100vh;
   }
 }
 
-.metadataMobile {
+.swipeSlider {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+  height: 100%;
+}
+
+.swipeSliderMobile {
   width: 100%;
   height: 100%;
 }
@@ -188,6 +196,7 @@ $mobile-landscape-height: 100vh;
   display: flex;
   flex-direction: column;
   gap: 24px;
+  width: 46%;
   max-width: 46%;
   padding-left: calc(variables.$base-spacing * 4);
 
@@ -225,6 +234,7 @@ $mobile-landscape-height: 100vh;
 
   @include responsive.mobile-only-landscape() {
     max-width: 70%;
+    min-height: initial;
     padding: 0 calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3);
   }
 

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
@@ -49,6 +49,7 @@ $mobile-landscape-height: 100vh;
   @include responsive.mobile-only() {
     height: calc($mobile-height - variables.$header-height - var(--safe-area-top, 0));
     min-height: calc($mobile-min-height - variables.$header-height);
+    margin-top: var(--safe-area-top, 0);
   }
 
   @include responsive.mobile-only-landscape() {
@@ -97,6 +98,7 @@ $mobile-landscape-height: 100vh;
   height: 56.25vw;
   max-height: 700px;
   background-color: var(--hero-shelf-background-color);
+  transition: opacity ease-out 0.3s;
 
   @include responsive.tablet-only() {
     height: $tablet-height;
@@ -106,20 +108,12 @@ $mobile-landscape-height: 100vh;
   @include responsive.mobile-only() {
     height: $mobile-height;
     min-height: $mobile-min-height;
+    margin-top: var(--safe-area-top, 0);
   }
 
   @include responsive.mobile-only-landscape() {
     height: $mobile-landscape-height;
   }
-}
-
-.undimmed {
-  opacity: 1;
-  transition: opacity ease-out 0.3s;
-}
-
-.dimmed {
-  opacity: 0.01;
 }
 
 .background {
@@ -145,13 +139,13 @@ $mobile-landscape-height: 100vh;
   }
 
   @include responsive.tablet-small-only() {
-    -webkit-mask-image: linear-gradient(190deg, black, rgba(0, 0, 0, 0.8) 40%, transparent 90%);
-    mask-image: linear-gradient(190deg, black, rgba(0, 0, 0, 0.8) 40%, transparent 90%);
+    -webkit-mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 90%);
+    mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 90%);
   }
 
   @include responsive.mobile-only() {
-    -webkit-mask-image: linear-gradient(190deg, black, rgba(0, 0, 0, 0.8) 40%, transparent 85%);
-    mask-image: linear-gradient(190deg, black, rgba(0, 0, 0, 0.8) 40%, transparent 85%);
+    -webkit-mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 75%);
+    mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 75%);
   }
 }
 

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
@@ -98,7 +98,6 @@ $mobile-landscape-height: 100vh;
   height: 56.25vw;
   max-height: 700px;
   background-color: var(--hero-shelf-background-color);
-  transition: opacity ease-out 0.3s;
 
   @include responsive.tablet-only() {
     height: $tablet-height;
@@ -196,8 +195,8 @@ $mobile-landscape-height: 100vh;
   display: flex;
   flex-direction: column;
   gap: 24px;
-  width: 46%;
-  max-width: 46%;
+  min-width: 50%;
+  max-width: 50%;
   padding-left: calc(variables.$base-spacing * 4);
 
   > h2 {
@@ -233,13 +232,23 @@ $mobile-landscape-height: 100vh;
   }
 
   @include responsive.mobile-only-landscape() {
-    max-width: 70%;
     min-height: initial;
     padding: 0 calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3);
+
+    > h2 {
+      font-size: 24px;
+    }
+    > div {
+      font-size: 14px;
+    }
   }
 
   @include responsive.tablet-small-only() {
     padding: 0 calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3);
+
+    > div > button {
+      width: auto !important; // Override StartWatchingButton fullWidth prop
+    }
   }
 
   @include responsive.mobile-only() {

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
@@ -32,7 +32,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
   const [animationPhase, setAnimationPhase] = useState<'init' | 'start' | 'end' | null>(null);
   const [isSwipeAnimation, setIsSwipeAnimation] = useState(false);
 
-  useScrolledDown(50, isMobile ? 200 : 700, (progress: number) => {
+  useScrolledDown(50, isMobile ? 200 : 600, (progress: number) => {
     if (posterRef.current) posterRef.current.style.opacity = `${Math.max(1 - progress, isMobile ? 0 : 0.1)}`;
   });
 
@@ -182,14 +182,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
           />
         )}
         renderItem={() => (
-          <HeroShelfMetadata
-            loading={loading}
-            item={renderedItem}
-            playlistId={playlist.feedid}
-            isMobile={isMobile}
-            key={renderedItem?.mediaid}
-            style={getMetadataStyle()}
-          />
+          <HeroShelfMetadata loading={loading} item={renderedItem} playlistId={playlist.feedid} key={renderedItem?.mediaid} style={getMetadataStyle()} />
         )}
         renderRightItem={(isSwiping: boolean) => (
           <HeroShelfMetadata

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState, type CSSProperties, type TransitionEventHandler } from 'react';
+import React, { useCallback, useEffect, useRef, useState, type CSSProperties, type TransitionEventHandler } from 'react';
 import type { Playlist } from '@jwp/ott-common/types/playlist';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -27,9 +27,13 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
   const { t } = useTranslation('common');
   const breakpoint = useBreakpoint();
   const isMobile = breakpoint <= Breakpoint.sm;
-  const scrolledDown = useScrolledDown(500, 200);
+  const posterRef = useRef<HTMLDivElement>(null);
   const [direction, setDirection] = useState<'left' | 'right' | null>(null);
   const [animationPhase, setAnimationPhase] = useState<'init' | 'start' | 'end' | null>(null);
+
+  useScrolledDown(50, isMobile ? 200 : 700, (progress: number) => {
+    if (posterRef.current) posterRef.current.style.opacity = `${Math.max(1 - progress, isMobile ? 0 : 0.1)}`;
+  });
 
   const slideTo = (toIndex: number) => {
     if (animationPhase) return;
@@ -108,7 +112,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
 
   return (
     <div className={classNames(styles.shelf)}>
-      <div className={classNames(styles.poster, styles.undimmed, { [styles.dimmed]: scrolledDown })}>
+      <div className={styles.poster} ref={posterRef}>
         <div className={styles.background} id="background">
           <HeroShelfBackground
             item={leftItem}
@@ -128,7 +132,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
         <div className={styles.fade2} />
       </div>
       <button
-        className={classNames(styles.chevron, styles.chevronLeft, styles.undimmed, { [styles.dimmed]: scrolledDown })}
+        className={classNames(styles.chevron, styles.chevronLeft)}
         aria-label={t('slide_previous')}
         disabled={!leftItem}
         onClick={leftItem ? slideLeft : undefined}
@@ -153,21 +157,14 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
         </>
       )}
       <button
-        className={classNames(styles.chevron, styles.chevronRight, styles.undimmed, { [styles.dimmed]: scrolledDown })}
+        className={classNames(styles.chevron, styles.chevronRight)}
         aria-label={t('slide_next')}
         disabled={!rightItem}
         onClick={rightItem ? slideRight : undefined}
       >
         <Icon icon={ChevronRight} />
       </button>
-      <HeroShelfPagination
-        className={scrolledDown ? styles.dimmed : undefined}
-        playlist={playlist}
-        index={index}
-        setIndex={slideTo}
-        nextIndex={nextIndex}
-        direction={direction || false}
-      />
+      <HeroShelfPagination playlist={playlist} index={index} setIndex={slideTo} nextIndex={nextIndex} direction={direction || false} />
     </div>
   );
 };

--- a/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
@@ -12,6 +12,7 @@ import TruncatedText from '../TruncatedText/TruncatedText';
 import StartWatchingButton from '../../containers/StartWatchingButton/StartWatchingButton';
 import Button from '../Button/Button';
 import Icon from '../Icon/Icon';
+import useBreakpoint, { Breakpoint } from '../../hooks/useBreakpoint';
 
 import styles from './HeroShelf.module.scss';
 
@@ -21,17 +22,18 @@ const HeroShelfMetadata = ({
   playlistId,
   style,
   hidden,
-  isMobile,
 }: {
   item: PlaylistItem | null;
   loading: boolean;
   playlistId: string | undefined;
-  style?: CSSProperties;
+  style: CSSProperties;
   hidden?: boolean;
   isMobile?: boolean;
 }) => {
   const navigate = useNavigate();
   const { t } = useTranslation('common');
+  const breakpoint = useBreakpoint();
+  const isMobile = breakpoint <= Breakpoint.sm;
 
   if (!item) return null;
 

--- a/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
@@ -28,12 +28,11 @@ const HeroShelfMetadata = ({
   playlistId: string | undefined;
   style: CSSProperties;
   hidden?: boolean;
-  isMobile?: boolean;
 }) => {
   const navigate = useNavigate();
   const { t } = useTranslation('common');
   const breakpoint = useBreakpoint();
-  const isMobile = breakpoint <= Breakpoint.sm;
+  const isMobile = breakpoint < Breakpoint.sm;
 
   if (!item) return null;
 

--- a/packages/ui-react/src/components/HeroShelf/HeroShelfPagination.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelfPagination.tsx
@@ -35,19 +35,9 @@ type Props = {
   setIndex: (index: number) => void;
   range?: number;
   animationDuration?: number;
-  className?: string;
 };
 
-const HeroShelfPagination = ({
-  playlist,
-  index: indexIn,
-  direction,
-  nextIndex: nextIndexIn,
-  setIndex,
-  range = 3,
-  animationDuration = 200,
-  className,
-}: Props) => {
+const HeroShelfPagination = ({ playlist, index: indexIn, direction, nextIndex: nextIndexIn, setIndex, range = 3, animationDuration = 200 }: Props) => {
   const { t } = useTranslation('common');
   const placeholderCount = range + 1; // Placeholders are used to keep a stable amount of DOM elements
   const index = indexIn + placeholderCount;
@@ -60,7 +50,7 @@ const HeroShelfPagination = ({
   }, [playlist.playlist, placeholderCount]);
 
   return (
-    <nav className={classNames(styles.dots, styles.undimmed, className)}>
+    <nav className={styles.dots}>
       <div aria-live="polite" className="hidden">
         {t('slide_indicator', { page: indexIn + 1, pages: playlist.playlist.length })}
       </div>

--- a/packages/ui-react/src/components/Image/Image.tsx
+++ b/packages/ui-react/src/components/Image/Image.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { createURL } from '@jwp/ott-common/src/utils/urlFormatting';
 import { logInfo } from '@jwp/ott-common/src/logger';
 
@@ -42,7 +42,7 @@ const resolveImageURL = async (imgUrl: string, width: number) => {
   return url;
 };
 
-const Image = ({ className, image, onLoad, alt = '', width = 640 }: Props) => {
+const Image = forwardRef<HTMLImageElement, Props>(({ className, image, onLoad, alt = '', width = 640 }, ref) => {
   const [src, setSrc] = useState<string | null>(null);
 
   useEffect(() => {
@@ -65,7 +65,7 @@ const Image = ({ className, image, onLoad, alt = '', width = 640 }: Props) => {
 
   if (!src) return null;
 
-  return <img className={`${className} ${styles.image}`} src={src} alt={alt} />;
-};
+  return <img ref={ref} className={`${className} ${styles.image}`} src={src} alt={alt} />;
+});
 
 export default React.memo(Image);

--- a/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
+++ b/packages/ui-react/src/components/TruncatedText/TruncatedText.tsx
@@ -18,6 +18,8 @@ const TruncatedText: React.FC<TruncatedTextProps> = ({ text, maximumLines, class
       style={{
         maxHeight: `calc(1.5em * ${maximumLines})`,
         WebkitLineClamp: maximumLines,
+        lineClamp: maximumLines,
+        display: '-webkit-box',
       }}
     >
       <MarkdownComponent markdownString={text} inline />

--- a/packages/ui-react/src/components/TruncatedText/__snapshots__/TruncatedText.test.tsx.snap
+++ b/packages/ui-react/src/components/TruncatedText/__snapshots__/TruncatedText.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<TruncatedText> > renders and matches snapshot 1`] = `
 <div>
   <div
     class="_truncatedText_b1c064"
-    style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8;"
+    style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8; line-clamp: 8; display: -webkit-box;"
   >
     <div
       class="_markdown_e219e2 _inline_e219e2"

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           </div>
           <div
             class="_truncatedText_b1c064 _description_77f2c2 _description_d0c133"
-            style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8;"
+            style="max-height: calc(1.5em * 8); -webkit-line-clamp: 8; line-clamp: 8; display: -webkit-box;"
           >
             <div
               class="_markdown_e219e2 _inline_e219e2"

--- a/packages/ui-react/src/hooks/useScrolledDown.ts
+++ b/packages/ui-react/src/hooks/useScrolledDown.ts
@@ -1,28 +1,22 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import useEventCallback from '@jwp/ott-hooks-react/src/useEventCallback';
 
-export const useScrolledDown = (scrollUpHeight = 300, scrollDownHeight = 30) => {
-  const scrollingElement = document.scrollingElement || document.body;
-  const scrollTopRef = useRef(scrollingElement.scrollTop);
-  const [scrolledDown, setScrolledDown] = useState(false);
-
+export const useScrolledDown = (start = 300, end = 30, onChange: (progress: number) => void) => {
   const handleScroll = useEventCallback(() => {
-    const scrollPosition = scrollingElement.scrollTop;
-    const direction = scrollTopRef.current > scrollPosition ? 'up' : 'down';
+    const scrollTarget = document.scrollingElement || document.body;
+    const scrollPosition = scrollTarget.scrollTop;
+    const progress = Math.max(0, Math.min(1, (scrollPosition - start) / (end - start)));
 
-    scrollTopRef.current = scrollPosition;
-
-    // toggle the scrolledDown based on the direction to
-    setScrolledDown((direction === 'up' && scrollPosition > scrollUpHeight) || (direction === 'down' && scrollPosition > scrollDownHeight));
+    onChange(progress);
   });
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll, { passive: true });
+    const { scrollingElement, documentElement, body } = document;
+    const listenerElement = scrollingElement && scrollingElement !== documentElement && scrollingElement !== body ? scrollingElement : window;
 
+    listenerElement.addEventListener('scroll', handleScroll, { passive: true });
     return () => {
-      window.removeEventListener('scroll', handleScroll);
+      listenerElement.removeEventListener('scroll', handleScroll);
     };
   }, [handleScroll]);
-
-  return scrolledDown;
 };

--- a/platforms/web/src/styles/main.scss
+++ b/platforms/web/src/styles/main.scss
@@ -19,10 +19,13 @@
   --card-tag-bg: #{theme.$card-tag-bg};
 
   // Safe area insets, can be overridden for specific platforms
-  --safe-area-top: 0;
-  --safe-area-right: 0;
-  --safe-area-bottom: 0;
-  --safe-area-left: 0;
+  /* stylelint-disable length-zero-no-unit */
+  --safe-area-top: 0px; 
+  --safe-area-right: 0px;
+  --safe-area-bottom: 0px;
+  --safe-area-left: 0px;
+  /* stylelint-enable length-zero-no-unit */
+
 }
 
 @include accessibility.globalClassNames;


### PR DESCRIPTION
## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR improves the Hero and HeroShelf and removes Card shadow:
- Fade out the background incrementally based on scroll position. This brings a much smoother scrolling experience.
- Add swiping gesture to HeroShelf for all breakpoints. Previously swiping was only possible for mobile devices, but on tablets or landscape mobile it is needed as well to navigate between slides. I have tried simplifying the code by merging the two implementations, leaving only style differences between mobile and the rest.
- Some minor style updates to HeroShelf: a bit more height on tablet, better support for mobile landscape and respecting the safe-area better (useful for non-web platforms).
- Make the Hero fixed as well, and add the same fade behaviour.
- Remove the Card box-shadow. Since we've re-introduced support for a light background, the card shadow seemed a bit overdone, or out-dated even in some opinions (have a look here: https://vd-ott.com/?app-config=kcm2oevm). We figured that the card shadow could be left out entirely, as it was once introduced mainly because of the blur background, which was removed quite some time ago. 

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [x] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code
