### PR TITLE
OWA-102: fix modal closing behavior

### DIFF
--- a/packages/ui-react/src/components/Modal/Modal.tsx
+++ b/packages/ui-react/src/components/Modal/Modal.tsx
@@ -40,6 +40,7 @@ const Modal: React.FC<Props> = ({
   ...ariaAttributes
 }: Props) => {
   const modalRef = useRef<HTMLDialogElement>() as React.MutableRefObject<HTMLDialogElement>;
+  const mouseEventTargetsPairRef = useRef<Record<'downTarget' | 'upTarget', HTMLElement | null>>({ downTarget: null, upTarget: null });
 
   const { handleOpen, handleClose } = useModal();
 
@@ -89,6 +90,15 @@ const Modal: React.FC<Props> = ({
   }, [openModalEvent, closeModalEvent, open]);
 
   const clickHandler: ReactEventHandler<HTMLDialogElement> = (event) => {
+    const {
+      current: { downTarget, upTarget },
+    } = mouseEventTargetsPairRef;
+
+    // modal should only close if both mousedown and mouseup are done on the overlay
+    if (downTarget !== upTarget) {
+      return;
+    }
+
     // Backdrop click (the dialog itself) will close the modal
     if (event.target === modalRef.current) {
       onClose?.();
@@ -102,6 +112,12 @@ const Modal: React.FC<Props> = ({
       onKeyDown={keyDownHandler}
       onClose={closeHandler}
       onClick={clickHandler}
+      onMouseDown={(e) => {
+        mouseEventTargetsPairRef.current.downTarget = e.target as HTMLElement;
+      }}
+      onMouseUp={(e) => {
+        mouseEventTargetsPairRef.current.upTarget = e.target as HTMLElement;
+      }}
       ref={modalRef}
       role={role}
       {...ariaAttributes}


### PR DESCRIPTION
## Description

When the modal is open, clicking and holding the mouse button down on any element and then moving the cursor to the overlay to release the mouse button causes the modal to close. This behavior is unintended. The modal should only close if the initial mousedown event originated on the overlay itself.

#### Acceptance Criteria
Correct Close Behavior

The modal closes only when the initial mousedown event starts on the overlay and the mouseup event is completed on the overlay.

#### Prevent Unintended Close

If the mousedown event begins on any interactive or non-overlay element within the modal and the cursor is dragged to the overlay before releasing, the modal should not close.

#### Interaction on Modal Content

All interactions within modal elements (e.g., buttons, text fields, dropdowns) are unaffected, and the modal remains open regardless of cursor movement or mouse button release outside these elements.

#### Overlay-Specific Closing

The overlay retains its intended functionality: Clicking directly on the overlay (both mousedown and mouseup) closes the modal.

This PR solves [OWA-102](https://jwplayer.atlassian.net/browse/OWA-102)

### Steps completed:

<!-- Check all completed steps so we know  -->

According to our definition of done, I have completed the following steps:

- [x] Acceptance criteria met
- [ ] Unit tests added
- [ ] Docs updated (including config and env variables)
- [ ] Translations added
- [x] UX tested
- [ ] Browsers / platforms tested
- [x] Rebased & ready to merge without conflicts
- [x] Reviewed own code


[OWA-102]: https://jwplayer.atlassian.net/browse/OWA-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