### PR TITLE
OWA-99: fix: do not perform logout if password reset with token

### DIFF
--- a/packages/common/src/services/StorageService.ts
+++ b/packages/common/src/services/StorageService.ts
@@ -5,7 +5,7 @@ export default abstract class StorageService {
 
   abstract setItem(key: string, value: string, usePrefix?: boolean): Promise<void>;
 
-  abstract removeItem(key: string): Promise<void>;
+  abstract removeItem(key: string, usePrefix?: boolean): Promise<void>;
 
   abstract base64Decode(input: string): string;
 

--- a/packages/common/src/services/integrations/jwp/JWPAPIService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPAPIService.ts
@@ -51,7 +51,7 @@ export default class JWPAPIService {
   };
 
   removeToken = async () => {
-    await Promise.all([this.storageService.removeItem(INPLAYER_TOKEN_KEY), this.storageService.removeItem(INPLAYER_IOT_KEY)]);
+    await Promise.all([this.storageService.removeItem(INPLAYER_TOKEN_KEY, false), this.storageService.removeItem(INPLAYER_IOT_KEY, false)]);
   };
 
   isAuthenticated = async () => {

--- a/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
@@ -36,6 +36,8 @@ const ResetPassword = ({ type }: { type?: 'add' }) => {
     const resetToken = resetPasswordToken || resetPasswordTokenParam;
 
     try {
+      let pathname = location.pathname;
+
       if (resetToken) {
         await accountController.changePasswordWithToken(emailParam || '', password, resetToken, passwordConfirmation);
       } else {
@@ -44,12 +46,14 @@ const ResetPassword = ({ type }: { type?: 'add' }) => {
           return setSubmitting(false);
         }
 
+        pathname = '/';
+
         await accountController.changePasswordWithOldPassword(oldPassword || '', password, passwordConfirmation);
         await accountController.logout();
       }
 
       announce(t('reset.password_reset_success'), 'success');
-      navigate(modalURLFromLocation(location, 'login'));
+      navigate(modalURLFromLocation({ ...location, pathname }, 'login'));
     } catch (error: unknown) {
       if (error instanceof Error) {
         if (error.message.includes('invalid param password')) {

--- a/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/EditPassword.tsx
@@ -32,24 +32,23 @@ const ResetPassword = ({ type }: { type?: 'add' }) => {
 
       return setSubmitting(false);
     }
-    let resetToken = resetPasswordTokenParam;
-    if (resetPasswordToken) {
-      resetToken = resetPasswordToken;
-    }
-    try {
-      if (user && !resetToken) {
-        await accountController.changePasswordWithOldPassword(oldPassword || '', password, passwordConfirmation);
-      } else {
-        if (!resetToken) {
-          setErrors({ form: t('reset.invalid_link') });
 
+    const resetToken = resetPasswordToken || resetPasswordTokenParam;
+
+    try {
+      if (resetToken) {
+        await accountController.changePasswordWithToken(emailParam || '', password, resetToken, passwordConfirmation);
+      } else {
+        if (!user) {
+          setErrors({ form: t('reset.invalid_link') });
           return setSubmitting(false);
         }
-        await accountController.changePasswordWithToken(emailParam || '', password, resetToken, passwordConfirmation);
+
+        await accountController.changePasswordWithOldPassword(oldPassword || '', password, passwordConfirmation);
+        await accountController.logout();
       }
 
       announce(t('reset.password_reset_success'), 'success');
-      await accountController.logout();
       navigate(modalURLFromLocation(location, 'login'));
     } catch (error: unknown) {
       if (error instanceof Error) {

--- a/platforms/web/src/services/LocalStorageService.ts
+++ b/platforms/web/src/services/LocalStorageService.ts
@@ -10,8 +10,8 @@ export class LocalStorageService extends StorageService {
     this.prefix = prefix;
   }
 
-  getStorageKey(key: string) {
-    return `${this.prefix}.${key}`;
+  getStorageKey(key: string, usePrefix = true) {
+    return usePrefix ? `${this.prefix}.${key}` : key;
   }
 
   async getItem(key: string, parse: boolean, usePrefix = true) {
@@ -32,9 +32,9 @@ export class LocalStorageService extends StorageService {
     }
   }
 
-  async removeItem(key: string) {
+  async removeItem(key: string, usePrefix = true) {
     try {
-      window.localStorage.removeItem(this.getStorageKey(key));
+      window.localStorage.removeItem(this.getStorageKey(key, usePrefix));
     } catch (error: unknown) {
       logError('LocalStorageService', 'Failed to remove localStorage entry', { error });
     }


### PR DESCRIPTION
## Description

<!-- Describe the proposed solution/fix/feature in this pull request here. -->

This PR solves [OWA-99](https://jwplayer.atlassian.net/browse/OWA-99).

Whenever a password change or reset is requested and finished successfully, we're performing a logout request afterwards. This is fine is the password change is requested by a logged in user. But the logout request should NOT be performed when a logged out user has forgotten their password and starts a process for resetting their password. With changes in this PR the logout request will only be made if there is a user logged in.

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [ ] UX tested
- [ ] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code


[OWA-99]: https://jwplayer.atlassian.net/browse/OWA-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