### PR TITLE
Feat / styling changes

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -21,7 +21,9 @@ export const VideoProgressMinMax = {
   Max: 0.95,
 };
 
-export const PLAYLIST_LIMIT = 25;
+export const PLAYLIST_LIMIT = 25; // Recommended for performance
+
+export const PLAYLIST_LIMIT_MAX = 500; // JW API limit
 
 export const ADYEN_TEST_CLIENT_KEY = 'test_I4OFGUUCEVB5TI222AS3N2Y2LY6PJM3K';
 

--- a/packages/common/types/playlist.ts
+++ b/packages/common/types/playlist.ts
@@ -1,6 +1,6 @@
 import type { CustomParams } from './custom-params';
 
-export type GetPlaylistParams = { page_limit?: string; token?: string; search?: string; related_media_id?: string };
+export type GetPlaylistParams = { page_limit?: number; token?: string; search?: string; related_media_id?: string };
 
 export type Image = {
   src: string;

--- a/packages/hooks-react/src/usePlaylists.ts
+++ b/packages/hooks-react/src/usePlaylists.ts
@@ -18,8 +18,7 @@ type UsePlaylistResult = {
 
 const isPlaylistType = (type: AppContentType): type is AppMenuType => !PersonalShelves.some((pType) => pType === type);
 
-const usePlaylists = (content: Content[], rowsToLoad: number | undefined = undefined) => {
-  const page_limit = PLAYLIST_LIMIT.toString();
+const usePlaylists = (content: Content[], rowsToLoad: number | undefined = undefined, pageLimit: number | undefined = PLAYLIST_LIMIT) => {
   const queryClient = useQueryClient();
 
   const siteId = useConfigStore((state) => state.config.siteId);
@@ -39,7 +38,7 @@ const usePlaylists = (content: Content[], rowsToLoad: number | undefined = undef
           contentId,
           queryClient,
           usePlaceholderData: true,
-          params: { page_limit },
+          params: { page_limit: pageLimit },
           language: i18n.language,
         });
       }

--- a/packages/ui-react/src/components/Animation/Fade/Fade.tsx
+++ b/packages/ui-react/src/components/Animation/Fade/Fade.tsx
@@ -9,18 +9,29 @@ type Props = {
   delay?: number;
   children?: ReactNode;
   keepMounted?: boolean;
+  willChange?: boolean;
   onOpenAnimationEnd?: () => void;
   onCloseAnimationEnd?: () => void;
 };
 
-const Fade: React.FC<Props> = ({ className, open = true, duration = 250, delay = 0, onOpenAnimationEnd, onCloseAnimationEnd, keepMounted, children }) => {
+const Fade: React.FC<Props> = ({
+  className,
+  open = true,
+  duration = 250,
+  delay = 0,
+  willChange = true,
+  onOpenAnimationEnd,
+  onCloseAnimationEnd,
+  keepMounted,
+  children,
+}) => {
   const seconds = duration / 1000;
   const transition = `opacity ${seconds}s ease-in-out`;
 
   const createStyle = (status: Status): CSSProperties => ({
     transition,
     opacity: status === 'opening' || status === 'open' ? 1 : 0,
-    willChange: 'opacity',
+    willChange: willChange ? 'opacity' : undefined,
   });
 
   return (

--- a/packages/ui-react/src/components/Hero/Hero.module.scss
+++ b/packages/ui-react/src/components/Hero/Hero.module.scss
@@ -3,10 +3,13 @@
 @use '@jwp/ott-ui-react/src/styles/mixins/responsive';
 @use '@jwp/ott-ui-react/src/styles/mixins/typography';
 
+$max-height: 56vw; // To maintain acceptable aspect ratio's
+
 .hero {
   display: flex;
   max-width: 100vw;
-  min-height: 60vh;
+  height: 60vh;
+  max-height: $max-height; 
   padding: calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 2);
   font-family: var(--body-font-family), sans-serif;
   text-shadow: var(--body-text-shadow);
@@ -37,18 +40,17 @@
   top: 0;
   right: 0;
   z-index: -1;
-  width: 100vw;
-  height: 56.25vw;
-  max-height: 700px;
+  width: 80vw;
+  height: calc(60vh + variables.$header-height + 40px);
+  max-height: $max-height;
   object-fit: cover;
-  object-position: center 30%;
-  transition: opacity ease-out 0.3s;
+  object-position: 30% 30%;
 
-  -webkit-mask-image: radial-gradient(farthest-corner at 80% 30%, rgba(0, 0, 0, 0.8) 20%, rgb(0 0 0 / 21%) 45%, rgb(0 0 0 / 0%) 73%);
-  mask-image: radial-gradient(farthest-corner at 80% 30%, rgba(0, 0, 0, 0.8) 20%, rgb(0 0 0 / 21%) 45%, rgb(0 0 0 / 0%) 73%);
+  -webkit-mask-image: radial-gradient(123% 123% at 100% 0%, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
+  mask-image: radial-gradient(123% 123% at 100% 0%, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 60%, rgba(0, 0, 0, 0) 100%);
 }
 
-.posterFade {
+.posterFadeMenu {
   position: fixed;
   top: 0;
   right: 0;
@@ -58,25 +60,82 @@
   background: linear-gradient(0deg, transparent, var(--body-background-color, variables.$white));
 }
 
+.posterBackground {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: -1;
+  height: calc(60vh + variables.$header-height + 40px);
+  max-height: $max-height;
+  background: rgba(0,0,0,0.2);
+  -webkit-mask-image: linear-gradient(to bottom, var(--body-background-color, variables.$white) 85%, transparent 100%);
+  mask-image: linear-gradient(to bottom, var(--body-background-color, variables.$white) 85%, transparent 100%);
+}
+
+.posterFadeBottom {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: -1;
+  height: calc(60vh + variables.$header-height + 40px);
+  max-height: $max-height;
+  background: linear-gradient(to bottom, transparent 75%, var(--body-background-color, variables.$white) 100%);
+}
+
+.posterFadeLeft {
+  position: fixed;
+  top: 0;
+  right: 0;
+  z-index: -1;
+  width: 80vw;
+  height: calc(60vh + variables.$header-height + 40px);
+  max-height: $max-height;
+  background: linear-gradient(to left, transparent 60%, var(--body-background-color, variables.$white) 98%);
+}
+
 @include responsive.tablet-only() {
   .hero {
-    min-height: 50vh;
     padding: calc(variables.$base-spacing * 2);
+  }
+  
+  .hero, .poster, .posterBackground, .posterFadeBottom {
+    width: 100vw;
+    height: 75vh;
+    max-height: 75vw;
   }
 
   .info {
-    width: 70%;
+    width: 100%;
+    max-width: 100%;
   }
 
   .poster {
-    height: 80vw;
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 30%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 30%, transparent 100%);
+
+    max-height: $max-height;
+  }
+
+  .posterFadeBottom {
+    max-height: $max-height;
+  }
+
+  .posterFadeLeft {
+    display: none;
   }
 }
 
-@include responsive.mobile-only() {
+@include responsive.mobile-and-small-tablet() {
+  .hero, .poster, .posterBackground, .posterFadeBottom {
+    height: auto;
+    max-height: 100%;
+  }
+  
   .hero {
     min-height: 50vh;
-    padding: variables.$base-spacing;
+    padding: variables.$base-spacing calc(variables.$base-spacing * 2);
   }
 
   .info {
@@ -87,9 +146,33 @@
 
   .poster {
     width: 100vw;
-    height: 101.25vw;
+    height: $max-height;
+    object-position: center center;
 
-    -webkit-mask-image: linear-gradient(190deg, black, rgb(0 0 0 / 0.8) 40%, transparent 90%);
-    mask-image: linear-gradient(190deg, black, rgb(0 0 0 / 0.8) 40%, transparent 90%);
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 40%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 40%, transparent 100%);
+  }
+
+  .posterBackground {
+    height: calc(50vh + variables.$header-height + 40px);
+  }
+
+  .posterFadeLeft {
+    display: none;
+  }
+}
+
+
+@include responsive.mobile-only() {
+  .hero {
+    padding: variables.$base-spacing;
+  }
+
+  .poster {
+    left: 0;
+    height: 80vw;
+
+    -webkit-mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 55%, transparent 100%);
+    mask-image: linear-gradient(to bottom, black 0%, rgb(0 0 0 / 0.8) 55%, transparent 100%);
   }
 }

--- a/packages/ui-react/src/components/Hero/Hero.tsx
+++ b/packages/ui-react/src/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, type PropsWithChildren } from 'react';
+import classNames from 'classnames';
 
 import Image from '../Image/Image';
 import { useScrolledDown } from '../../hooks/useScrolledDown';
@@ -8,9 +9,10 @@ import styles from './Hero.module.scss';
 
 type Props = PropsWithChildren<{
   image?: string;
+  infoClassName?: string;
 }>;
 
-const Hero = ({ image, children }: Props) => {
+const Hero = ({ image, children, infoClassName }: Props) => {
   const alt = ''; // intentionally empty for a11y, because adjacent text alternative
   const posterRef = useRef<HTMLImageElement>(null);
   const breakpoint = useBreakpoint();
@@ -23,8 +25,11 @@ const Hero = ({ image, children }: Props) => {
   return (
     <div className={styles.hero}>
       <Image ref={posterRef} className={styles.poster} image={image} width={1280} alt={alt} />
-      <div className={styles.posterFade} />
-      <div className={styles.info}>{children}</div>
+      <div className={styles.posterFadeMenu} />
+      <div className={styles.posterFadeLeft} />
+      <div className={styles.posterFadeBottom} />
+      <div className={styles.posterBackground} />
+      <div className={classNames(styles.info, infoClassName)}>{children}</div>
     </div>
   );
 };

--- a/packages/ui-react/src/components/Hero/HeroDescription.tsx
+++ b/packages/ui-react/src/components/Hero/HeroDescription.tsx
@@ -9,7 +9,7 @@ import styles from './Hero.module.scss';
 
 const HeroDescription = ({ className, description, maximumLines = 8 }: { className?: string; description: string; maximumLines?: number }) => {
   const breakpoint: Breakpoint = useBreakpoint();
-  const isMobile = breakpoint === Breakpoint.xs;
+  const isMobile = breakpoint <= Breakpoint.sm;
 
   return isMobile ? (
     <CollapsibleText text={description} className={classNames(styles.description, className)} />

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.module.scss
@@ -8,9 +8,9 @@ $desktop-max-height: 700px;
 $desktop-min-height: 275px;
 
 $tablet-height: 70vw;
-$tablet-min-height: 550px;
+$tablet-min-height: 600px;
 
-$mobile-height: 70vh;
+$mobile-height: 150vw;
 $mobile-min-height: 450px;
 $mobile-landscape-height: 100vh;
 
@@ -97,7 +97,7 @@ $mobile-landscape-height: 100vh;
   width: 100%;
   height: 56.25vw;
   max-height: 700px;
-  background-color: var(--hero-shelf-background-color);
+  background-color: var(--hero-shelf-background-color, rgba(0,0,0,0.1));
 
   @include responsive.tablet-only() {
     height: $tablet-height;
@@ -107,7 +107,7 @@ $mobile-landscape-height: 100vh;
   @include responsive.mobile-only() {
     height: $mobile-height;
     min-height: $mobile-min-height;
-    margin-top: var(--safe-area-top, 0);
+    min-height: calc(450px + var(--safe-area-top))
   }
 
   @include responsive.mobile-only-landscape() {
@@ -126,35 +126,47 @@ $mobile-landscape-height: 100vh;
   height: 100%;
   justify-self: flex-end;
 
-  -webkit-mask-image: linear-gradient(to right, rgba(0, 0, 0, 0.05) 0, rgba(0, 0, 0, 0.35) 50%, rgba(0, 0, 0, 0.8) 80%);
-  mask-image: linear-gradient(to right, rgba(0, 0, 0, 0.05) 0, rgba(0, 0, 0, 0.35) 50%, rgba(0, 0, 0, 0.8) 80%);
+  -webkit-mask-image: linear-gradient(to right, rgba(0,0,0,0) 30%, rgba(0,0,0,0.2) 45%, rgba(0,0,0,1) 65%);
+  mask-image: linear-gradient(to right, rgba(0,0,0,0) 30%, rgba(0,0,0,0.2) 45%, rgba(0,0,0,1) 65%);
 
   > div {
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
-    left: 0;
+    left: 30%;
     overflow: hidden;
   }
 
   @include responsive.tablet-small-only() {
-    -webkit-mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 90%);
-    mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 90%);
+    -webkit-mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%,  rgba(0, 0, 0, 0.8) 50%, transparent 90%);
+    mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%,  rgba(0, 0, 0, 0.8) 50%, transparent 90%);
+
+    > div {
+      left: 0;
+    }
   }
 
   @include responsive.mobile-only() {
-    -webkit-mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 75%);
-    mask-image: linear-gradient(180deg, rgba(0,0,0,0.4) 0%, rgba(0, 0, 0, 1) 30%, transparent 75%);
+    -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5) 8%, rgb(0, 0, 0) 20%, rgb(0, 0, 0) 50%, transparent 75%);
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.5) 8%, rgb(0, 0, 0) 20%, rgb(0, 0, 0) 50%, transparent 75%);
+
+    > div {
+      left: 0;
+    }
   }
 }
 
 .image {
-  width: 100%;
+  width: 100%; 
   height: 100%;
   object-fit: cover;
-  object-position: center 20%;
+  
+  @include responsive.mobile-only() {
+    height: 120vw;
+  }
 }
