### PR TITLE
Fix / crash when personal shelf data is not valid

### DIFF
--- a/packages/common/src/services/WatchHistoryService.ts
+++ b/packages/common/src/services/WatchHistoryService.ts
@@ -7,7 +7,7 @@ import type { Customer } from '../../types/account';
 import { getNamedModule } from '../modules/container';
 import { INTEGRATION_TYPE } from '../modules/types';
 import { MAX_WATCHLIST_ITEMS_COUNT } from '../constants';
-import { logError } from '../logger';
+import { logDebug, logError } from '../logger';
 
 import ApiService from './ApiService';
 import StorageService from './StorageService';
@@ -18,11 +18,12 @@ const schema = array(
     mediaid: string(),
     progress: number(),
   }),
-);
+).nullable();
 
 @injectable()
 export default class WatchHistoryService {
   protected PERSIST_KEY_WATCH_HISTORY = 'history';
+  protected hasErrors = false;
 
   protected readonly apiService;
   protected readonly storageService;
@@ -40,7 +41,11 @@ export default class WatchHistoryService {
 
   // Retrieve watch history media items info using a provided watch list
   protected getWatchHistoryItems = async (continueWatchingList: string, ids: string[], language?: string): Promise<Record<string, PlaylistItem>> => {
-    const watchHistoryItems = await this.apiService.getMediaByWatchlist({ playlistId: continueWatchingList, mediaIds: ids, language });
+    const watchHistoryItems = await this.apiService.getMediaByWatchlist({
+      playlistId: continueWatchingList,
+      mediaIds: ids,
+      language,
+    });
     const watchHistoryItemsDict = Object.fromEntries((watchHistoryItems || []).map((item) => [item.mediaid, item]));
 
     return watchHistoryItemsDict;
@@ -57,7 +62,11 @@ export default class WatchHistoryService {
       .map((key) => mediaWithSeries?.[key]?.[0]?.series_id)
       .filter(Boolean) as string[];
     const uniqueSerieIds = [...new Set(seriesIds)];
-    const seriesItems = await this.apiService.getMediaByWatchlist({ playlistId: continueWatchingList, mediaIds: uniqueSerieIds, language });
+    const seriesItems = await this.apiService.getMediaByWatchlist({
+      playlistId: continueWatchingList,
+      mediaIds: uniqueSerieIds,
+      language,
+    });
     const seriesItemsDict = Object.keys(mediaWithSeries || {}).reduce((acc, key) => {
       const seriesItemId = mediaWithSeries?.[key]?.[0]?.series_id;
       if (seriesItemId) {
@@ -70,8 +79,13 @@ export default class WatchHistoryService {
   };
 
   protected validateWatchHistory(history: unknown) {
-    if (history && schema.validateSync(history)) {
-      return history as SerializedWatchHistoryItem[];
+    try {
+      if (history && schema.validateSync(history)) {
+        return history as SerializedWatchHistoryItem[];
+      }
+    } catch (error: unknown) {
+      this.hasErrors = true;
+      logError('WatchHistoryService', 'Failed to validate watch history', { error });
     }
 
     return [];
@@ -127,6 +141,10 @@ export default class WatchHistoryService {
     }));
 
   persistWatchHistory = async (watchHistory: WatchHistoryItem[], user: Customer | null) => {
+    if (this.hasErrors) {
+      return logDebug('WatchHistoryService', 'persist prevented due to an encountered problem while validating the stored watch history');
+    }
+
     if (user) {
       await this.accountService?.updateWatchHistory({
         history: this.serializeWatchHistory(watchHistory),


### PR DESCRIPTION
## Description

This PR fixes two problems with the personal shelves (favorites & watch history) when we try to load an account with invalid data.

The first problem is that the web app crashes while validating the data. This is a bit to aggressive and can be prevented.

When a validation error occurs, it basically means we can't guarantee that the integrity or the origin of the data. So instead of overwriting the data, we now prevent saving the data so we don't accidentally reset the favorites or watch history list.

When this happens, the user isn't notified, but we log an error to the console. We can improve this in the future to show a message to the user in this scenario.
