### PR TITLE
Fix / Correct sidebar translation key

### DIFF
--- a/packages/ui-react/src/containers/SidebarContainer/SidebarContainer.tsx
+++ b/packages/ui-react/src/containers/SidebarContainer/SidebarContainer.tsx
@@ -51,7 +51,7 @@ const SidebarUserActions = ({
 
 const SidebarContainer = () => {
   const { t } = useTranslation('common');
-  const translationKey = useTranslationKey('title');
+  const translationKey = useTranslationKey('label');
   const navigate = useNavigate();
   const location = useLocation();
 


### PR DESCRIPTION
I made an copy/paste error while writing `useTranslationKey`. This fixes showing the correct translation in the sidebar menu.