+
 
 .fade {
   position: absolute;
@@ -163,6 +175,16 @@ $mobile-landscape-height: 100vh;
   bottom: 0;
   left: 0;
   background: linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 75%, rgba(0, 0, 0, 0.8) 95%, rgba(0, 0, 0, 1) 100%);
+}
+
+.fadeMenu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 120px;
+  background: linear-gradient(0deg, transparent, var(--body-background-color, variables.$white));
+  opacity: 0.5;
 }
 
 .fade2 {
@@ -222,6 +244,7 @@ $mobile-landscape-height: 100vh;
     max-width: 100%;
     padding: calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 2);
     gap: 20px;
+    text-align: center;
 
     > h2 {
       font-size: 24px;
@@ -244,7 +267,7 @@ $mobile-landscape-height: 100vh;
   }
 
   @include responsive.tablet-small-only() {
-    padding: 0 calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 3);
+    padding: 0 calc(variables.$base-spacing * 3) calc(variables.$base-spacing * 4) calc(variables.$base-spacing * 3);
 
     > div > button {
       width: auto !important; // Override StartWatchingButton fullWidth prop
@@ -252,8 +275,7 @@ $mobile-landscape-height: 100vh;
   }
 
   @include responsive.mobile-only() {
-    padding: calc(variables.$base-spacing * 3) variables.$base-spacing;
-    text-align: center;
+    padding: 0 variables.$base-spacing calc(variables.$base-spacing * 4);
   }
 }
 

