### PR TITLE
Fix / add array at polyfill

### DIFF
--- a/platforms/web/src/polyfills.ts
+++ b/platforms/web/src/polyfills.ts
@@ -1,2 +1,3 @@
 import 'core-js/es/array/flat-map';
+import 'core-js/es/array/at';
 import 'core-js/es/object/from-entries';


### PR DESCRIPTION
## Description

In the maintenance update #656, the marked package was updated. While testing this on TV platforms or older Android devices, we ran into a crash caused by this [upgrade](https://github.com/markedjs/marked/issues/3546). The crash was caused by marked using `Array#at` which isn't transpiled for browser usage.

The easiest fix was to add the polyfill...


