### PR TITLE
Feat / Replace hard-coded English string with translatable strings

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,9 +1,11 @@
-export const formatDurationTag = (seconds: number) => {
+import type { DurationAbbreviation } from '../../types/i18n';
+
+export const formatDurationTag = (seconds: number, { minutesAbbreviation }: Pick<DurationAbbreviation, 'minutesAbbreviation'>) => {
   if (!seconds) return '';
 
   const minutes = Math.ceil(seconds / 60);
 
-  return `${minutes} min`;
+  return `${minutes} ${minutesAbbreviation}`;
 };
 
 /**
@@ -16,14 +18,14 @@ export const formatDurationTag = (seconds: number) => {
  * @returns string, such as '2hrs 24min' or '31min'
  */
 
-export const formatDuration = (duration: number) => {
+export const formatDuration = (duration: number, { hoursAbbreviation, minutesAbbreviation }: DurationAbbreviation) => {
   if (!duration) return '';
 
   const hours = Math.floor(duration / 3600);
   const minutes = Math.round((duration - hours * 3600) / 60);
 
-  const hoursString = hours ? `${hours}hrs` : '';
-  const minutesString = minutes ? `${minutes}min` : '';
+  const hoursString = hours ? `${hours}${hoursAbbreviation}` : '';
+  const minutesString = minutes ? `${minutes}${minutesAbbreviation}` : '';
 
   return [hoursString, minutesString].filter(Boolean).join(' ');
 };

--- a/packages/common/src/utils/metadata.ts
+++ b/packages/common/src/utils/metadata.ts
@@ -1,14 +1,15 @@
 import type { Playlist, PlaylistItem } from '../../types/playlist';
+import type { DurationAbbreviation } from '../../types/i18n';
 
 import { formatDuration, formatVideoSchedule } from './formatting';
 
-export const createVideoMetadata = (media: PlaylistItem, episodesLabel?: string) => {
+export const createVideoMetadata = (media: PlaylistItem, i18n: DurationAbbreviation & { episodesLabel?: string }) => {
   const metaData = [];
-  const duration = formatDuration(media.duration);
+  const duration = formatDuration(media.duration, i18n);
 
   if (media.pubdate) metaData.push(String(new Date(media.pubdate * 1000).getFullYear()));
-  if (!episodesLabel && duration) metaData.push(duration);
-  if (episodesLabel) metaData.push(episodesLabel);
+  if (!i18n.episodesLabel && duration) metaData.push(duration);
+  if (i18n.episodesLabel) metaData.push(i18n.episodesLabel);
   if (media.genre) metaData.push(media.genre);
   if (media.rating) metaData.push(media.rating);
 
@@ -23,10 +24,10 @@ export const createPlaylistMetadata = (playlist: Playlist, episodesLabel?: strin
 
   return metaData;
 };
-export const createLiveEventMetadata = (media: PlaylistItem, locale: string) => {
+export const createLiveEventMetadata = (media: PlaylistItem, locale: string, i18n: DurationAbbreviation) => {
   const metaData = [];
   const scheduled = formatVideoSchedule(locale, media.scheduledStart, media.scheduledEnd);
-  const duration = formatDuration(media.duration);
+  const duration = formatDuration(media.duration, i18n);
 
   if (scheduled) metaData.push(scheduled);
   if (duration) metaData.push(duration);

--- a/packages/common/types/i18n.ts
+++ b/packages/common/types/i18n.ts
@@ -2,3 +2,8 @@ export type LanguageDefinition = {
   code: string;
   displayName: string;
 };
+
+export type DurationAbbreviation = {
+  hoursAbbreviation: string;
+  minutesAbbreviation: string;
+};

--- a/packages/ui-react/src/components/Card/Card.tsx
+++ b/packages/ui-react/src/components/Card/Card.tsx
@@ -81,7 +81,7 @@ function Card({
     } else if (episodeNumber) {
       return <div className={styles.tag}>{formatSeriesMetaString(seasonNumber, episodeNumber)}</div>;
     } else if (duration) {
-      return <div className={styles.tag}>{formatDurationTag(duration)}</div>;
+      return <div className={styles.tag}>{formatDurationTag(duration, { minutesAbbreviation: t('common:abbreviation.minutes') })}</div>;
     } else if (isLive) {
       return <div className={classNames(styles.tag, styles.live)}>{t('live')}</div>;
     } else if (isScheduled) {

--- a/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/ui-react/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`<Card> > should render anchor tag 1`] = `
           <div
             class="_tag_d75732"
           >
-            2 min
+            2 common:abbreviation.minutes
           </div>
         </div>
       </div>

--- a/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
+++ b/packages/ui-react/src/components/CardGrid/__snapshots__/CardGrid.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                   <div
                     class="_tag_d75732"
                   >
-                    4 min
+                    4 common:abbreviation.minutes
                   </div>
                 </div>
               </div>
@@ -90,7 +90,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                   <div
                     class="_tag_d75732"
                   >
-                    10 min
+                    10 common:abbreviation.minutes
                   </div>
                 </div>
               </div>
@@ -132,7 +132,7 @@ exports[`<CardGrid> > renders and matches snapshot 1`] = `
                   <div
                     class="_tag_d75732"
                   >
-                    11 min
+                    11 common:abbreviation.minutes
                   </div>
                 </div>
               </div>

--- a/packages/ui-react/src/components/CheckoutForm/__snapshots__/CheckoutForm.test.tsx.snap
+++ b/packages/ui-react/src/components/CheckoutForm/__snapshots__/CheckoutForm.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`<CheckoutForm> > renders and matches snapshot 1`] = `
                 class="_label_86f2f5"
                 for="text-field_1235_cardnumber"
               >
-                Card number
+                payment.credit_card_number
                 <span
                   aria-hidden="true"
                 >
@@ -163,7 +163,7 @@ exports[`<CheckoutForm> > renders and matches snapshot 1`] = `
                   class="_label_86f2f5"
                   for="text-field_1235_cardexpiry"
                 >
-                  Expiry date
+                  payment.credit_card_expiry_date
                   <span
                     aria-hidden="true"
                   >

--- a/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
+++ b/packages/ui-react/src/components/Favorites/__snapshots__/Favorites.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      2 min
+                      2 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -116,7 +116,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      3 min
+                      3 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -163,7 +163,7 @@ exports[`<Favorites> > renders and matches snapshot 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      13 min
+                      13 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>

--- a/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
+++ b/packages/ui-react/src/components/Shelf/__snapshots__/Shelf.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      21 min
+                      21 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -100,7 +100,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      1 min
+                      1 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -136,7 +136,7 @@ exports[`Shelf Component tests > Featured shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      1 min
+                      1 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -246,7 +246,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      1 min
+                      1 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -286,7 +286,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      1 min
+                      1 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -326,7 +326,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      1 min
+                      1 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>
@@ -366,7 +366,7 @@ exports[`Shelf Component tests > Regular shelf 1`] = `
                     <div
                       class="_tag_d75732"
                     >
-                      21 min
+                      21 common:abbreviation.minutes
                     </div>
                   </div>
                 </div>

--- a/packages/ui-react/src/components/VideoListItem/VideoListItem.tsx
+++ b/packages/ui-react/src/components/VideoListItem/VideoListItem.tsx
@@ -50,7 +50,7 @@ function VideoListItem({ onHover, progress, activeLabel, item, url, loading = fa
     } else if (episodeNumber) {
       return <div className={styles.tag}>{formatSeriesMetaString(seasonNumber, episodeNumber)}</div>;
     } else if (duration) {
-      return <div className={styles.tag}>{formatDurationTag(duration)}</div>;
+      return <div className={styles.tag}>{formatDurationTag(duration, { minutesAbbreviation: t('common:abbreviation.minutes') })}</div>;
     } else if (isLive) {
       return <div className={classNames(styles.tag, styles.live)}>{t('live')}</div>;
     } else if (isScheduled) {

--- a/packages/ui-react/src/components/form-fields/CreditCardExpiryField/CreditCardExpiryField.tsx
+++ b/packages/ui-react/src/components/form-fields/CreditCardExpiryField/CreditCardExpiryField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import TextField from '../TextField/TextField';
 
@@ -10,6 +11,7 @@ type Props = {
 };
 
 const CreditCardExpiryField: React.FC<Props> = ({ value, onChange, error, ...props }: Props) => {
+  const { t } = useTranslation('account');
   const formatExpirationDate: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     let clearValue = e.target.value.replace(/\D+/g, '');
 
@@ -34,7 +36,7 @@ const CreditCardExpiryField: React.FC<Props> = ({ value, onChange, error, ...pro
   };
   return (
     <TextField
-      label={`Expiry date`}
+      label={t('payment.credit_card_expiry_date')}
       {...props}
       name="cardExpiry"
       className="directPostExpiryDate"

--- a/packages/ui-react/src/components/form-fields/CreditCardExpiryField/__snapshots__/CreditCardExpiryField.test.tsx.snap
+++ b/packages/ui-react/src/components/form-fields/CreditCardExpiryField/__snapshots__/CreditCardExpiryField.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<CreditCardExpiryField> > renders and matches snapshot 1`] = `
       class="_label_86f2f5"
       for="text-field_1235_cardexpiry"
     >
-      Expiry date
+      payment.credit_card_expiry_date
       <span
         aria-hidden="true"
       >

--- a/packages/ui-react/src/components/form-fields/CreditCardNumberField/CreditCardNumberField.tsx
+++ b/packages/ui-react/src/components/form-fields/CreditCardNumberField/CreditCardNumberField.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import Payment from 'payment';
 
 import TextField from '../TextField/TextField';
@@ -25,6 +26,7 @@ const cardIssuers: { [key: string]: string } = {
 };
 
 const CreditCardNumberField: React.FC<Props> = ({ value, error, onChange, onBlur, ...props }: Props) => {
+  const { t } = useTranslation('account');
   const [cardIssuer, setCardIssuer] = useState<JSX.Element | null>(null);
 
   const formatCreditCardNumber: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -62,7 +64,7 @@ const CreditCardNumberField: React.FC<Props> = ({ value, error, onChange, onBlur
     <TextField
       value={value}
       name="cardNumber"
-      label={`Card number`}
+      label={t('payment.credit_card_number')}
       className="directPostCreditCardNumber"
       onChange={formatCreditCardNumber}
       onBlur={onBlur}

--- a/packages/ui-react/src/components/form-fields/CreditCardNumberField/__snapshots__/CreditCardNumberField.test.tsx.snap
+++ b/packages/ui-react/src/components/form-fields/CreditCardNumberField/__snapshots__/CreditCardNumberField.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<CreditCardNumberField> > renders and matches snapshot 1`] = `
       class="_label_86f2f5"
       for="text-field_1235_cardnumber"
     >
-      Card number
+      payment.credit_card_number
       <span
         aria-hidden="true"
       >

--- a/packages/ui-react/src/containers/HeaderSearch/HeaderSearch.tsx
+++ b/packages/ui-react/src/containers/HeaderSearch/HeaderSearch.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { shallow } from '@jwp/ott-common/src/utils/compare';
@@ -15,6 +16,7 @@ import HeaderActionButton from '../../components/Header/HeaderActionButton';
 import styles from './HeaderSearch.module.scss';
 
 const HeaderSearch = () => {
+  const { t } = useTranslation('menu');
   const location = useLocation();
   const searchInputRef = useRef<HTMLInputElement>(null) as React.MutableRefObject<HTMLInputElement>;
 
@@ -68,12 +70,12 @@ const HeaderSearch = () => {
         inputRef={searchInputRef}
         onClose={closeSearchButtonClickHandler}
       />
-      <HeaderActionButton aria-label="Close search" onClick={closeSearchButtonClickHandler}>
+      <HeaderActionButton aria-label={t('search_close')} onClick={closeSearchButtonClickHandler}>
         <Icon icon={CloseIcon} />
       </HeaderActionButton>
     </div>
   ) : (
-    <HeaderActionButton aria-label="Open search" onClick={searchButtonClickHandler}>
+    <HeaderActionButton aria-label={t('search_open')} onClick={searchButtonClickHandler}>
       <Icon icon={SearchIcon} />
     </HeaderActionButton>
   );

--- a/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
+++ b/packages/ui-react/src/pages/Home/__snapshots__/Home.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               class="_tag_d75732"
                             >
-                              6 min
+                              6 common:abbreviation.minutes
                             </div>
                           </div>
                         </div>
@@ -113,7 +113,7 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               class="_tag_d75732"
                             >
-                              6 min
+                              6 common:abbreviation.minutes
                             </div>
                           </div>
                         </div>
@@ -192,7 +192,7 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               class="_tag_d75732"
                             >
-                              6 min
+                              6 common:abbreviation.minutes
                             </div>
                           </div>
                         </div>
@@ -232,7 +232,7 @@ exports[`Home Component tests > Home test 1`] = `
                             <div
                               class="_tag_d75732"
                             >
-                              6 min
+                              6 common:abbreviation.minutes
                             </div>
                           </div>
                         </div>

--- a/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
+++ b/packages/ui-react/src/pages/LegacySeries/LegacySeries.tsx
@@ -119,7 +119,13 @@ const LegacySeries = () => {
   const backgroundImage = (selectedItem.backgroundImage as string) || undefined;
 
   const primaryMetadata = episode ? (
-    <VideoMetaData attributes={createVideoMetadata(episode, t('video:total_episodes', { count: seriesPlaylist?.playlist?.length }))} />
+    <VideoMetaData
+      attributes={createVideoMetadata(episode, {
+        episodesLabel: t('video:total_episodes', { count: seriesPlaylist?.playlist?.length }),
+        hoursAbbreviation: t('common:abbreviation.hours'),
+        minutesAbbreviation: t('common:abbreviation.minutes'),
+      })}
+    />
   ) : (
     <VideoMetaData attributes={createPlaylistMetadata(seriesPlaylist, t('video:total_episodes', { count: seriesPlaylist?.playlist?.length }))} />
   );

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaEvent/MediaEvent.tsx
@@ -33,7 +33,7 @@ import VideoMetaData from '../../../../components/VideoMetaData/VideoMetaData';
 import Icon from '../../../../components/Icon/Icon';
 
 const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) => {
-  const { t, i18n } = useTranslation('video');
+  const { t, i18n } = useTranslation(['video', 'common']);
 
   const [playTrailer, setPlayTrailer] = useState<boolean>(false);
   const breakpoint = useBreakpoint();
@@ -96,7 +96,12 @@ const MediaEvent: ScreenComponent<PlaylistItem> = ({ data: media, isLoading }) =
   const primaryMetadata = (
     <>
       <StatusIcon mediaStatus={media.mediaStatus} />
-      <VideoMetaData attributes={createLiveEventMetadata(media, i18n.language)} />
+      <VideoMetaData
+        attributes={createLiveEventMetadata(media, i18n.language, {
+          minutesAbbreviation: t('common:abbreviation.minutes'),
+          hoursAbbreviation: t('common:abbreviation.hours'),
+        })}
+      />
     </>
   );
 

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaMovie/MediaMovie.tsx
@@ -81,7 +81,11 @@ const MediaMovie: ScreenComponent<PlaylistItem> = ({ data, isLoading }) => {
   const pageTitle = `${data.title} - ${siteName}`;
   const canonicalUrl = data ? `${env.APP_PUBLIC_URL}${mediaURL({ id: data.mediaid, title: data.title })}` : window.location.href;
 
-  const primaryMetadata = <VideoMetaData attributes={createVideoMetadata(data)} />;
+  const primaryMetadata = (
+    <VideoMetaData
+      attributes={createVideoMetadata(data, { hoursAbbreviation: t('common:abbreviation.hours'), minutesAbbreviation: t('common:abbreviation.minutes') })}
+    />
+  );
   const shareButton = <ShareButton title={data.title} description={data.description} url={canonicalUrl} />;
   const startWatchingButton = (
     <StartWatchingButton

--- a/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/mediaScreens/MediaSeries/MediaSeries.tsx
@@ -196,7 +196,15 @@ const MediaSeries: ScreenComponent<PlaylistItem> = ({ data: seriesMedia }) => {
   const pageTitle = `${selectedItem.title} - ${siteName}`;
   const canonicalUrl = `${env.APP_PUBLIC_URL}${mediaURL({ id: seriesMedia.mediaid, title: seriesMedia.title, episodeId: episode?.mediaid })}`;
 
-  const primaryMetadata = <VideoMetaData attributes={createVideoMetadata(selectedItem, t('video:total_episodes', { count: series.episode_count }))} />;
+  const primaryMetadata = (
+    <VideoMetaData
+      attributes={createVideoMetadata(selectedItem, {
+        episodesLabel: t('video:total_episodes', { count: series.episode_count }),
+        hoursAbbreviation: t('common:abbreviation.hours'),
+        minutesAbbreviation: t('common:abbreviation.minutes'),
+      })}
+    />
+  );
   const secondaryMetadata = episodeMetadata && episode && (
     <>
       <strong>{formatSeriesMetaString(episodeMetadata.seasonNumber, episodeMetadata.episodeNumber)}</strong> - {episode.title}

--- a/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
+++ b/packages/ui-react/src/pages/ScreenRouting/playlistScreens/PlaylistLiveChannels/PlaylistLiveChannels.tsx
@@ -88,7 +88,7 @@ const PlaylistLiveChannels: ScreenComponent<Playlist> = ({ data: { feedid, playl
     const startTime = new Date(program.startTime);
     const endTime = new Date(program.endTime);
     const durationInSeconds = differenceInSeconds(endTime, startTime);
-    const duration = formatDurationTag(durationInSeconds);
+    const duration = formatDurationTag(durationInSeconds, { minutesAbbreviation: t('common:abbreviation.minutes') });
     const attributes = [t('on_channel', { name: channel.title }), duration].filter(Boolean);
 
     return (

--- a/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
+++ b/packages/ui-react/src/pages/User/__snapshots__/User.test.tsx.snap
@@ -455,7 +455,7 @@ exports[`User Component tests > Favorites Page 1`] = `
                         <div
                           class="_tag_d75732"
                         >
-                          1 min
+                          1 common:abbreviation.minutes
                         </div>
                       </div>
                     </div>
@@ -497,7 +497,7 @@ exports[`User Component tests > Favorites Page 1`] = `
                         <div
                           class="_tag_d75732"
                         >
-                          100 min
+                          100 common:abbreviation.minutes
                         </div>
                       </div>
                     </div>
@@ -539,7 +539,7 @@ exports[`User Component tests > Favorites Page 1`] = `
                         <div
                           class="_tag_d75732"
                         >
-                          11 min
+                          11 common:abbreviation.minutes
                         </div>
                       </div>
                     </div>

--- a/platforms/web/public/locales/en/account.json
+++ b/platforms/web/public/locales/en/account.json
@@ -98,6 +98,8 @@
   "payment": {
     "back_to_profile": "Back to profile",
     "credit_card": "Credit card",
+    "credit_card_expiry_date": "Expiry date",
+    "credit_card_number": "Card number",
     "edit_card": "Edit card",
     "longer_than_usual": "The payment is taking longer than usual. Please try again later.",
     "paypal": "PayPal",

--- a/platforms/web/public/locales/en/common.json
+++ b/platforms/web/public/locales/en/common.json
@@ -1,4 +1,8 @@
 {
+  "abbreviation": {
+    "hours": "hrs",
+    "minutes": "min"
+  },
   "alert": {
     "close": "Close",
     "success": "Success",

--- a/platforms/web/public/locales/en/menu.json
+++ b/platforms/web/public/locales/en/menu.json
@@ -4,6 +4,8 @@
   "logo_alt": "Homepage of {{siteName}}",
   "open_menu": "Open menu",
   "open_user_menu": "Open user menu",
+  "search_close": "Close search",
+  "search_open": "Open search",
   "sign_in": "Sign in",
   "sign_up": "Sign up",
   "skip_to_content": "Skip to content"

--- a/platforms/web/public/locales/es/account.json
+++ b/platforms/web/public/locales/es/account.json
@@ -104,6 +104,8 @@
   "payment": {
     "back_to_profile": "Volver al perfil",
     "credit_card": "Tarjeta de crédito",
+    "credit_card_expiry_date": "Fecha de caducidad",
+    "credit_card_number": "Número de tarjeta",
     "edit_card": "Editar tarjeta",
     "longer_than_usual": "El pago está tardando más de lo habitual. Por favor, inténtelo de nuevo más tarde.",
     "paypal": "PayPal",

--- a/platforms/web/public/locales/es/common.json
+++ b/platforms/web/public/locales/es/common.json
@@ -1,4 +1,8 @@
 {
+  "abbreviation": {
+    "hours": "h",
+    "minutes": "min"
+  },
   "alert": {
     "close": "Cerrar",
     "success": "Éxito",

--- a/platforms/web/public/locales/es/menu.json
+++ b/platforms/web/public/locales/es/menu.json
@@ -4,6 +4,8 @@
   "logo_alt": "Página de inicio de {{siteName}}",
   "open_menu": "Abrir menú",
   "open_user_menu": "Abrir menú de usuario",
+  "search_close": "Cerrar búsqueda",
+  "search_open": "Abrir búsqueda",
   "sign_in": "Iniciar sesión",
   "sign_up": "Registrarse",
   "skip_to_content": "Saltar al contenido"


### PR DESCRIPTION
This change adds missing translations for the OTT platform. We believe that there are no hard-coded English labels present anymore in the code. This means we 100% of the text occurrences can be translated.

Adds:
- Translations for credit card (number + expiry date)
- Abbreviations for hours and minutes
- Translated open/close aria label for search

Let me know if there is still a hard-coded English string anywhere.

Ticket: [OTT-2762](https://videodock.atlassian.net/browse/OTT-2762)