--- a/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelf.tsx
@@ -82,20 +82,20 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
 
     if (side == 'left') {
       return {
-        transform: `scale(1.2) translateX(${animationPhase === 'init' ? backgroundX * -1 : 0}px)`,
-        opacity: isAnimating ? 1 : 0,
-        transition: isAnimating ? 'opacity 0.3s ease-out, transform 0.3s ease-out' : 'none',
+        transform: `translateX(${animationPhase === 'init' ? backgroundX * -1 : 0}px)`,
+        opacity: isAnimating && direction === 'left' ? 1 : 0,
+        transition: isAnimating && direction === 'left' ? 'opacity 0.3s ease-out, transform 0.3s ease-out' : 'none',
       };
     }
     if (side == 'right') {
       return {
-        transform: `scale(1.2) translateX(${animationPhase === 'init' ? backgroundX : 0}px)`,
-        opacity: isAnimating ? 1 : 0,
-        transition: isAnimating ? 'opacity 0.3s ease-out, transform 0.3s ease-out' : 'none',
+        transform: `translateX(${animationPhase === 'init' ? backgroundX : 0}px)`,
+        opacity: isAnimating && direction === 'right' ? 1 : 0,
+        transition: isAnimating && direction === 'right' ? 'opacity 0.3s ease-out, transform 0.3s ease-out' : 'none',
       };
     }
     return {
-      transform: `scale(1.2) translateX(${isAnimating ? backgroundX * directionFactor : 0}px)`,
+      transform: `translateX(${isAnimating ? backgroundX * directionFactor : 0}px)`,
       opacity: isAnimating ? 0 : 1,
       transition: isAnimating ? `opacity ${isMobile ? 0.3 : 0.1}s ease-out, transform 0.3s ease-in` : 'none',
     };
