### PR TITLE
Fix / Support newline break in Markdown content

### DIFF
--- a/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
+++ b/packages/ui-react/src/components/MarkdownComponent/MarkdownComponent.tsx
@@ -44,7 +44,7 @@ const adjustHeaderLevels = (markdown: string, offset: number): string => {
 const MarkdownComponent: React.FC<Props> = ({ markdownString, className, tag = 'div', inline = false, headerOffset = 0 }) => {
   const sanitizedHTMLString = useMemo(() => {
     const adjustedMarkdown = adjustHeaderLevels(markdownString, headerOffset);
-    const dirtyHTMLString = inline ? marked.parseInline(adjustedMarkdown, { async: false }) : marked.parse(adjustedMarkdown, { async: false });
+    const dirtyHTMLString = inline ? marked.parseInline(adjustedMarkdown, { async: false }) : marked.parse(adjustedMarkdown, { async: false, breaks: true });
 
     return DOMPurify.sanitize(dirtyHTMLString, { ADD_ATTR: ['target'] });
   }, [inline, markdownString, headerOffset]);


### PR DESCRIPTION
When the description field utilizes newline-breaks we want them to be rendered as such in the front-end.
Intentionally left empty for the inline variant (where `breaks` option defaults to `false`)

JW dashboard description example:
<img width="538" alt="Screenshot 2025-03-12 at 17 17 07" src="https://github.com/user-attachments/assets/180f8148-3976-4e6d-820f-4ad07c2cf1fb" />

Previous situation in front-end:
![Screenshot 2025-03-12 at 17 17 51](https://github.com/user-attachments/assets/0e135b4e-509c-474a-be07-b978d327bfec)

New situation in front-end:
![Screenshot 2025-03-12 at 17 17 35](https://github.com/user-attachments/assets/c70996eb-1232-4a85-85cc-f44222852d55)

This is the content returned from the API response (description field):
```
"Rafael Payare kicks off the OSM’s 90th season with two amazing works. Stravinsky’s The Rite of Spring is driven by an incomparable rhythmic force and fierceness. A comparable quality of explosive joy and vitality is also present in Janáček’s Glagolitic Mass, a boldly original piece featuring the Maison symphonique’s Grand Orgue Pierre-Béique as the OSM celebrates the organ’s 10th anniversary during the 2023-2024 season.\n\n# Program \n**Leoš Janáček** (1854 - 1928). \n*Glagolithic Mass* \n\nI. *Úvod* (Introduction) \nII. *Gospodi pomiluj* (Kyrie)\nIII. *Slava* (Gloria) \nIV. *Věruju* (Credo) \nV. *Svet* (Sanctus)\nVI. *Agneče Božij* (Agnus Dei)\nVII. *Varhany sólo* (Postludium)\nVIII. *Intrada* (Exodus)\n\n**Igor Stravinsky** (1882 - 1971)\n*The Rite of Spring* \n\nI. *Adoration of the Earth*\nII. *The Sacrifice*\n\n# Performers\n**Orchestre symphonique de Montréal**\n\n**Rafael Payare** (Conductor)\n\n**OSM Chorus**\n\n**Andrew Megill** (Choir master)\n\n**Jean-Willy Kunz** (Organ)\n\n**Camilla Tilling** (Soprano)\n\n**Rose Naggar-Tremblay** (Alto)\n\n**Ladislav Elgr** (Tenor)\n\n**Matthew Rose** (Bass)"
```

Ticket: https://videodock.atlassian.net/browse/MAINT-926