### PR TITLE
Chore / payments e2e tests stability improvements

### DIFF
--- a/packages/common/src/services/integrations/jwp/JWPSubscriptionService.ts
+++ b/packages/common/src/services/integrations/jwp/JWPSubscriptionService.ts
@@ -50,7 +50,7 @@ export default class JWPSubscriptionService extends SubscriptionService {
   protected readonly accountService: JWPAccountService;
   protected readonly apiService: JWPAPIService;
 
-  constructor(@named('JWP') accountService: AccountService, @inject(JWPAPIService) apiService: JWPAPIService) {
+  constructor(@named('JWP') @inject(AccountService) accountService: AccountService, @inject(JWPAPIService) apiService: JWPAPIService) {
     super();
 
     this.accountService = accountService as JWPAccountService;

--- a/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
+++ b/packages/ui-react/src/containers/AccountModal/forms/Checkout.tsx
@@ -113,9 +113,9 @@ const Checkout = () => {
 
   const paymentMethod = paymentMethods?.find((method) => method.id === parseInt(paymentMethodId));
   const noPaymentRequired = !order?.requiredPaymentDetails;
-  const isStripePayment = paymentMethod?.methodName === 'card' && paymentMethod?.provider === 'stripe';
-  const isAdyenPayment = paymentMethod?.methodName === 'card' && paymentMethod?.paymentGateway === 'adyen';
-  const isPayPalPayment = paymentMethod?.methodName === 'paypal';
+  const isStripePayment = !noPaymentRequired && paymentMethod?.methodName === 'card' && paymentMethod?.provider === 'stripe';
+  const isAdyenPayment = !noPaymentRequired && paymentMethod?.methodName === 'card' && paymentMethod?.paymentGateway === 'adyen';
+  const isPayPalPayment = !noPaymentRequired && paymentMethod?.methodName === 'paypal';
 
   return (
     <CheckoutForm

--- a/platforms/web/test-e2e/utils/payments.ts
+++ b/platforms/web/test-e2e/utils/payments.ts
@@ -32,7 +32,7 @@ export function formatDate(date: Date) {
 export async function finishSubscription(I: CodeceptJS.I) {
   I.click('Continue');
   I.waitForText(`Welcome to JW OTT Web App (SVOD)`, longTimeout);
-  I.waitForText(`Thank you for subscribing to JW OTT Web App (SVOD). Please enjoy all our content.`);
+  I.waitForText(`Thank you for subscribing to JW OTT Web App (SVOD). Please enjoy all our content.`, longTimeout);
 
   I.click('Start watching');
 }

--- a/platforms/web/test-e2e/utils/steps_file.ts
+++ b/platforms/web/test-e2e/utils/steps_file.ts
@@ -4,7 +4,7 @@ import { TestConfig } from '@jwp/ott-testing/constants';
 
 import { randomDate } from './randomizers';
 
-import constants, { makeShelfXpath, normalTimeout, ShelfId } from '#utils/constants';
+import constants, { longTimeout, makeShelfXpath, normalTimeout, ShelfId } from '#utils/constants';
 import passwordUtils, { LoginContext } from '#utils/password_utils';
 
 const configFileQueryKey = 'app-config';
@@ -235,7 +235,7 @@ const stepsObj = {
     });
   },
   waitForLoaderDone: function (this: CodeceptJS.I) {
-    this.dontSeeElement(loaderElement);
+    this.limitTime(longTimeout).dontSeeElement(loaderElement);
   },
   openSignUpModal: async function (this: CodeceptJS.I) {
     const { isMobile } = await this.openSignInMenu();


### PR DESCRIPTION
## Description

I found that the payments e2e tests were failing many times and while looking into this I found some problems in the tests and a bug in the payments form. These fixes should be rebased to #656 and #657.

- The loading times can vary a lot and the biggest culprit was the timeout of `I.waitForLoaderDone()`, so I increased the timeout for this test specifically
- The SubscriptionService couldn't be injected due to an error in the test build caused by a missing `@inject()` annotation
- The Checkout form was showing the Adyen card payment form while no payment was needed. This caused the coupon test to fail