@@ -105,7 +105,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
     if (side === 'left') {
       return {
         left: isSwiping || isSwipeAnimation ? '-100%' : animationPhase === 'init' ? -60 : 0,
-        opacity: isSwiping || isSwipeAnimation || isAnimating ? 1 : 0,
+        opacity: isSwiping || isSwipeAnimation || (isAnimating && direction === 'left') ? 1 : 0,
         transition: isAnimating ? 'opacity 0.2s ease-out, left 0.2s ease-out' : 'none',
         pointerEvents: 'none',
       };
@@ -113,7 +113,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
     if (side === 'right') {
       return {
         left: isSwiping || isSwipeAnimation ? '100%' : animationPhase === 'init' ? 60 : 0,
-        opacity: isSwiping || isSwipeAnimation || isAnimating ? 1 : 0,
+        opacity: isSwiping || isSwipeAnimation || (isAnimating && direction === 'right') ? 1 : 0,
         transition: isAnimating ? 'opacity 0.2s ease-out, left 0.2s ease-out' : 'none',
         pointerEvents: 'none',
       };
@@ -153,6 +153,7 @@ const HeroShelf = ({ playlist, loading = false, error = null }: Props) => {
           />
           <div className={styles.fade} />
         </div>
+        <div className={styles.fadeMenu} />
         <div className={styles.fade2} />
       </div>
       <button

--- a/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
+++ b/packages/ui-react/src/components/HeroShelf/HeroShelfMetadata.tsx
@@ -50,7 +50,7 @@ const HeroShelfMetadata = ({
       aria-hidden={hidden ? 'true' : undefined}
     >
       <h2 className={classNames(loading ? styles.loadingTitle : styles.title)}>{!loading && item?.title}</h2>
-      <TruncatedText text={item?.description} maximumLines={3} />
+      {item?.synopsis ? <div>{item.synopsis as string}</div> : <TruncatedText text={item?.description} maximumLines={3} />}
       <div>
         {showStartWatchingButton && <StartWatchingButton item={item} playUrl={mediaURL({ id: item.mediaid, title: item.title, playlistId, play: true })} />}
         <Button

--- a/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
+++ b/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
@@ -30,14 +30,24 @@ type Props = {
   className?: string;
   inline?: boolean;
   tag?: string;
+  headerOffset?: number;
 };
 
-const MarkdownComponent: React.FC<Props> = ({ markdownString, className, tag = 'div', inline = false }) => {
+const adjustHeaderLevels = (markdown: string, offset: number): string => {
+  const adjustedMarkdown = markdown.replace(/^(#{1,6})\s/gm, (_, hashes) => {
+    const newLevel = Math.min(hashes.length + offset, 6);
+    return `${'#'.repeat(newLevel)} `;
+  });
+  return adjustedMarkdown;
+};
+
+const MarkdownComponent: React.FC<Props> = ({ markdownString, className, tag = 'div', inline = false, headerOffset = 0 }) => {
   const sanitizedHTMLString = useMemo(() => {
-    const dirtyHTMLString = inline ? marked.parseInline(markdownString, { async: false }) : marked.parse(markdownString, { async: false });
+    const adjustedMarkdown = adjustHeaderLevels(markdownString, headerOffset);
+    const dirtyHTMLString = inline ? marked.parseInline(adjustedMarkdown, { async: false }) : marked.parse(adjustedMarkdown, { async: false });
 
     return DOMPurify.sanitize(dirtyHTMLString, { ADD_ATTR: ['target'] });
-  }, [inline, markdownString]);
+  }, [inline, markdownString, headerOffset]);
 
   return React.createElement(tag, {
     dangerouslySetInnerHTML: { __html: sanitizedHTMLString },

--- a/packages/ui-react/src/components/ShareButton/ShareButton.tsx
+++ b/packages/ui-react/src/components/ShareButton/ShareButton.tsx
@@ -12,9 +12,10 @@ type Props = {
   title: string;
   description: string;
   url: string;
+  className?: string;
 };
 
-const ShareButton = ({ title, description, url }: Props) => {
+const ShareButton = ({ title, description, url, className }: Props) => {
   const { t } = useTranslation();
   const breakpoint = useBreakpoint();
   const [hasShared, setHasShared] = useState<boolean>(false);
@@ -37,6 +38,7 @@ const ShareButton = ({ title, description, url }: Props) => {
       onClick={onShareClick}
       active={hasShared}
       fullWidth={breakpoint < Breakpoint.md}
+      className={className}
     />
   );
 };

--- a/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
+++ b/packages/ui-react/src/components/VideoDetails/VideoDetails.module.scss
@@ -32,7 +32,7 @@
   line-height: variables.$base-line-height;
   letter-spacing: 0.5px;
 
-  @include responsive.mobile-only() {
+  @include responsive.mobile-and-small-tablet() {
     order: 1;
     margin: 4px 0;
     font-size: 18px;
@@ -50,6 +50,7 @@
   align-items: center;
   gap: calc(variables.$base-spacing / 2);
   width: 100%;
+  max-width: 400px;
 
   > button {
     flex: 1;
@@ -60,8 +61,8 @@
     }
   }
 
-  @include responsive.tablet-and-larger() {
-    max-width: 400px;
+  @include responsive.mobile-and-small-tablet() {
+    max-width: none;
   }
 }
 

--- a/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
+++ b/packages/ui-react/src/components/VideoDetails/__snapshots__/VideoDetails.test.tsx.snap
@@ -19,7 +19,16 @@ exports[`<VideoDetails> > renders and matches snapshot 1`] = `
           src="http://image.jpg?width=1280"
         />
         <div
-          class="_posterFade_77f2c2"
+          class="_posterFadeMenu_77f2c2"
+        />
+        <div
+          class="_posterFadeLeft_77f2c2"
+        />
+        <div
+          class="_posterFadeBottom_77f2c2"
+        />
+        <div
+          class="_posterBackground_77f2c2"
         />
         <div
           class="_info_77f2c2"

--- a/packages/ui-react/src/containers/FavoriteButton/FavoriteButton.tsx
+++ b/packages/ui-react/src/containers/FavoriteButton/FavoriteButton.tsx
@@ -14,9 +14,10 @@ import Icon from '../../components/Icon/Icon';
 
 type Props = {
   item: PlaylistItem;
+  className?: string;
 };
 
-const FavoriteButton: React.VFC<Props> = ({ item }) => {
+const FavoriteButton: React.VFC<Props> = ({ item, className }) => {
   const { t } = useTranslation();
   const breakpoint = useBreakpoint();
   const favoritesController = getModule(FavoritesController);
@@ -46,6 +47,7 @@ const FavoriteButton: React.VFC<Props> = ({ item }) => {
         aria-pressed={isFavorite}
         color={isFavorite ? 'primary' : 'default'}
         fullWidth={breakpoint < Breakpoint.md}
+        className={className}
       />
       <Alert open={warning !== null} message={warning} onClose={clearWarning} />
     </>

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.module.scss
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.module.scss
@@ -25,6 +25,9 @@
     &.featured {
       padding: 24px variables.$base-spacing;
     }
+    &.grid {
+      padding: 8px variables.$base-spacing;
+    }
   }
 
   @include responsive.tablet-only() {

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -106,7 +106,7 @@ const ShelfList = ({ rows }: Props) => {
               data-testid={testId(`shelf-${isHero ? 'hero' : isFeatured ? 'featured' : type === 'playlist' ? slugify(translatedTitle) : type}`)}
               aria-label={translatedTitle}
             >
-              <Fade duration={250} delay={index * 33} open>
+              <Fade duration={250} delay={index * 33} willChange={!isHero} open>
                 {isHero ? (
                   <HeroShelf loading={isPlaceholderData} error={error} playlist={playlist} />
                 ) : (

--- a/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
+++ b/packages/ui-react/src/containers/ShelfList/ShelfList.tsx
@@ -7,10 +7,10 @@ import type { Content } from '@jwp/ott-common/types/config';
 import { useAccountStore } from '@jwp/ott-common/src/stores/AccountStore';
 import { useConfigStore } from '@jwp/ott-common/src/stores/ConfigStore';
 import { useWatchHistoryStore } from '@jwp/ott-common/src/stores/WatchHistoryStore';
-import { slugify } from '@jwp/ott-common/src/utils/urlFormatting';
+import { mediaURL, slugify } from '@jwp/ott-common/src/utils/urlFormatting';
 import { parseAspectRatio, parseTilesDelta } from '@jwp/ott-common/src/utils/collection';
 import { testId } from '@jwp/ott-common/src/utils/common';
-import { PersonalShelf, SHELF_LAYOUT_TYPE } from '@jwp/ott-common/src/constants';
+import { PersonalShelf, SHELF_LAYOUT_TYPE, PLAYLIST_LIMIT_MAX } from '@jwp/ott-common/src/constants';
 import usePlaylists from '@jwp/ott-hooks-react/src/usePlaylists';
 import { useTranslationKey } from '@jwp/ott-hooks-react/src/useTranslationKey';
 
@@ -20,6 +20,7 @@ import ErrorPage from '../../components/ErrorPage/ErrorPage';
 import Fade from '../../components/Animation/Fade/Fade';
 import HeroShelf from '../../components/HeroShelf/HeroShelf';
 import { getScrollParent } from '../../utils/dom';
+import CardGrid from '../../components/CardGrid/CardGrid';
 
 import styles from './ShelfList.module.scss';
 
@@ -42,8 +43,8 @@ const ShelfList = ({ rows }: Props) => {
   const { user, subscription } = useAccountStore(({ user, subscription }) => ({ user, subscription }), shallow);
 
   // Todo: move to more common package?
-
-  const playlists = usePlaylists(rows, rowsToLoad);
+  const singlePlaylist = rows.length === 1;
+  const playlists = usePlaylists(rows, rowsToLoad, singlePlaylist ? PLAYLIST_LIMIT_MAX : undefined);
 
   useEffect(() => {
     // reset row count when the page changes
@@ -55,6 +56,23 @@ const ShelfList = ({ rows }: Props) => {
 
   if (allPlaylistsEmpty) {
     return <ErrorPage title={t('empty_shelves_heading')} message={t('empty_shelves_description')} />;
+  }
+
+  if (singlePlaylist) {
+    if (!playlists[0].data) return;
+
+    return (
+      <section className={classNames(styles.shelfContainer, styles.grid)}>
+        <CardGrid
+          getUrl={(playlistItem) => mediaURL({ id: playlistItem.mediaid, title: playlistItem.title, playlistId: playlists[0].data?.feedid })}
+          playlist={playlists[0].data}
+          accessModel={accessModel}
+          isLoading={playlists[0].isPlaceholderData || false}
+          isLoggedIn={!!user}
+          hasSubscription={!!subscription}
+        />
+      </section>
+    );
   }
 
   return (

--- a/packages/ui-react/src/containers/StartWatchingButton/StartWatchingButton.tsx
+++ b/packages/ui-react/src/containers/StartWatchingButton/StartWatchingButton.tsx
@@ -52,6 +52,14 @@ const StartWatchingButton: React.VFC<Props> = ({ item, playUrl, disabled = false
     return t('complete_your_subscription');
   }, [isEntitled, isLoggedIn, hasMediaOffers, videoProgress, t]);
 
+  const testId = useMemo(() => {
+    if (isEntitled) return 'start_watching';
+    if (hasMediaOffers) return 'buy';
+    if (!isLoggedIn) return 'sign_up';
+
+    return 'complete_subscription';
+  }, [hasMediaOffers, isEntitled, isLoggedIn]);
+
   const handleStartWatchingClick = useCallback(() => {
     if (isEntitled) {
       if (onClick) {
@@ -88,6 +96,8 @@ const StartWatchingButton: React.VFC<Props> = ({ item, playUrl, disabled = false
       onClick={handleStartWatchingClick}
       fullWidth={breakpoint < Breakpoint.md}
       disabled={disabled}
+      data-testid={testId}
+      data-mediaid={item.mediaid}
     >
       {videoProgress ? (
         <div className={styles.progressRail}>

--- a/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
+++ b/packages/ui-react/src/containers/TrailerModal/TrailerModal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import type { PlaylistItem } from '@jwp/ott-common/types/playlist';
 
 import Modal from '../../components/Modal/Modal';
-import Player from '../../components/Player/Player';
+import PlayerContainer from '../../containers/PlayerContainer/PlayerContainer';
 import ModalCloseButton from '../../components/ModalCloseButton/ModalCloseButton';
 import Fade from '../../components/Animation/Fade/Fade';
 
@@ -29,7 +29,7 @@ const TrailerModal: React.FC<Props> = ({ item, open, title, onClose }) => {
   return (
     <Modal open={open} onClose={onClose} aria-labelledby="trailer-modal-title" centered>
       <div className={styles.container}>
-        <Player
+        <PlayerContainer
           item={item}
           onPlay={handlePlay}
           onPause={handlePause}


### PR DESCRIPTION
## Description


**refactor: add className prop to share and favorite buttons**

This allows us to configure some additional styling on mobile devices without ugly selectors.

**feat: show hub items in grid layout when single shelf**

When a single playlist is configured, the items are presented as a grid instead of a single horizontal slider.

**fix: hero shelf clipping on safari browsers**

CSS `will-change` causes some header clipping issues on Safari browsers. The only fix seems to remove it for the hero shelf.

**feat(home): hero shelf styling improvements**

We tweaked the hero shelf a few times and this is the result. The background image was not always presented nicely. The biggest challenge is that this depends on the image and position of the subject. 

**fix: video details buttons wrapping**

The buttons on the video details page were wrapping (noticeable in other languages).

**refactor(a11y): markdown heading offset**

The markdown component renders headings, but for a11y reasons, we need to offset the heading level so that it doesn't mess up the document hierarchy.

**fix: allow playing signed trailer items**

Trailers didn't work on URL-protected properties. By using the PlayerContainer, the items are signed when needed.