### PR TITLE
Chore / upgrade Inversify

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,7 @@
     "fast-xml-parser": "^4.5.3",
     "i18next": "^24.2.2",
     "ini": "^3.0.1",
-    "inversify": "^6.1.5",
+    "inversify": "^7.5.4",
     "jwt-decode": "^4.0.0",
     "lodash.merge": "^4.6.2",
     "react-i18next": "^15.4.1",

--- a/packages/common/src/modules/container.ts
+++ b/packages/common/src/modules/container.ts
@@ -1,13 +1,13 @@
-import { Container, injectable, type interfaces, inject } from 'inversify';
+import { Container, injectable, type ServiceIdentifier, inject } from 'inversify';
 
-export const container = new Container({ defaultScope: 'Singleton', skipBaseClassChecks: true });
+export const container = new Container({ defaultScope: 'Singleton' });
 
 export { injectable, inject };
 
-export function getModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, required: false): T | undefined;
-export function getModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, required: true): T;
-export function getModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>): T;
-export function getModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, required = true): T | undefined {
+export function getModule<T>(constructorFunction: ServiceIdentifier<T>, required: false): T | undefined;
+export function getModule<T>(constructorFunction: ServiceIdentifier<T>, required: true): T;
+export function getModule<T>(constructorFunction: ServiceIdentifier<T>): T;
+export function getModule<T>(constructorFunction: ServiceIdentifier<T>, required = true): T | undefined {
   const module = container.getAll(constructorFunction)[0];
 
   if (required && !module) throw new Error(`Service / Controller '${String(constructorFunction)}' not found`);
@@ -15,14 +15,14 @@ export function getModule<T>(constructorFunction: interfaces.ServiceIdentifier<T
   return module;
 }
 
-export function getAllModules<T>(constructorFunction: interfaces.ServiceIdentifier<T>): T[] {
+export function getAllModules<T>(constructorFunction: ServiceIdentifier<T>): T[] {
   return container.getAll(constructorFunction);
 }
 
-export function getNamedModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, name: string | null, required: false): T | undefined;
-export function getNamedModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, name: string | null, required: true): T;
-export function getNamedModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, name: string | null): T;
-export function getNamedModule<T>(constructorFunction: interfaces.ServiceIdentifier<T>, name: string | null, required = true): T | undefined {
+export function getNamedModule<T>(constructorFunction: ServiceIdentifier<T>, name: string | null, required: false): T | undefined;
+export function getNamedModule<T>(constructorFunction: ServiceIdentifier<T>, name: string | null, required: true): T;
+export function getNamedModule<T>(constructorFunction: ServiceIdentifier<T>, name: string | null): T;
+export function getNamedModule<T>(constructorFunction: ServiceIdentifier<T>, name: string | null, required = true): T | undefined {
   if (!name) {
     // if no name is given we throw an error to satisfy the non-nullable return type
     if (required) {
@@ -34,7 +34,7 @@ export function getNamedModule<T>(constructorFunction: interfaces.ServiceIdentif
   let module;
 
   try {
-    module = container.getAllNamed(constructorFunction, name)[0];
+    module = container.getAll(constructorFunction, { name })[0];
 
     return module;
   } catch (err: unknown) {

--- a/packages/common/src/modules/functions/getApiAccessBridgeUrl.ts
+++ b/packages/common/src/modules/functions/getApiAccessBridgeUrl.ts
@@ -1,4 +1,4 @@
-import type { interfaces } from 'inversify';
+import type { ResolutionContext } from 'inversify';
 
 import AppController from '../../controllers/AppController';
 
@@ -7,6 +7,6 @@ import AppController from '../../controllers/AppController';
  * If the access bridge URL is defined in the application's .ini configuration file,
  * the function returns the URL. If the value is not defined, it returns `undefined`.
  */
-export const getApiAccessBridgeUrl = (context: interfaces.Context) => {
-  return context.container.get(AppController).getApiAccessBridgeUrl();
+export const getApiAccessBridgeUrl = (context: ResolutionContext) => {
+  return context.get(AppController).getApiAccessBridgeUrl();
 };

--- a/packages/common/src/modules/functions/getIntegrationType.ts
+++ b/packages/common/src/modules/functions/getIntegrationType.ts
@@ -1,4 +1,4 @@
-import type { interfaces } from 'inversify';
+import type { ResolutionContext } from 'inversify';
 
 import AppController from '../../controllers/AppController';
 
@@ -6,6 +6,6 @@ import AppController from '../../controllers/AppController';
  * This function is used to get the integration type from the AppController and is mainly used for getting named
  * modules from the container registry.
  */
-export const getIntegrationType = (context: interfaces.Context) => {
-  return context.container.get(AppController).getIntegrationType();
+export const getIntegrationType = (context: ResolutionContext) => {
+  return context.get(AppController).getIntegrationType();
 };

--- a/packages/common/src/modules/register.ts
+++ b/packages/common/src/modules/register.ts
@@ -72,8 +72,8 @@ container.bind(CheckoutController).toSelf();
 container.bind(AccessController).toSelf();
 
 // EPG services
-container.bind(EpgService).to(JWEpgService).whenTargetNamed(EPG_TYPE.jwp);
-container.bind(EpgService).to(ViewNexaEpgService).whenTargetNamed(EPG_TYPE.viewNexa);
+container.bind(EpgService).to(JWEpgService).whenNamed(EPG_TYPE.jwp);
+container.bind(EpgService).to(ViewNexaEpgService).whenNamed(EPG_TYPE.viewNexa);
 
 // Functions
 container.bind(INTEGRATION_TYPE).toDynamicValue(getIntegrationType);
@@ -82,14 +82,14 @@ container.bind(API_ACCESS_BRIDGE_URL).toDynamicValue(getApiAccessBridgeUrl);
 // Cleeng integration
 container.bind(DETERMINE_INTEGRATION_TYPE).toConstantValue(isCleengIntegrationType);
 container.bind(CleengService).toSelf();
-container.bind(AccountService).to(CleengAccountService).whenTargetNamed(INTEGRATION.CLEENG);
-container.bind(CheckoutService).to(CleengCheckoutService).whenTargetNamed(INTEGRATION.CLEENG);
-container.bind(SubscriptionService).to(CleengSubscriptionService).whenTargetNamed(INTEGRATION.CLEENG);
+container.bind(AccountService).to(CleengAccountService).whenNamed(INTEGRATION.CLEENG);
+container.bind(CheckoutService).to(CleengCheckoutService).whenNamed(INTEGRATION.CLEENG);
+container.bind(SubscriptionService).to(CleengSubscriptionService).whenNamed(INTEGRATION.CLEENG);
 
 // JWP integration
 container.bind(DETERMINE_INTEGRATION_TYPE).toConstantValue(isJwpIntegrationType);
 container.bind(JWPAPIService).toSelf();
 container.bind(JWPEntitlementService).toSelf();
-container.bind(AccountService).to(JWPAccountService).whenTargetNamed(INTEGRATION.JWP);
-container.bind(CheckoutService).to(JWPCheckoutService).whenTargetNamed(INTEGRATION.JWP);
-container.bind(SubscriptionService).to(JWPSubscriptionService).whenTargetNamed(INTEGRATION.JWP);
+container.bind(AccountService).to(JWPAccountService).whenNamed(INTEGRATION.JWP);
+container.bind(CheckoutService).to(JWPCheckoutService).whenNamed(INTEGRATION.JWP);
+container.bind(SubscriptionService).to(JWPSubscriptionService).whenNamed(INTEGRATION.JWP);

--- a/packages/common/test/mockService.ts
+++ b/packages/common/test/mockService.ts
@@ -1,8 +1,8 @@
-import type { interfaces } from 'inversify';
+import type { ServiceIdentifier } from 'inversify';
 import { afterEach } from 'vitest';
 
 type ServiceMockEntry = {
-  serviceIdentifier: interfaces.ServiceIdentifier;
+  serviceIdentifier: ServiceIdentifier;
   implementation: unknown;
 };
 
@@ -10,10 +10,9 @@ export type OptionalMembers<T> = { [K in keyof T]?: T[K] };
 
 export let mockedServices: ServiceMockEntry[] = [];
 
-const getName = (serviceIdentifier: interfaces.ServiceIdentifier) =>
-  serviceIdentifier instanceof Function ? serviceIdentifier.name : serviceIdentifier.toString();
+const getName = (serviceIdentifier: ServiceIdentifier) => (serviceIdentifier instanceof Function ? serviceIdentifier.name : serviceIdentifier.toString());
 
-export const mockService = <T, B extends OptionalMembers<T>>(serviceIdentifier: interfaces.ServiceIdentifier<T>, implementation: B, override = false) => {
+export const mockService = <T, B extends OptionalMembers<T>>(serviceIdentifier: ServiceIdentifier<T>, implementation: B, override = false) => {
   if (!override && mockedServices.some((mock) => mock.serviceIdentifier === serviceIdentifier)) {
     throw new Error(`There already is a mocked service for ${getName(serviceIdentifier)}`);
   }
@@ -34,7 +33,7 @@ afterEach(() => {
 
 vi.mock('@jwp/ott-common/src/modules/container', async () => {
   const actual = (await vi.importActual('@jwp/ott-common/src/modules/container')) as Record<string, unknown>;
-  const getModule = (serviceIdentifier: interfaces.ServiceIdentifier) => {
+  const getModule = (serviceIdentifier: ServiceIdentifier) => {
     const mockedService = mockedServices.find((current) => current.serviceIdentifier === serviceIdentifier);
 
     if (!mockedService) {
@@ -44,7 +43,7 @@ vi.mock('@jwp/ott-common/src/modules/container', async () => {
     return mockedService.implementation;
   };
 
-  const getAllModules = (serviceIdentifier: interfaces.ServiceIdentifier) => {
+  const getAllModules = (serviceIdentifier: ServiceIdentifier) => {
     const mockedService = mockedServices.find((current) => current.serviceIdentifier === serviceIdentifier);
 
     return mockedService ? [mockedService.implementation] : [];
@@ -54,7 +53,7 @@ vi.mock('@jwp/ott-common/src/modules/container', async () => {
     ...actual,
     getModule,
     getAllModules,
-    getNamedModule: (serviceIdentifier: interfaces.ServiceIdentifier, _name: string) => {
+    getNamedModule: (serviceIdentifier: ServiceIdentifier, _name: string) => {
       return getModule(serviceIdentifier);
     },
   };

--- a/packages/hooks-react/src/useBootstrapApp.ts
+++ b/packages/hooks-react/src/useBootstrapApp.ts
@@ -8,8 +8,6 @@ import { CACHE_TIME, STALE_TIME } from '@jwp/ott-common/src/constants';
 import { logDebug } from '@jwp/ott-common/src/logger';
 import { useTranslation } from 'react-i18next';
 
-const applicationController = getModule(AppController);
-
 type Resources = {
   config: Config;
   configSource: string | undefined;
@@ -19,6 +17,7 @@ type Resources = {
 export type OnReadyCallback = (config: Config | undefined) => void;
 
 export const useBootstrapApp = (url: string, onReady: OnReadyCallback) => {
+  const applicationController = getModule(AppController);
   const queryClient = useQueryClient();
   const { i18n } = useTranslation();
 

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -18,7 +18,7 @@
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.4",
     "i18next": "^24.2.2",
-    "inversify": "^6.1.5",
+    "inversify": "^7.5.4",
     "marked": "^15.0.7",
     "payment": "^2.4.7",
     "planby": "^0.3.0",

--- a/packages/ui-react/src/modules/container.ts
+++ b/packages/ui-react/src/modules/container.ts
@@ -1,5 +1,5 @@
 import { Container } from 'inversify';
 
-const container = new Container({ defaultScope: 'Singleton', skipBaseClassChecks: true });
+const container = new Container({ defaultScope: 'Singleton', autobind: true });
 
 export { container };

--- a/platforms/web/src/index.tsx
+++ b/platforms/web/src/index.tsx
@@ -5,9 +5,7 @@ import 'wicg-inert';
 import { registerSW } from 'virtual:pwa-register';
 import { configureEnv } from '@jwp/ott-common/src/env';
 
-import './modules/register';
-
-import App from './App';
+import { register } from './modules/register';
 
 import { attachAccessibilityListener } from '#src/utils/accessibility';
 
@@ -39,14 +37,23 @@ configureEnv({
 
 attachAccessibilityListener();
 
-const rootElement = document.getElementById('root');
+async function run() {
+  await register();
 
-if (rootElement) {
-  const root = createRoot(rootElement);
-  root.render(<App />);
-} else {
-  console.info('Application - rootElement not found');
+  attachAccessibilityListener();
+
+  const { default: App } = await import('./App');
+  const rootElement = document.getElementById('root');
+
+  if (rootElement) {
+    const root = createRoot(rootElement);
+    root.render(<App />);
+  } else {
+    console.info('Application - rootElement not found');
+  }
 }
+
+run();
 
 const refresh = registerSW({
   immediate: true,

--- a/platforms/web/src/modules/register.ts
+++ b/platforms/web/src/modules/register.ts
@@ -29,44 +29,45 @@ import { LocalStorageService } from '#src/services/LocalStorageService';
  * })
  * ```
  */
+export const register = async () => {
+  container.bind(StorageService).to(LocalStorageService);
 
-container.bind(StorageService).to(LocalStorageService);
+  container.bind(BROADCAST_CHANNEL).toConstantValue(new BroadcastChannel('jwp-refresh-token-channel'));
 
-container.bind(BROADCAST_CHANNEL).toConstantValue(new BroadcastChannel('jwp-refresh-token-channel'));
+  // Currently, this is only used for e2e testing to override the customer ip from a browser cookie
+  container.bind<GetCustomerIP>(GET_CUSTOMER_IP).toConstantValue(async () => getOverrideIP());
 
-// Currently, this is only used for e2e testing to override the customer ip from a browser cookie
-container.bind<GetCustomerIP>(GET_CUSTOMER_IP).toConstantValue(async () => getOverrideIP());
+  /**
+   * Log transporters
+   *
+   * Add custom log transporters by registering more modules to the LogTransporter type. The custom transporter must
+   * extend the LogTransporter class.
+   *
+   * @example
+   * ```ts
+   * container.bind<LogTransporter>(LogTransporter).toDynamicValue(() => new GoogleGTMTransporter(import.meta.env.DEV ? LogLevel.SILENT : LogLevel.WARN));
+   * ```
+   */
+  container.bind<LogTransporter>(LogTransporter).toDynamicValue(() => new ConsoleTransporter(import.meta.env.DEV ? LogLevel.DEBUG : LogLevel.ERROR));
 
-/**
- * Log transporters
- *
- * Add custom log transporters by registering more modules to the LogTransporter type. The custom transporter must
- * extend the LogTransporter class.
- *
- * @example
- * ```ts
- * container.bind<LogTransporter>(LogTransporter).toDynamicValue(() => new GoogleGTMTransporter(import.meta.env.DEV ? LogLevel.SILENT : LogLevel.WARN));
- * ```
- */
-container.bind<LogTransporter>(LogTransporter).toDynamicValue(() => new ConsoleTransporter(import.meta.env.DEV ? LogLevel.DEBUG : LogLevel.ERROR));
+  /**
+   * UI Component override
+   *
+   * @example
+   * ```ts
+   * // Define an identifier from the component (from `ui-react` for example):
+   * export const CardIdentifier = Symbol('CARD');
+   *
+   * // Make sure the component is wrapped in the HOC:
+   * export default createInjectableComponent(CardIdentifier, Card);
+   *
+   * // Override the component into the associated container, from register.ts:
+   * import { container as uiComponentContainer } from '@jwp/ott-ui-react/src/modules/container';
+   *
+   * uiComponentContainer.bind<React.FC<CardProps>>(CardIdentifier).toConstantValue(CustomCard);
+   * ```
+   */
 
-/**
- * UI Component override
- *
- * @example
- * ```ts
- * // Define an identifier from the component (from `ui-react` for example):
- * export const CardIdentifier = Symbol('CARD');
- *
- * // Make sure the component is wrapped in the HOC:
- * export default createInjectableComponent(CardIdentifier, Card);
- *
- * // Override the component into the associated container, from register.ts:
- * import { container as uiComponentContainer } from '@jwp/ott-ui-react/src/modules/container';
- *
- * uiComponentContainer.bind<React.FC<CardProps>>(CardIdentifier).toConstantValue(CustomCard);
- * ```
- */
-
-// Override ui-react component
-// uiComponentContainer.bind<React.FC<CardProps>>(CardIdentifier).toConstantValue(CustomCard);
+  // Override ui-react component
+  // uiComponentContainer.bind<React.FC<CardProps>>(CardIdentifier).toConstantValue(CustomCard);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,7 +58,7 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.26.2", "@babel/code-frame@^7.27.1":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -72,28 +72,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.27.7.tgz#7fd698e531050cce432b073ab64857b99e0f3804"
   integrity sha512-xgu/ySj2mTiUFmdE9yCMfBxLp4DHd5DwmbbD05YAuICfodYT3VvRxbrh81LGQ/8UpSdtMdfKMn3KouYDX59DGQ==
 
-"@babel/core@7.26.10":
-  version "7.26.10"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.10.tgz#5c876f83c8c4dcb233ee4b670c0606f2ac3000f9"
-  integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
-  dependencies:
-    "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.26.2"
-    "@babel/generator" "^7.26.10"
-    "@babel/helper-compilation-targets" "^7.26.5"
-    "@babel/helper-module-transforms" "^7.26.0"
-    "@babel/helpers" "^7.26.10"
-    "@babel/parser" "^7.26.10"
-    "@babel/template" "^7.26.9"
-    "@babel/traverse" "^7.26.10"
-    "@babel/types" "^7.26.10"
-    convert-source-map "^2.0.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.3"
-    semver "^6.3.1"
-
-"@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.18.5", "@babel/core@^7.21.3", "@babel/core@^7.24.4", "@babel/core@^7.25.2", "@babel/core@^7.26.0":
+"@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.18.5", "@babel/core@^7.21.3", "@babel/core@^7.24.4", "@babel/core@^7.25.2", "@babel/core@^7.26.0", "@babel/core@^7.26.10":
   version "7.27.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.27.7.tgz#0ddeab1e7b17317dad8c3c3a887716f66b5c4428"
   integrity sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==
@@ -114,7 +93,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.25.0", "@babel/generator@^7.26.10", "@babel/generator@^7.27.5":
+"@babel/generator@^7.25.0", "@babel/generator@^7.27.5":
   version "7.27.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.27.5.tgz#3eb01866b345ba261b04911020cbe22dd4be8c8c"
   integrity sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==
@@ -140,7 +119,7 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.26.5", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
+"@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.27.1", "@babel/helper-compilation-targets@^7.27.2":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz#46a0f6efab808d51d29ce96858dd10ce8732733d"
   integrity sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==
@@ -200,7 +179,7 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0", "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.27.3":
+"@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.27.1", "@babel/helper-module-transforms@^7.27.3":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz#db0bbcfba5802f9ef7870705a7ef8788508ede02"
   integrity sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==
@@ -271,7 +250,7 @@
     "@babel/traverse" "^7.27.1"
     "@babel/types" "^7.27.1"
 
-"@babel/helpers@^7.26.10", "@babel/helpers@^7.27.6":
+"@babel/helpers@^7.27.6":
   version "7.27.6"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.6.tgz#6456fed15b2cb669d2d1fabe84b66b34991d812c"
   integrity sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==
@@ -279,7 +258,7 @@
     "@babel/template" "^7.27.2"
     "@babel/types" "^7.27.6"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.25.3", "@babel/parser@^7.26.10", "@babel/parser@^7.27.2", "@babel/parser@^7.27.5", "@babel/parser@^7.27.7", "@babel/parser@^7.8.3":
+"@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.25.3", "@babel/parser@^7.27.2", "@babel/parser@^7.27.5", "@babel/parser@^7.27.7", "@babel/parser@^7.8.3":
   version "7.27.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.7.tgz#1687f5294b45039c159730e3b9c1f1b242e425e9"
   integrity sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==
@@ -333,14 +312,14 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-decorators@7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.25.9.tgz#8680707f943d1a3da2cd66b948179920f097e254"
-  integrity sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==
+"@babel/plugin-proposal-decorators@^7.25.9":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.27.1.tgz#3686f424b2f8b2fee7579aa4df133a4f5244a596"
+  integrity sha512-DTxe4LBPrtFdsWzgpmbBKevg3e9PBy+dXRt19kSbucbZvL2uqtdqwwpluL1jfxYE0wIDTFp1nTy/q6gNLsxXrg==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/plugin-syntax-decorators" "^7.25.9"
+    "@babel/helper-create-class-features-plugin" "^7.27.1"
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-decorators" "^7.27.1"
 
 "@babel/plugin-proposal-export-default-from@^7.24.7":
   version "7.27.1"
@@ -399,7 +378,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-decorators@^7.25.9":
+"@babel/plugin-syntax-decorators@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz#ee7dd9590aeebc05f9d4c8c0560007b05979a63d"
   integrity sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==
@@ -1121,7 +1100,7 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
 
-"@babel/template@^7.25.0", "@babel/template@^7.26.9", "@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
+"@babel/template@^7.25.0", "@babel/template@^7.27.1", "@babel/template@^7.27.2", "@babel/template@^7.3.3":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
   integrity sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==
@@ -1130,7 +1109,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.10", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.27.7":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.27.1", "@babel/traverse@^7.27.3", "@babel/traverse@^7.27.7":
   version "7.27.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.27.7.tgz#8355c39be6818362eace058cf7f3e25ac2ec3b55"
   integrity sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==
@@ -1143,7 +1122,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.25.2", "@babel/types@^7.25.9", "@babel/types@^7.26.10", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.27.6", "@babel/types@^7.27.7", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.25.2", "@babel/types@^7.25.9", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.27.6", "@babel/types@^7.27.7", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.27.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.7.tgz#40eabd562049b2ee1a205fa589e629f945dce20f"
   integrity sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==
@@ -2031,23 +2010,46 @@
     lodash "^4.17.20"
     qs "^6.9.4"
 
-"@inversifyjs/common@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.4.0.tgz#4df42e8cb012a1630ebf2f3c65bb76ac5b0f3e4c"
-  integrity sha512-qfRJ/3iOlCL/VfJq8+4o5X4oA14cZSBbpAmHsYj8EsIit1xDndoOl0xKOyglKtQD4u4gdNVxMHx4RWARk/I4QA==
+"@inversifyjs/common@1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/common/-/common-1.5.2.tgz#6836287fef1c25dddbdf6af345a33a6d6caf6835"
+  integrity sha512-WlzR9xGadABS9gtgZQ+luoZ8V6qm4Ii6RQfcfC9Ho2SOlE6ZuemFo7PKJvKI0ikm8cmKbU8hw5UK6E4qovH21w==
 
-"@inversifyjs/core@1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-1.3.5.tgz#c02ee3ed036aae40189302794f16a9f4e0ed4557"
-  integrity sha512-B4MFXabhNTAmrfgB+yeD6wd/GIvmvWC6IQ8Rh/j2C3Ix69kmqwz9pr8Jt3E+Nho9aEHOQCZaGmrALgtqRd+oEQ==
+"@inversifyjs/container@1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/container/-/container-1.10.3.tgz#115e953f3928526e3f69a382d23ae45708adcb9d"
+  integrity sha512-uuB6fNd3XeFBtsysJXqOt0G114M69EpQCfM2G2XnhNYUb/osnHNGeubl2sMHd6SO08HbtAD8yNQOkPpxKeQTEw==
   dependencies:
-    "@inversifyjs/common" "1.4.0"
-    "@inversifyjs/reflect-metadata-utils" "0.2.4"
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/core" "5.3.3"
+    "@inversifyjs/plugin" "0.2.0"
+    "@inversifyjs/reflect-metadata-utils" "1.2.0"
 
-"@inversifyjs/reflect-metadata-utils@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-0.2.4.tgz#c65172283db9516c4a27e8d673ca7a31a07d528b"
-  integrity sha512-u95rV3lKfG+NT2Uy/5vNzoDujos8vN8O18SSA5UyhxsGYd4GLQn/eUsGXfOsfa7m34eKrDelTKRUX1m/BcNX5w==
+"@inversifyjs/core@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/core/-/core-5.3.3.tgz#a0588a7dd8f01373b79ec0d2cdd2b15320163713"
+  integrity sha512-sx7msHtmgu/7gNPTMN9TzeBiE7y9y3dCEbLgtY8JOLP7okRPrrjTl7w6pd5RY00s/AovdDoE7BscNZVjqWIR0A==
+  dependencies:
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/prototype-utils" "0.1.2"
+    "@inversifyjs/reflect-metadata-utils" "1.2.0"
+
+"@inversifyjs/plugin@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/plugin/-/plugin-0.2.0.tgz#03957c7d02803f32254a2ff2f8f8ffb05ec57eec"
+  integrity sha512-R/JAdkTSD819pV1zi0HP54mWHyX+H2m8SxldXRgPQarS3ySV4KPyRdosWcfB8Se0JJZWZLHYiUNiS6JvMWSPjw==
+
+"@inversifyjs/prototype-utils@0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/prototype-utils/-/prototype-utils-0.1.2.tgz#2ff5241c2f50772b3202ad5f052b84852eedd8d3"
+  integrity sha512-WZAEycwVd8zVCPCQ7GRzuQmjYF7X5zbjI9cGigDbBoTHJ8y5US9om00IAp0RYislO+fYkMzgcB2SnlIVIzyESA==
+  dependencies:
+    "@inversifyjs/common" "1.5.2"
+
+"@inversifyjs/reflect-metadata-utils@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.2.0.tgz#06ef157a29ffa532a2a67731f80a03ab5060c364"
+  integrity sha512-EvXdBP+IjAZ3QKWFWGDzWLacyng9RMohtZ0c0EPUmvbaF4wgfwrE6n92ilt9aGwdbE5roGmDTmoRSmvavVOtIA==
 
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
@@ -8074,13 +8076,14 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^6.1.5:
-  version "6.1.5"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-6.1.5.tgz#5883e1e355d31d119a3320bc47376cd42b08a0b7"
-  integrity sha512-+287m3dGkSDZjgi6y6KzAjIsD199ffnwUQ0yURAoSg7hx/6vCj7+qWMNF7hEoWXwMJ+F48bnsW8gcxMohazS8g==
+inversify@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-7.5.4.tgz#5d4a933e8b225428ae67496f5e9ff7a97532222d"
+  integrity sha512-4UqlM8ALDzxsqQpK9ExQJAgnJoYhGJ88sr5v0ukwjpwIsE/ZKl9PyRtm9sWmViaHA4n2SergxC5sL3eeW+EWLQ==
   dependencies:
-    "@inversifyjs/common" "1.4.0"
-    "@inversifyjs/core" "1.3.5"
+    "@inversifyjs/common" "1.5.2"
+    "@inversifyjs/container" "1.10.3"
+    "@inversifyjs/core" "5.3.3"
 
 invisi-data@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
## Description

This PR upgrades the Inversify library to v7. This upgrade has some breaking changes in the types export and removed support for the synchronous `rebind` method. 

For this reason it is now needed to needed to do:

```ts
await container.unbind(SettingsService);
container.bind(SettingsService).to(CustomSettingsService);
```

This means we need to wait for the registration before bootstrapping the app (see `platforms/web/modules/register.ts`).

When extending an existing class (the SettingsService for example) you'll need to add a second decorator to ensure that the parent class receives the injected services in the constructor method. This is not needed when the concrete class has a constructor and calls `super`.

In our React Native app we have a custom implementation for the SettingsService to prevent the ini load mechanism. The `@injectFromBase` decorator is needed here so the SettingsService constructor still works.

```ts
@injectable()
@injectFromBase({ extendConstructorArguments: true })
export default class ReactNativeSettingsService extends SettingsService {
```