### PR TITLE
Fix /  Translatable shelf titles for hub pages

### DIFF
--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -75,7 +75,7 @@ const ShelfList = ({ rows }: Props) => {
           const posterAspect = parseAspectRatio(playlist.cardImageAspectRatio || playlist.shelfImageAspectRatio);
           const visibleTilesDelta = parseTilesDelta(posterAspect);
 
-          const translatedKey = custom?.[`title-${language}`];
+          const translatedKey = custom?.[`title-${language}`] || (playlist?.[`title-${language}`] as string);
           const translatedTitle = translatedKey || title || playlist?.title;
 
           const isHero = custom?.layoutType === SHELF_LAYOUT_TYPE.hero && index === 0;


### PR DESCRIPTION
This fixes an issue where translated playlist titles didn't show up as translated shelf titles on the hub page. 